### PR TITLE
HTTPCORE-491 make basicasyncresponseconsumer paranoid

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/nio/protocol/BasicAsyncRequestConsumer.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/protocol/BasicAsyncRequestConsumer.java
@@ -50,6 +50,8 @@ import org.apache.http.util.Asserts;
  */
 public class BasicAsyncRequestConsumer extends AbstractAsyncRequestConsumer<HttpRequest> {
 
+    private static final int MAX_INITIAL_BUFFER_SIZE = 256 * 1024;
+
     private volatile HttpRequest request;
     private volatile SimpleInputBuffer buf;
 
@@ -72,7 +74,8 @@ public class BasicAsyncRequestConsumer extends AbstractAsyncRequestConsumer<Http
         if (len < 0) {
             len = 4096;
         }
-        this.buf = new SimpleInputBuffer((int) len, new HeapByteBufferAllocator());
+        final int initialBufferSize = Math.min((int) len, MAX_INITIAL_BUFFER_SIZE);
+        this.buf = new SimpleInputBuffer(initialBufferSize, new HeapByteBufferAllocator());
         ((HttpEntityEnclosingRequest) this.request).setEntity(
                 new ContentBufferEntity(entity, this.buf));
     }

--- a/httpcore-nio/src/main/java/org/apache/http/nio/protocol/BasicAsyncResponseConsumer.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/protocol/BasicAsyncResponseConsumer.java
@@ -49,6 +49,8 @@ import org.apache.http.util.Asserts;
  */
 public class BasicAsyncResponseConsumer extends AbstractAsyncResponseConsumer<HttpResponse> {
 
+    private static final int MAX_INITIAL_BUFFER_SIZE = 256 * 1024;
+
     private volatile HttpResponse response;
     private volatile SimpleInputBuffer buf;
 
@@ -71,7 +73,8 @@ public class BasicAsyncResponseConsumer extends AbstractAsyncResponseConsumer<Ht
         if (len < 0) {
             len = 4096;
         }
-        this.buf = new SimpleInputBuffer((int) len, new HeapByteBufferAllocator());
+        final int initialBufferSize = Math.min((int) len, MAX_INITIAL_BUFFER_SIZE);
+        this.buf = new SimpleInputBuffer(initialBufferSize, new HeapByteBufferAllocator());
         this.response.setEntity(new ContentBufferEntity(entity, this.buf));
     }
 


### PR DESCRIPTION
`BasicAsyncRequestConsumer` and `BasicAsyncResponseConsumer` used to
blindly pre-allocate a buffer of `Content-Length`. If the request / response
is crafted to have a very large `Content-Length` header, this can result in
`OutOfMemoryError`s.

This limits the initial buffer size to 256kb, while still allowing the
buffer to grow if a larger message is read.