### PR TITLE
Workaround for misbehaved servers that return HTTP 204 responses with a content

### DIFF
--- a/httpcore/src/main/java/org/apache/http/impl/DefaultConnectionReuseStrategy.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultConnectionReuseStrategy.java
@@ -80,17 +80,26 @@ public class DefaultConnectionReuseStrategy implements ConnectionReuseStrategy {
         Args.notNull(response, "HTTP response");
         Args.notNull(context, "HTTP context");
 
-        // If a HTTP 204 No Content response contains a Content-length or Transfer-encoding:Chunked header,
+        // If a HTTP 204 No Content response contains a Content-length with value > 0 or Transfer-encoding:Chunked header,
         // don't reuse the connection. This is to avoid getting out-of-sync if a misbehaved HTTP server
         // returns content as part of a HTTP 204 response.
         if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NO_CONTENT) {
-              if (response.getFirstHeader(HTTP.CONTENT_LEN) != null) {
-                  return false;
-              }
-              final Header transferEncodingHeader = response.getFirstHeader(HTTP.TRANSFER_ENCODING);
-              if (transferEncodingHeader != null && HTTP.CHUNK_CODING.equalsIgnoreCase(transferEncodingHeader.getValue())) {
-                  return false;
-              }
+            final Header clh = response.getFirstHeader(HTTP.CONTENT_LEN);
+            if (clh != null) {
+                try {
+                    final int contentLen = Integer.parseInt(clh.getValue());
+                    if (contentLen > 0) {
+                        return false;
+                    }
+                } catch (final NumberFormatException ex) {
+                    // fall through
+                }
+            }
+
+            final Header teh = response.getFirstHeader(HTTP.TRANSFER_ENCODING);
+            if (teh != null && HTTP.CHUNK_CODING.equalsIgnoreCase(teh.getValue())) {
+                return false;
+            }
         }
 
         final HttpRequest request = (HttpRequest) context.getAttribute(HttpCoreContext.HTTP_REQUEST);

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultConnectionReuseStrategy.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultConnectionReuseStrategy.java
@@ -80,7 +80,7 @@ public class DefaultConnectionReuseStrategy implements ConnectionReuseStrategy {
         Args.notNull(response, "HTTP response");
         Args.notNull(context, "HTTP context");
 
-        // If a HTTP 204 No Content response contain a Content-length or Transfer-encoding:Chunked header,
+        // If a HTTP 204 No Content response contains a Content-length or Transfer-encoding:Chunked header,
         // don't reuse the connection. This is to avoid getting out-of-sync if a misbehaved HTTP server
         // returns content as part of a HTTP 204 response.
         if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NO_CONTENT) {

--- a/httpcore/src/test/java/org/apache/http/impl/TestDefaultConnectionReuseStrategy.java
+++ b/httpcore/src/test/java/org/apache/http/impl/TestDefaultConnectionReuseStrategy.java
@@ -284,5 +284,20 @@ public class TestDefaultConnectionReuseStrategy {
         Assert.assertTrue(reuseStrategy.keepAlive(response, context));
     }
 
+    @Test
+    public void testHttp204ContentLength() throws Exception {
+        final HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 204, "OK");
+        response.addHeader("Content-Length", "10");
+        response.addHeader("Connection", "keep-alive");
+        Assert.assertFalse(reuseStrategy.keepAlive(response, context));
+    }
+
+    @Test
+    public void testHttp204ChunkedContent() throws Exception {
+        final HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 204, "OK");
+        response.addHeader("Transfer-Encoding", "chunked");
+        response.addHeader("Connection", "keep-alive");
+        Assert.assertFalse(reuseStrategy.keepAlive(response, context));
+    }
 }
 

--- a/httpcore/src/test/java/org/apache/http/impl/TestDefaultConnectionReuseStrategy.java
+++ b/httpcore/src/test/java/org/apache/http/impl/TestDefaultConnectionReuseStrategy.java
@@ -285,11 +285,19 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHttp204ContentLength() throws Exception {
+    public void testHttp204ContentLengthGreaterThanZero() throws Exception {
         final HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 204, "OK");
         response.addHeader("Content-Length", "10");
         response.addHeader("Connection", "keep-alive");
         Assert.assertFalse(reuseStrategy.keepAlive(response, context));
+    }
+
+    @Test
+    public void testHttp204ContentLengthEqualToZero() throws Exception {
+        final HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 204, "OK");
+        response.addHeader("Content-Length", "0");
+        response.addHeader("Connection", "keep-alive");
+        Assert.assertTrue(reuseStrategy.keepAlive(response, context));
     }
 
     @Test


### PR DESCRIPTION
I have encountered a server that incorrectly returns a content on a HTTP 204 response. The server also returns a Content-length header with the response.

httpclient assumes that HTTP 204 responses have no content, so it doesn't consume the content.

If the connection is reused, this causes httpclient to hang when looking for the status line of the next response.

This patch attempts to prevent the issue by allowing HTTP 204 responses with Content-length or Transfer-encoding: Chunked as responses to have a content.