### PR TITLE
setting time limit on processPending methods

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/SingleCoreIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/SingleCoreIOReactor.java
@@ -178,7 +178,7 @@ class SingleCoreIOReactor extends AbstractSingleCoreIOReactor implements Connect
 
     private void processPendingChannels() throws IOException {
         SocketChannel socketChannel;
-        while ((socketChannel = this.channelQueue.poll()) != null) {
+        for (int i = 0;i < 100000 && (socketChannel = this.channelQueue.poll()) != null;i++) {
             try {
                 prepareSocket(socketChannel.socket());
                 socketChannel.configureBlocking(false);
@@ -279,7 +279,7 @@ class SingleCoreIOReactor extends AbstractSingleCoreIOReactor implements Connect
 
     private void processPendingConnectionRequests() {
         IOSessionRequest sessionRequest;
-        while ((sessionRequest = this.requestQueue.poll()) != null) {
+        for (int i = 0;i < 100000 && (sessionRequest = this.requestQueue.poll()) != null;i++) {
             if (!sessionRequest.isCancelled()) {
                 final SocketChannel socketChannel;
                 try {


### PR DESCRIPTION
setting time limit to avoid the SingleCoreIOReactor's time be exhausted
and then  block the remaining work to do.