### PR TITLE
Fix hang when using AbstractClassicEntityProducer

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractClassicEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractClassicEntityProducer.java
@@ -62,7 +62,7 @@ public abstract class AbstractClassicEntityProducer implements AsyncEntityProduc
 
     @Override
     public final int available() {
-        return buffer.length();
+        return Integer.MAX_VALUE;
     }
 
     @Override


### PR DESCRIPTION
When AsyncDataProducer.available returns zero, the caller may
not execute the produce method again until
DataStreamChannel.requestOutput has been invoked.

This approach sets available to Integer.MAX_VALUE to avoid this
case. It would be more efficient to call requestOutput after
writes, but I'm not certain if invoking the method unnecessarily
would affect performance, and the MAX_VALUE approach is used by
other producers.

I was able to reproduce this issue in a test by sending a dummy 4gb
stream using AbstractClassicEntityProducer. Overriding available with
a non-zero value stopped the hangs.
Again, it may be more efficient to track `available()` invocations and
call `requestOutput()` from a subtype of ContentOutputStream, but I
haven't dug in quite that far yet :-)