### PR TITLE
Make EntityUtils.toString more lenient towards invalid character sets.

### DIFF
--- a/httpcore/src/main/java/org/apache/http/util/EntityUtils.java
+++ b/httpcore/src/main/java/org/apache/http/util/EntityUtils.java
@@ -199,14 +199,15 @@ public final class EntityUtils {
      * If defaultCharset is null, the default "ISO-8859-1" is used.
      *
      * @param entity must not be null
-     * @param defaultCharset character set to be applied if none found in the entity
+     * @param defaultCharset character set to be applied if none found in the entity, 
+     * or if the entity provided charset is invalid or not available.
      * @return the entity content as a String. May be null if
      *   {@link HttpEntity#getContent()} is null.
      * @throws ParseException if header elements cannot be parsed
      * @throws IllegalArgumentException if entity is null or if content length > Integer.MAX_VALUE
      * @throws IOException if an error occurs reading the input stream
-     * @throws UnsupportedCharsetException Thrown when the named charset is not available in
-     * this instance of the Java virtual machine
+     * @throws UnsupportedCharsetException Thrown when the named entity's charset is not available in
+     * this instance of the Java virtual machine and no defaultCharset is provided.
      */
     public static String toString(
             final HttpEntity entity, final Charset defaultCharset) throws IOException, ParseException {

--- a/httpcore/src/main/java/org/apache/http/util/EntityUtils.java
+++ b/httpcore/src/main/java/org/apache/http/util/EntityUtils.java
@@ -229,7 +229,9 @@ public final class EntityUtils {
                     charset = contentType.getCharset();
                 }
             } catch (final UnsupportedCharsetException ex) {
-                throw new UnsupportedEncodingException(ex.getMessage());
+                if (defaultCharset==null) {
+                    throw new UnsupportedEncodingException(ex.getMessage());
+                }
             }
             if (charset == null) {
                 charset = defaultCharset;

--- a/httpcore/src/test/java/org/apache/http/util/TestEntityUtils.java
+++ b/httpcore/src/test/java/org/apache/http/util/TestEntityUtils.java
@@ -29,7 +29,6 @@ package org.apache.http.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHeader;
 import org.junit.Assert;
@@ -200,6 +199,16 @@ public class TestEntityUtils {
         httpentity.setContent(new ByteArrayInputStream(bytes));
         httpentity.setContentType(new BasicHeader("Content-Type", "text/plain; charset=UTF-8"));
         final String s = EntityUtils.toString(httpentity, "ISO-8859-1");
+        Assert.assertEquals(content, s);
+    }
+    @Test
+    public void testContentWithInvalidContentTypeToString() throws Exception {
+        final String content = constructString(RUSSIAN_HELLO);
+        final byte[] bytes = content.getBytes("UTF-8");
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(bytes));
+        httpentity.setContentType(new BasicHeader("Content-Type", "text/plain; charset=nosuchcharset"));
+        final String s = EntityUtils.toString(httpentity, "UTF-8");
         Assert.assertEquals(content, s);
     }
 


### PR DESCRIPTION
e.g. one website is returning "Content-Type text/html; charset=EN-AU"

That charset is invalid (and should be fixed) however this change permits EntityUtils#toString to work around that if a defaultCharset is passed in.
