### PR TITLE
Fixed invalid module name

### DIFF
--- a/httpcore-nio/pom.xml
+++ b/httpcore-nio/pom.xml
@@ -106,7 +106,7 @@
             <configuration>
               <archive combine.children="append">
                 <manifestEntries>
-                  <Automatic-Module-Name>org.apache.httpcomponents.httpcore-nio</Automatic-Module-Name>
+                  <Automatic-Module-Name>org.apache.httpcomponents.httpcorenio</Automatic-Module-Name>
                 </manifestEntries>
               </archive>
             </configuration>


### PR DESCRIPTION
I was trying to use httpcomponents (4.4.10) with java jingsaw modules and discovered that httpcore-nio has wrong automatic module name defined in its MANIFEST.MF 

My project module descriptor:
```
open module my.module {
	requires org.apache.httpcomponents.httpcore;
}
```

But after i tried to run such application and got following error:

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for target/modules/httpcore-nio-4.4.10.jar
Caused by: java.lang.module.FindException: Automatic-Module-Name: org.apache.httpcomponents.httpcore-nio: Invalid module name: 'httpcore-nio' is not a Java identifier
```

It appears like "-" is not allowed character in module name. However i was not able to confirm this speculation since i could not find its specifications anywhere. 

This PR removes the "-" character from the module name. After this change the problem has disappeared. 


I tested this on java 11.0.1
```
$ java -version
openjdk version "11.0.1" 2018-10-16
OpenJDK Runtime Environment 18.9 (build 11.0.1+13)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.1+13, mixed mode)
```



