### PR TITLE
Set EmptyInputStream in entity instead of ContentLengthInputStream(in, 0)

### DIFF
--- a/httpcore/src/main/java/org/apache/http/entity/BasicHttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/entity/BasicHttpEntity.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.impl.io.EmptyInputStream;
 import org.apache.http.util.Args;
 import org.apache.http.util.Asserts;
 
@@ -124,7 +125,7 @@ public class BasicHttpEntity extends AbstractHttpEntity implements HttpContentPr
 
     @Override
     public boolean isStreaming() {
-        return this.content != null;
+        return this.content != null && this.content != EmptyInputStream.INSTANCE;
     }
 
 }

--- a/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
+++ b/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
@@ -54,6 +54,7 @@ import org.apache.http.impl.io.ChunkedInputStream;
 import org.apache.http.impl.io.ChunkedOutputStream;
 import org.apache.http.impl.io.ContentLengthInputStream;
 import org.apache.http.impl.io.ContentLengthOutputStream;
+import org.apache.http.impl.io.EmptyInputStream;
 import org.apache.http.impl.io.HttpTransportMetricsImpl;
 import org.apache.http.impl.io.IdentityInputStream;
 import org.apache.http.impl.io.IdentityOutputStream;
@@ -205,6 +206,8 @@ public class BHttpConnectionBase implements BHttpConnection {
             return new ChunkedInputStream(inbuffer, this.messageConstraints);
         } else if (len == ContentLengthStrategy.IDENTITY) {
             return new IdentityInputStream(inbuffer);
+        } else if (len == 0L) {
+            return EmptyInputStream.INSTANCE;
         } else {
             return new ContentLengthInputStream(inbuffer, len);
         }

--- a/httpcore/src/main/java/org/apache/http/impl/io/EmptyInputStream.java
+++ b/httpcore/src/main/java/org/apache/http/impl/io/EmptyInputStream.java
@@ -1,0 +1,80 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.io;
+
+import java.io.InputStream;
+
+public final class EmptyInputStream extends InputStream {
+    public static final EmptyInputStream INSTANCE = new EmptyInputStream();
+
+    private EmptyInputStream() {
+    }
+
+    @Override
+    public int available() {
+        return 0;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void mark(final int readLimit) {
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public int read() {
+        return -1;
+    }
+
+    @Override
+    public int read(final byte[] buf) {
+        return -1;
+    }
+
+    @Override
+    public int read(final byte[] buf, final int off, final int len) {
+        return -1;
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public long skip(final long n) {
+        return 0L;
+    }
+}
+


### PR DESCRIPTION
# Problem description
1. If HttpClient receives response with `Content-Length: 0` the connection won't be returned to connection pool until `entity.getContent().close()` is called (it is usually done by `EntityUtils.consume()`) or any read operation performed on `entity.getContent()`.
2. If CloseableHttpResponse.close() is called on such response without entity consuming, the connection will be closed, despite of any keep-alive strategies.

Here the [sample](https://gist.github.com/hirthwork/6f4ebb047e77a61f644e) illustrating first problem. Trying to execute two sequential requests with maxPerRoute set to 1 we will hit TimeoutException because connection from first response (which has empty body) won't be returned to pool.
# Problem analysis

Current BHttpConnectionBase contract is to set input stream regardless of `Content-Length:` header value. The only way to distinct empty response entities from regular ones is to set entity content to some pre-defined value which can indicate that entity is not streaming, so `MainClientExec.execute()` can return connection to pool immediately.
# Solution

Introduce `EmptyInputStream` singleton which will be set as BasicHttpEntity content on zero length responses. `isStreaming()` will check content for nullness and equality with `EmptyInputStream.INSTANCE`.
As alternative, suggested solution can be applied to 4.4.x branch, while for 5.0 branch contract can be broken and `prepareInput()` will return null for zero-length responses.
# Test

Aforementioned sample can be used for this solution testing.
