### PR TITLE
Reduce synchronized scopes in IOSessionImpl

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/IOSessionImpl.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/IOSessionImpl.java
@@ -343,8 +343,8 @@ public class IOSessionImpl implements IOSession, SocketAccessor {
 
     @Override
     public String toString() {
+        final StringBuilder buffer = new StringBuilder();
         synchronized (this.key) {
-            final StringBuilder buffer = new StringBuilder();
             final SocketAddress remoteAddress = getRemoteAddress();
             final SocketAddress localAddress = getLocalAddress();
             if (remoteAddress != null && localAddress != null) {
@@ -352,7 +352,7 @@ public class IOSessionImpl implements IOSession, SocketAccessor {
                 buffer.append("<->");
                 formatAddress(buffer, remoteAddress);
             }
-            buffer.append("[");
+            buffer.append('[');
             switch (this.status) {
             case ACTIVE:
                 buffer.append("ACTIVE");
@@ -368,12 +368,12 @@ public class IOSessionImpl implements IOSession, SocketAccessor {
             if (this.key.isValid()) {
                 formatOps(buffer, this.interestOpsCallback != null ?
                         this.currentEventMask : this.key.interestOps());
-                buffer.append(":");
+                buffer.append(':');
                 formatOps(buffer, this.key.readyOps());
             }
-            buffer.append("]");
-            return buffer.toString();
         }
+        buffer.append(']');
+        return new String(buffer);
     }
 
     @Override


### PR DESCRIPTION
Currently IOSessionImpl has too many synchronized methods which results in poor performance on high load.
Changes consist of two commits:
First one removes synchronization from lastRead/Write/AccessTime variables access and makes this variables volatile.
Second one introduces double checks for status member-field which is already volatile. At the same time, synchronized (this) scope in IOSessionImpl.close() reduced to have double checks faster.
In order to avoid CancelledKeyException in .toString() member-function key cancellation is made in scope synchronized on this key.
