### PR TITLE
Avoid endless loop

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -110,16 +110,18 @@ public class ExpandableBuffer {
     protected void expand() {
         int newcapacity = (this.buffer.capacity() + 1) << 1;
         if (newcapacity < 0) {
-            int headRoom = Integer.max(Long.BYTES, 8);
-            // Reason: In GC the size of objects is passed as int (2 bytes). 
-            // Then, the header size of the objects is added to the size. 
-            // Long has the longest header available. Object header seems to be linked to it. 
-            // Details: I added a minimum of 8 just to be safe and because 8 is used in 
+            final int vmBytes = Long.SIZE >> 3;
+            final int javaBytes = 8; // this is to be checked when the JVM version changes
+            @SuppressWarnings("unused") // we really need the 8 if we're going to make this foolproof
+            final int headRoom = (vmBytes >= javaBytes) ? vmBytes : javaBytes;
+            // Reason: In GC the size of objects is passed as int (2 bytes).
+            // Then, the header size of the objects is added to the size.
+            // Long has the longest header available. Object header seems to be linked to it.
+            // Details: I added a minimum of 8 just to be safe and because 8 is used in
             // java.lang.Object.ArrayList: private static final int MAX_ARRAY_SIZE = 2147483639.
             //
             // WARNING: This code assumes you are providing enough heap room with -Xmx.
             // source of inspiration: https://bugs.openjdk.java.net/browse/JDK-8059914
-                    
             newcapacity = Integer.MAX_VALUE - headRoom;
         }
         expandCapacity(newcapacity);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -28,7 +28,7 @@
 package org.apache.hc.core5.http.impl.nio;
 
 import java.nio.ByteBuffer;
-import org.apache.hc.core5.http.MessageConstraintException;
+import java.nio.BufferOverflowException;
 
 /**
  * A buffer that expand its capacity on demand. Internally, this class is backed
@@ -107,8 +107,10 @@ public class ExpandableBuffer {
 
     /**
      * Expands buffer's capacity.
+     * 
+     * @throws BufferOverflowException in case we get over the maximum allowed value
      */
-    protected void expand() {
+    protected void expand() throws BufferOverflowException {
         int newcapacity = (this.buffer.capacity() + 1) << 1;
         if (newcapacity < 0) {
             final int vmBytes = Long.SIZE >> 3;
@@ -124,9 +126,9 @@ public class ExpandableBuffer {
             // WARNING: This code assumes you are providing enough heap room with -Xmx.
             // source of inspiration: https://bugs.openjdk.java.net/browse/JDK-8059914
             newcapacity = Integer.MAX_VALUE - headRoom;
-            if (newcapacity == this.buffer.capacity()) {
+            if (newcapacity <= this.buffer.capacity()) {
                 // avoid an endless loop in org.apache.http.nio.util.SimpleInputBuffer.consumeContent(ContentDecoder)
-                throw new MessageConstraintException("Maximum buffer size (" + newcapacity + ") exceeded");
+                throw new BufferOverflowException();
             }
         }
         expandCapacity(newcapacity);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl.nio;
 
 import java.nio.ByteBuffer;
+import org.apache.hc.core5.http.MessageConstraintException;
 
 /**
  * A buffer that expand its capacity on demand. Internally, this class is backed

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -123,6 +123,10 @@ public class ExpandableBuffer {
             // WARNING: This code assumes you are providing enough heap room with -Xmx.
             // source of inspiration: https://bugs.openjdk.java.net/browse/JDK-8059914
             newcapacity = Integer.MAX_VALUE - headRoom;
+            if (newcapacity == this.buffer.capacity()) {
+                // avoid an endless loop in org.apache.http.nio.util.SimpleInputBuffer.consumeContent(ContentDecoder)
+                throw new MessageConstraintException("Maximum buffer size (" + newcapacity + ") exceeded");
+            }
         }
         expandCapacity(newcapacity);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -126,6 +126,7 @@ public class ExpandableBuffer {
             // WARNING: This code assumes you are providing enough heap room with -Xmx.
             // source of inspiration: https://bugs.openjdk.java.net/browse/JDK-8059914
             newcapacity = Integer.MAX_VALUE - headRoom;
+
             if (newcapacity <= this.buffer.capacity()) {
                 // avoid an endless loop in org.apache.http.nio.util.SimpleInputBuffer.consumeContent(ContentDecoder)
                 throw new BufferOverflowException();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -110,7 +110,17 @@ public class ExpandableBuffer {
     protected void expand() {
         int newcapacity = (this.buffer.capacity() + 1) << 1;
         if (newcapacity < 0) {
-            newcapacity = Integer.MAX_VALUE;
+            int headRoom = Integer.max(Long.BYTES, 8);
+            // Reason: In GC the size of objects is passed as int (2 bytes). 
+            // Then, the header size of the objects is added to the size. 
+            // Long has the longest header available. Object header seems to be linked to it. 
+            // Details: I added a minimum of 8 just to be safe and because 8 is used in 
+            // java.lang.Object.ArrayList: private static final int MAX_ARRAY_SIZE = 2147483639.
+            //
+            // WARNING: This code assumes you are providing enough heap room with -Xmx.
+            // source of inspiration: https://bugs.openjdk.java.net/browse/JDK-8059914
+                    
+            newcapacity = Integer.MAX_VALUE - headRoom;
         }
         expandCapacity(newcapacity);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ExpandableBuffer.java
@@ -107,7 +107,7 @@ public class ExpandableBuffer {
 
     /**
      * Expands buffer's capacity.
-     * 
+     *
      * @throws BufferOverflowException in case we get over the maximum allowed value
      */
     protected void expand() throws BufferOverflowException {


### PR DESCRIPTION
Of course, I did not think this through...
This pull request is related to https://github.com/apache/httpcomponents-core/pull/58 .

We might get into an endless loop for sizes which are in (Integer.MAX_VALUE - headRoom, Integer.MAX_VALUE] .