### PR TITLE
Fix request splitting

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/nio/protocol/UriHttpAsyncRequestHandlerMapper.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/protocol/UriHttpAsyncRequestHandlerMapper.java
@@ -39,8 +39,8 @@ import org.apache.http.util.Args;
  * Patterns may have three formats:
  * <ul>
  *   <li>{@code *}</li>
- *   <li>{@code *&lt;uri&gt;}</li>
- *   <li>{@code &lt;uri&gt;*}</li>
+ *   <li>{@code *<uri>}</li>
+ *   <li>{@code <uri>*}</li>
  * </ul>
  * <br>
  * This class can be used to map an instance of {@link HttpAsyncRequestHandler}

--- a/httpcore-nio/src/main/java/org/apache/http/nio/protocol/UriHttpAsyncRequestHandlerMapper.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/protocol/UriHttpAsyncRequestHandlerMapper.java
@@ -110,6 +110,11 @@ public class UriHttpAsyncRequestHandlerMapper implements HttpAsyncRequestHandler
         return uriPath;
     }
 
+    @Override
+    public String toString() {
+        return getClass().getName() + " [matcher=" + matcher + "]";
+    }
+
     /**
      * Looks up a handler matching the given request URI.
      *

--- a/httpcore/src/main/java/org/apache/http/message/BasicLineFormatter.java
+++ b/httpcore/src/main/java/org/apache/http/message/BasicLineFormatter.java
@@ -316,7 +316,18 @@ public class BasicLineFormatter implements LineFormatter {
         buffer.append(name);
         buffer.append(": ");
         if (value != null) {
-            buffer.append(value);
+            buffer.ensureCapacity(buffer.length() + value.length());
+            for (int valueIndex = 0; valueIndex < value.length(); ++valueIndex) {
+                char valueChar = value.charAt(valueIndex);
+                if (valueChar == '\r'
+                        || valueChar == '\n'
+                        || valueChar == '\f'
+                        || valueChar == 0x0b)  // vertical tab
+                {
+                    valueChar = ' ';
+                }
+                buffer.append(valueChar);
+            }
         }
     }
 

--- a/httpcore/src/main/java/org/apache/http/protocol/UriPatternMatcher.java
+++ b/httpcore/src/main/java/org/apache/http/protocol/UriPatternMatcher.java
@@ -43,8 +43,8 @@ import org.apache.http.util.Args;
  * Patterns may have three formats:
  * <ul>
  *   <li>{@code *}</li>
- *   <li>{@code *&lt;uri&gt;}</li>
- *   <li>{@code &lt;uri&gt;*}</li>
+ *   <li>{@code *<uri>}</li>
+ *   <li>{@code <uri>*}</li>
  * </ul>
  * <br>
  * This class can be used to resolve an object matching a particular request

--- a/httpcore/src/test/java/org/apache/http/message/TestBasicLineFormatter.java
+++ b/httpcore/src/test/java/org/apache/http/message/TestBasicLineFormatter.java
@@ -153,4 +153,11 @@ public class TestBasicLineFormatter {
         }
     }
 
+    @Test
+    public void testHeaderFormattingRequestSplitting() throws Exception {
+        final Header header = new BasicHeader("Host", "apache.org\r\nOops: oops");
+        String s = BasicLineFormatter.formatHeader(header, null);
+        Assert.assertFalse(s.contains("\n"));
+        Assert.assertEquals("Host: apache.org  Oops: oops", s);
+    }
 }


### PR DESCRIPTION
If user has access to any header value, he can add any additional malicious header, like `Host`, `X-Forwarded-Host` or even make another HTTP request.

http://projects.webappsec.org/w/page/13246929/HTTP%20Request%20Splitting