### PR TITLE
Improve connection reuse logic

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
@@ -156,7 +156,7 @@ public class ChunkedInputStream extends EofInputStream {
             pos++;
             if (pos >= chunkSize) {
                 state = CHUNK_CRLF;
-                consumeEndOfMessageIfCached();
+                consumeEndOfMessageIfBuffered();
             }
         }
         return b;
@@ -193,7 +193,7 @@ public class ChunkedInputStream extends EofInputStream {
             pos += bytesRead;
             if (pos >= chunkSize) {
                 state = CHUNK_CRLF;
-                consumeEndOfMessageIfCached();
+                consumeEndOfMessageIfBuffered();
             }
             return bytesRead;
         }
@@ -328,7 +328,7 @@ public class ChunkedInputStream extends EofInputStream {
         return this.footers.clone();
     }
 
-    private void consumeEndOfMessageIfCached() throws IOException {
+    private void consumeEndOfMessageIfBuffered() throws IOException {
         if (eof || state != CHUNK_CRLF) {
             return;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
@@ -37,6 +37,7 @@ import org.apache.hc.core5.http.MalformedChunkCodingException;
 import org.apache.hc.core5.http.StreamClosedException;
 import org.apache.hc.core5.http.TruncatedChunkException;
 import org.apache.hc.core5.http.config.H1Config;
+import org.apache.hc.core5.http.io.EofInputStream;
 import org.apache.hc.core5.http.io.SessionInputBuffer;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
@@ -57,7 +58,7 @@ import org.apache.hc.core5.util.CharArrayBuffer;
  * @since 4.0
  *
  */
-public class ChunkedInputStream extends InputStream {
+public class ChunkedInputStream extends EofInputStream {
 
     private static final int CHUNK_LEN               = 1;
     private static final int CHUNK_DATA              = 2;
@@ -322,6 +323,11 @@ public class ChunkedInputStream extends InputStream {
 
     public Header[] getFooters() {
         return this.footers.clone();
+    }
+
+    @Override
+    public boolean atEof() {
+        return eof;
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
@@ -339,7 +339,7 @@ public class ChunkedInputStream extends EofInputStream {
         // - A chunk size of 0, followed by CR+LF
         // - Zero or more footers followed by CR+LF
         // - An empty line
-        int bufferedLen = buffer.getBufferedLen();
+        final int bufferedLen = buffer.getBufferedLen();
         if (bufferedLen < 2 || buffer.peekBuffered(0) != Chars.CR || buffer.peekBuffered(1) != Chars.LF) {
             return;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.StreamClosedException;
+import org.apache.hc.core5.http.io.EofInputStream;
 import org.apache.hc.core5.http.io.SessionInputBuffer;
 import org.apache.hc.core5.util.Args;
 
@@ -51,7 +52,7 @@ import org.apache.hc.core5.util.Args;
  *
  * @since 4.0
  */
-public class ContentLengthInputStream extends InputStream {
+public class ContentLengthInputStream extends EofInputStream {
 
     private static final int BUFFER_SIZE = 2048;
 
@@ -222,5 +223,10 @@ public class ContentLengthInputStream extends InputStream {
             remaining -= l;
         }
         return count;
+    }
+
+    @Override
+    public boolean atEof() {
+        return pos == contentLength;
     }
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
@@ -384,4 +384,14 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
         return this.metrics;
     }
 
+    @Override
+    public int getBufferedLen() {
+        return bufferlen - bufferpos;
+    }
+
+    @Override
+    public byte peekBuffered(int offset) {
+        return buffer[this.bufferpos + offset];
+    }
+
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
@@ -390,7 +390,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
     }
 
     @Override
-    public byte peekBuffered(int offset) {
+    public byte peekBuffered(final int offset) {
         return buffer[this.bufferpos + offset];
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofInputStream.java
@@ -33,8 +33,8 @@ public abstract class EofInputStream extends InputStream {
 
     /**
      * Tries to determine, without blocking, if the entire content of the stream has already been read
-     * @return true if the entire content of the stream has already been read, false of either
-     * the entire content has not been read or a determination cannot be made without potentially blocking
+     * @return true if the entire content of the stream has already been read, false if either
+     * the entire content has not been read or a determination cannot be made without blocking
      */
     public abstract boolean atEof();
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofInputStream.java
@@ -1,0 +1,40 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http.io;
+
+import java.io.InputStream;
+
+public abstract class EofInputStream extends InputStream {
+
+    /**
+     * Tries to determine, without blocking, if the entire content of the stream has already been read
+     * @return true if the entire content of the stream has already been read, false of either
+     * the entire content has not been read or a determination cannot be made without potentially blocking
+     */
+    public abstract boolean atEof();
+}

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
@@ -192,7 +192,7 @@ public class EofSensorInputStream extends InputStream {
     private void checkEOF(final int eof) throws IOException {
 
         final InputStream toCheckStream = wrappedStream;
-        if ((toCheckStream != null) && (eof < 0)) {
+        if ((toCheckStream != null) && (eof < 0 || atEof(toCheckStream))) {
             try {
                 boolean scws = true; // should close wrapped stream?
                 if (eofWatcher != null) {
@@ -205,6 +205,10 @@ public class EofSensorInputStream extends InputStream {
                 wrappedStream = null;
             }
         }
+    }
+
+    private static boolean atEof(InputStream toCheckStream) {
+        return (toCheckStream instanceof EofInputStream) && ((EofInputStream)toCheckStream).atEof();
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
@@ -207,7 +207,7 @@ public class EofSensorInputStream extends InputStream {
         }
     }
 
-    private static boolean atEof(InputStream toCheckStream) {
+    private static boolean atEof(final InputStream toCheckStream) {
         return (toCheckStream instanceof EofInputStream) && ((EofInputStream)toCheckStream).atEof();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/SessionInputBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/SessionInputBuffer.java
@@ -144,4 +144,17 @@ public interface SessionInputBuffer {
      */
     HttpTransportMetrics getMetrics();
 
+    /**
+     * Returns the number of bytes stored in the session buffer
+     * @return     the number of bytes in the session buffer
+     */
+    int getBufferedLen();
+
+    /**
+     * Returns the byte stored at the given offset in the session buffer.
+     * The offset must be >= 0 and < getBufferedLen() - 1.
+     * @param       offset in the buffer
+     * @return      the buffered byte
+     */
+    byte peekBuffered(int offset);
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
@@ -521,7 +521,7 @@ public class TestChunkCoding {
     @Test
     public void testAtEof() throws IOException {
         final SessionInputBuffer inbuffer = new SessionInputBufferImpl(128);
-        String chunkedInput = CHUNKED_INPUT + "\r\n";
+        final String chunkedInput = CHUNKED_INPUT + "\r\n";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(chunkedInput.getBytes(StandardCharsets.ISO_8859_1));
         final ChunkedInputStream in = new ChunkedInputStream(inbuffer, inputStream);
         final byte[] buffer = new byte[64];

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
@@ -46,13 +46,15 @@ public class TestContentLengthInputStream {
         final String s = "1234567890123456";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
         final SessionInputBuffer inbuffer = new SessionInputBufferImpl(16);
-        final InputStream in = new ContentLengthInputStream(inbuffer, inputStream, 10L);
+        final ContentLengthInputStream in = new ContentLengthInputStream(inbuffer, inputStream, 10L);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         final byte[] buffer = new byte[50];
         int len = in.read(buffer, 0, 2);
+        Assert.assertFalse(in.atEof());
         outputStream.write(buffer, 0, len);
         len = in.read(buffer);
+        Assert.assertTrue(in.atEof());
         outputStream.write(buffer, 0, len);
 
         final String result = new String(outputStream.toByteArray(), StandardCharsets.ISO_8859_1);
@@ -64,34 +66,44 @@ public class TestContentLengthInputStream {
     public void testSkip() throws IOException {
         final ByteArrayInputStream inputStream1 = new ByteArrayInputStream(new byte[20]);
         final SessionInputBuffer inbuffer1 = new SessionInputBufferImpl(16);
-        final InputStream in1 = new ContentLengthInputStream(inbuffer1, inputStream1, 10L);
+        final ContentLengthInputStream in1 = new ContentLengthInputStream(inbuffer1, inputStream1, 10L);
         Assert.assertEquals(10, in1.skip(10));
+        Assert.assertTrue(in1.atEof());
         Assert.assertTrue(in1.read() == -1);
+        Assert.assertTrue(in1.atEof());
         in1.close();
 
         final ByteArrayInputStream inputStream2 = new ByteArrayInputStream(new byte[20]);
         final SessionInputBuffer inbuffer2 = new SessionInputBufferImpl(16);
-        final InputStream in2 = new ContentLengthInputStream(inbuffer2, inputStream2, 10L);
+        final ContentLengthInputStream in2 = new ContentLengthInputStream(inbuffer2, inputStream2, 10L);
         in2.read();
+        Assert.assertFalse(in2.atEof());
         Assert.assertEquals(9, in2.skip(10));
+        Assert.assertTrue(in2.atEof());
         Assert.assertTrue(in2.read() == -1);
+        Assert.assertTrue(in2.atEof());
         in2.close();
 
         final ByteArrayInputStream inputStream3 = new ByteArrayInputStream(new byte[20]);
         final SessionInputBuffer inbuffer3 = new SessionInputBufferImpl(16);
-        final InputStream in3 = new ContentLengthInputStream(inbuffer3, inputStream3, 2L);
+        final ContentLengthInputStream in3 = new ContentLengthInputStream(inbuffer3, inputStream3, 2L);
         in3.read();
+        Assert.assertFalse(in3.atEof());
         in3.read();
+        Assert.assertTrue(in3.atEof());
         Assert.assertTrue(in3.skip(10) <= 0);
         Assert.assertTrue(in3.skip(-1) == 0);
         Assert.assertTrue(in3.read() == -1);
+        Assert.assertTrue(in3.atEof());
         in3.close();
 
         final ByteArrayInputStream inputStream4 = new ByteArrayInputStream(new byte[20]);
         final SessionInputBuffer inbuffer4 = new SessionInputBufferImpl(16);
-        final InputStream in4 = new ContentLengthInputStream(inbuffer4, inputStream4, 10L);
+        final ContentLengthInputStream in4 = new ContentLengthInputStream(inbuffer4, inputStream4, 10L);
         Assert.assertEquals(5,in4.skip(5));
+        Assert.assertFalse(in4.atEof());
         Assert.assertEquals(5, in4.read(new byte[20]));
+        Assert.assertTrue(in4.atEof());
         in4.close();
     }
 
@@ -139,24 +151,25 @@ public class TestContentLengthInputStream {
         final String s = "1234567890123456";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
         final SessionInputBuffer inbuffer = new SessionInputBufferImpl(16);
-        final InputStream in = new ContentLengthInputStream(inbuffer, inputStream, 32L);
+        final ContentLengthInputStream in = new ContentLengthInputStream(inbuffer, inputStream, 32L);
 
         final byte[] tmp = new byte[32];
         final int byteRead = in.read(tmp);
         Assert.assertEquals(16, byteRead);
+        Assert.assertFalse(in.atEof());
         try {
             in.read(tmp);
-            Assert.fail("ConnectionClosedException should have been closed");
+            Assert.fail("ConnectionClosedException should have been thrown");
         } catch (final ConnectionClosedException ex) {
         }
         try {
             in.read();
-            Assert.fail("ConnectionClosedException should have been closed");
+            Assert.fail("ConnectionClosedException should have been thrown");
         } catch (final ConnectionClosedException ex) {
         }
         try {
             in.close();
-            Assert.fail("ConnectionClosedException should have been closed");
+            Assert.fail("ConnectionClosedException should have been thrown");
         } catch (final ConnectionClosedException ex) {
         }
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStreamWithEofInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStreamWithEofInputStream.java
@@ -49,8 +49,8 @@ public class TestEofSensorInputStreamWithEofInputStream {
     @Test
     public void testReadAtEof() throws Exception {
         Mockito.when(instream.read()).thenReturn(0);
-    	Mockito.when(instream.atEof()).thenReturn(true);
-    	Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
+        Mockito.when(instream.atEof()).thenReturn(true);
+        Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
 
         Assert.assertEquals(0, eofstream.read());
         Assert.assertNull(eofstream.getWrappedStream());
@@ -61,8 +61,8 @@ public class TestEofSensorInputStreamWithEofInputStream {
     @Test
     public void testReadNotAtEof() throws Exception {
         Mockito.when(instream.read()).thenReturn(0);
-    	Mockito.when(instream.atEof()).thenReturn(false);
-    	Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
+        Mockito.when(instream.atEof()).thenReturn(false);
+        Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
 
         Assert.assertEquals(0, eofstream.read());
         Assert.assertNotNull(eofstream.getWrappedStream());
@@ -74,8 +74,8 @@ public class TestEofSensorInputStreamWithEofInputStream {
     public void testReadByteArrayAtEof() throws Exception {
         Mockito.when(instream.read(Mockito.<byte []>any(), Mockito.anyInt(), Mockito.anyInt()))
             .thenReturn(1);
-    	Mockito.when(instream.atEof()).thenReturn(true);
-    	Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
+        Mockito.when(instream.atEof()).thenReturn(true);
+        Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
 
         final byte[] tmp = new byte[1];
 
@@ -89,7 +89,7 @@ public class TestEofSensorInputStreamWithEofInputStream {
     public void testReadByteArrayNotAtEof() throws Exception {
         Mockito.when(instream.read(Mockito.<byte []>any(), Mockito.anyInt(), Mockito.anyInt()))
             .thenReturn(1);
-    	Mockito.when(instream.atEof()).thenReturn(false);
+        Mockito.when(instream.atEof()).thenReturn(false);
 
         final byte[] tmp = new byte[1];
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStreamWithEofInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStreamWithEofInputStream.java
@@ -1,0 +1,101 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http.io;
+
+import java.io.InputStream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestEofSensorInputStreamWithEofInputStream {
+
+    private EofInputStream instream;
+    private EofSensorWatcher eofwatcher;
+    private EofSensorInputStream eofstream;
+
+    @Before
+    public void setup() throws Exception {
+        instream = Mockito.mock(EofInputStream.class);
+        eofwatcher = Mockito.mock(EofSensorWatcher.class);
+        eofstream = new EofSensorInputStream(instream, eofwatcher);
+    }
+
+    @Test
+    public void testReadAtEof() throws Exception {
+        Mockito.when(instream.read()).thenReturn(0);
+    	Mockito.when(instream.atEof()).thenReturn(true);
+    	Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
+
+        Assert.assertEquals(0, eofstream.read());
+        Assert.assertNull(eofstream.getWrappedStream());
+        Mockito.verify(instream, Mockito.times(1)).close();
+        Mockito.verify(eofwatcher).eofDetected(instream);
+    }
+
+    @Test
+    public void testReadNotAtEof() throws Exception {
+        Mockito.when(instream.read()).thenReturn(0);
+    	Mockito.when(instream.atEof()).thenReturn(false);
+    	Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
+
+        Assert.assertEquals(0, eofstream.read());
+        Assert.assertNotNull(eofstream.getWrappedStream());
+        Mockito.verify(instream, Mockito.never()).close();
+        Mockito.verify(eofwatcher, Mockito.never()).eofDetected(instream);
+    }
+
+    @Test
+    public void testReadByteArrayAtEof() throws Exception {
+        Mockito.when(instream.read(Mockito.<byte []>any(), Mockito.anyInt(), Mockito.anyInt()))
+            .thenReturn(1);
+    	Mockito.when(instream.atEof()).thenReturn(true);
+    	Mockito.when(eofwatcher.eofDetected(Mockito.<InputStream>any())).thenReturn(Boolean.TRUE);
+
+        final byte[] tmp = new byte[1];
+
+        Assert.assertEquals(1, eofstream.read(tmp));
+        Assert.assertNull(eofstream.getWrappedStream());
+        Mockito.verify(instream, Mockito.times(1)).close();
+        Mockito.verify(eofwatcher).eofDetected(instream);
+    }
+
+    @Test
+    public void testReadByteArrayNotAtEof() throws Exception {
+        Mockito.when(instream.read(Mockito.<byte []>any(), Mockito.anyInt(), Mockito.anyInt()))
+            .thenReturn(1);
+    	Mockito.when(instream.atEof()).thenReturn(false);
+
+        final byte[] tmp = new byte[1];
+
+        Assert.assertEquals(1, eofstream.read(tmp));
+        Assert.assertNotNull(eofstream.getWrappedStream());
+        Mockito.verify(instream, Mockito.never()).close();
+        Mockito.verify(eofwatcher, Mockito.never()).eofDetected(instream);
+    }
+}


### PR DESCRIPTION
This is still a work-in-progress, at this point I'm just soliciting feedback.

The purpose of this change is to improve connection reuse by detecting that the content stream of an HTTP response entity is already at EOF before the stream's read() method returns -1. This is useful when the application does not want to call the close() method of the content stream, since that method can potentially block.