### PR TITLE
Asymetric number of invocations of onLease/onRelease in conn pool

### DIFF
--- a/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
+++ b/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
@@ -308,10 +308,10 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
                 pool.free(entry, reusable);
                 if (reusable && !this.isShutDown) {
                     this.available.addFirst(entry);
-                    onRelease(entry);
                 } else {
                     entry.close();
                 }
+                onRelease(entry);
                 PoolEntryFuture<E> future = pool.nextPending();
                 if (future != null) {
                     this.pending.remove(future);


### PR DESCRIPTION
Hi colleagues,

I am investigating a connection leak problem in a library that, uses apache httpclient. To track the issue I have to set the logging severity to DEBUG in order to log connection management events as it is described here http://hc.apache.org/httpcomponents-client-ga/logging.html . This is not a valid option for me, since I have several apache http client instances on my setup, and I would like to trace all connection pool activities on exactly one particular instance. So, I decided to modify the httpclient in the following way: each time when а connection is taken from the pool to obtain the stacktrace of the caller, it is put in a map that is the mapping connection ID is put in the caller stacktrace. Then, when a connection is returned back to the pool just to remove the corresponding mapping. In this way I will always have the stacktrace of all leased connections. 

Looking at the httpclient code – org.apache.http.pool.AbstractConnPool I found two very convenient methods:

protected void onLease(final E entry) {
}

protected void onRelease(final E entry) {
}

I found this problem: The number of onLease invocation calls is not equal to the number of onRelease call. On the other hand, the number of leased connection reported by getTotalStats() is correct. Looking at the code, I found that onRelease has been invoked conditionally, which is not the correct behavior.
