### PR TITLE
Interpret HTTP/2 window updates as increments

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/ReactiveClientTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/ReactiveClientTest.java
@@ -271,12 +271,14 @@ public class ReactiveClientTest {
         final InetSocketAddress address = startClientAndServer();
         final AtomicLong requestLength = new AtomicLong(0L);
         final AtomicReference<MessageDigest> requestDigest = new AtomicReference<>(newDigest());
-        final Publisher<ByteBuffer> publisher = Flowable.rangeLong(1, 10)
+        final Publisher<ByteBuffer> publisher = Flowable.rangeLong(1, 100)
             .map(new Function<Long, ByteBuffer>() {
                 @Override
                 public ByteBuffer apply(final Long seed) {
                     final Random random = new Random(seed);
-                    final byte[] bytes = new byte[32 * 1024];
+                    // Using blocks slightly larger than the HTTP/2 window size serves to exercise the input window
+                    // management code
+                    final byte[] bytes = new byte[65535 + 7];
                     requestLength.addAndGet(bytes.length);
                     random.nextBytes(bytes);
                     return ByteBuffer.wrap(bytes);

--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/Cancellable.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/Cancellable.java
@@ -37,7 +37,7 @@ public interface Cancellable {
     /**
      * Cancels the ongoing operation or process.
      *
-     * @return {@code frue} if the operation or process has been cancelled as a result of
+     * @return {@code rue} if the operation or process has been cancelled as a result of
      * this method call or {@code false} if it has already been cancelled or not started.
      */
     boolean cancel();


### PR DESCRIPTION
The `CapacityChannel#update(int)` method accepts a capacity *increment*, essentially allowing the caller to signal that a certain number of bytes has just been freed up. However, the HTTP/2 implementation interprets that value as the *total* buffer capacity, and thus drops all capacity
increments below a certain size, causing the window size to irreversibly shrink over time.

This change causes HTTP/2 capacity updates to be applied directly to the input window as increments. Since there exist `AsyncEntityConsumer` implementations (such as `StringAsyncEntityConsumer`) that supply a capacity of `Integer.MAX_VALUE`, the `updateWindow` method has been modified to tolerate integer overflow, instead of throwing an ArithmeticException. This is intended as an interim measure until the topic of capacity channel update management can be addressed more comprehensively.