### PR TITLE
Allow default http client connection to read simple streamed responses

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
@@ -205,9 +205,6 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
         Args.notNull(response, "HTTP response");
         final SocketHolder socketHolder = ensureOpen();
         final long len = this.incomingContentStrategy.determineLength(response);
-        if (len == ContentLengthStrategy.UNDEFINED) {
-            return;
-        }
         response.setEntity(createIncomingEntity(response, this.inBuffer, socketHolder.getInputStream(), len));
     }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestDefaultBHttpClientConnection.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestDefaultBHttpClientConnection.java
@@ -92,6 +92,38 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
+    public void testReadResponseEntityWithoutContentLength() throws Exception {
+        final String s = "HTTP/1.1 200 OK\r\nServer: test\r\n\r\n123";
+        final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
+        Mockito.when(socket.getInputStream()).thenReturn(inStream);
+
+        conn.bind(socket);
+
+        Assert.assertEquals(0, conn.getEndpointDetails().getResponseCount());
+
+        final ClassicHttpResponse response = conn.receiveResponseHeader();
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(200, response.getCode());
+        Assert.assertTrue(response.containsHeader("Server"));
+        Assert.assertEquals(1, conn.getEndpointDetails().getResponseCount());
+
+        conn.receiveResponseEntity(response);
+
+        final HttpEntity entity = response.getEntity();
+        Assert.assertNotNull(entity);
+        Assert.assertEquals(-1, entity.getContentLength());
+        Assert.assertEquals(1, conn.getEndpointDetails().getResponseCount());
+
+        final InputStream content = entity.getContent();
+        Assert.assertNotNull(content);
+        Assert.assertEquals(3, content.available());
+        Assert.assertEquals('1', content.read());
+        Assert.assertEquals('2', content.read());
+        Assert.assertEquals('3', content.read());
+    }
+
+    @Test
     public void testReadResponseEntityWithContentLength() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nServer: test\r\nContent-Length: 3\r\n\r\n123";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));


### PR DESCRIPTION
As per spec these responses are terminated by the end of stream.

Issue: https://issues.apache.org/jira/browse/HTTPCORE-559

Note: this PR breaks one existing unit test - namely {{testReadResponseNoEntity}} from {{TestDefaultBHttpClientConnection}}.  The test is trivial to fix, but I'm not sure what you want the desired behaviour to be when an 'empty' response is returned.  Previously the result was a null entity, but with my change the result is now an empty entity, an entity with no content.  I think this is fine, but you may not.