### PR TITLE
SSLIOSession: Add `connectTimeout` constructor param

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiatorFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiatorFactory.java
@@ -38,6 +38,7 @@ import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link ClientHttpProtocolNegotiator} factory.
@@ -52,16 +53,19 @@ public class ClientHttpProtocolNegotiatorFactory implements IOEventHandlerFactor
     private final ClientHttp2StreamMultiplexerFactory http2StreamHandlerFactory;
     private final HttpVersionPolicy versionPolicy;
     private final TlsStrategy tlsStrategy;
+    private final Timeout handshakeTimeout;
 
     public ClientHttpProtocolNegotiatorFactory(
             final ClientHttp1StreamDuplexerFactory http1StreamHandlerFactory,
             final ClientHttp2StreamMultiplexerFactory http2StreamHandlerFactory,
             final HttpVersionPolicy versionPolicy,
-            final TlsStrategy tlsStrategy) {
+            final TlsStrategy tlsStrategy,
+            final Timeout handshakeTimeout) {
         this.http1StreamHandlerFactory = Args.notNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
         this.http2StreamHandlerFactory = Args.notNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.tlsStrategy = tlsStrategy;
+        this.handshakeTimeout = handshakeTimeout;
     }
 
     @Override
@@ -74,7 +78,8 @@ public class ClientHttpProtocolNegotiatorFactory implements IOEventHandlerFactor
                         host,
                         ioSession.getLocalAddress(),
                         ioSession.getRemoteAddress(),
-                        attachment);
+                        attachment,
+                        handshakeTimeout);
             }
         }
         return new ClientHttpProtocolNegotiator(

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiatorFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiatorFactory.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link ServerHttpProtocolNegotiator} factory.
@@ -50,16 +51,19 @@ public class ServerHttpProtocolNegotiatorFactory implements IOEventHandlerFactor
     private final ServerHttp2StreamMultiplexerFactory http2StreamMultiplexerFactory;
     private final HttpVersionPolicy versionPolicy;
     private final TlsStrategy tlsStrategy;
+    private final Timeout handshakeTimeout;
 
     public ServerHttpProtocolNegotiatorFactory(
             final ServerHttp1StreamDuplexerFactory http1StreamDuplexerFactory,
             final ServerHttp2StreamMultiplexerFactory http2StreamMultiplexerFactory,
             final HttpVersionPolicy versionPolicy,
-            final TlsStrategy tlsStrategy) {
+            final TlsStrategy tlsStrategy,
+            final Timeout handshakeTimeout) {
         this.http1StreamDuplexerFactory = Args.notNull(http1StreamDuplexerFactory, "HTTP/1.1 stream handler factory");
         this.http2StreamMultiplexerFactory = Args.notNull(http2StreamMultiplexerFactory, "HTTP/2 stream handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.tlsStrategy = tlsStrategy;
+        this.handshakeTimeout = handshakeTimeout;
     }
 
     @Override
@@ -70,7 +74,8 @@ public class ServerHttpProtocolNegotiatorFactory implements IOEventHandlerFactor
                     null,
                     ioSession.getLocalAddress(),
                     ioSession.getRemoteAddress(),
-                    attachment != null ? attachment : versionPolicy);
+                    attachment != null ? attachment : versionPolicy,
+                    handshakeTimeout);
         }
         return new ServerHttpProtocolNegotiator(ioSession, http1StreamDuplexerFactory, http2StreamMultiplexerFactory, versionPolicy);
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
@@ -63,6 +63,7 @@ import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link Http2AsyncRequester} bootstrap.
@@ -85,6 +86,7 @@ public class H2RequesterBootstrap {
     private PoolReusePolicy poolReusePolicy;
     private PoolConcurrencyPolicy poolConcurrencyPolicy;
     private TlsStrategy tlsStrategy;
+    private Timeout handshakeTimeout;
     private Decorator<IOSession> ioSessionDecorator;
     private IOSessionListener sessionListener;
     private Http2StreamListener streamListener;
@@ -184,6 +186,11 @@ public class H2RequesterBootstrap {
      */
     public final H2RequesterBootstrap setTlsStrategy(final TlsStrategy tlsStrategy) {
         this.tlsStrategy = tlsStrategy;
+        return this;
+    }
+
+    public final H2RequesterBootstrap setHandshakeTimeout(final Timeout handshakeTimeout) {
+        this.handshakeTimeout = handshakeTimeout;
         return this;
     }
 
@@ -304,7 +311,8 @@ public class H2RequesterBootstrap {
                 http1StreamHandlerFactory,
                 http2StreamHandlerFactory,
                 versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE,
-                tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy());
+                tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy(),
+                handshakeTimeout);
         return new Http2AsyncRequester(
                 versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE,
                 ioReactorConfig,

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
@@ -71,6 +71,7 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * HTTP/2 capable {@link HttpAsyncServer} bootstrap.
@@ -90,6 +91,7 @@ public class H2ServerBootstrap {
     private H2Config h2Config;
     private H1Config h1Config;
     private TlsStrategy tlsStrategy;
+    private Timeout handshakeTimeout;
     private Decorator<IOSession> ioSessionDecorator;
     private IOSessionListener sessionListener;
     private Http2StreamListener http2StreamListener;
@@ -167,6 +169,11 @@ public class H2ServerBootstrap {
      */
     public final H2ServerBootstrap setTlsStrategy(final TlsStrategy tlsStrategy) {
         this.tlsStrategy = tlsStrategy;
+        return this;
+    }
+
+    public final H2ServerBootstrap setHandshakeTimeout(final Timeout handshakeTimeout) {
+        this.handshakeTimeout = handshakeTimeout;
         return this;
     }
 
@@ -414,7 +421,8 @@ public class H2ServerBootstrap {
                 http1StreamHandlerFactory,
                 http2StreamHandlerFactory,
                 versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE,
-                tlsStrategy != null ? tlsStrategy : new H2ServerTlsStrategy(443, 8443));
+                tlsStrategy != null ? tlsStrategy : new H2ServerTlsStrategy(443, 8443),
+                handshakeTimeout);
         return new HttpAsyncServer(ioEventHandlerFactory, ioReactorConfig, ioSessionDecorator, sessionListener);
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequester.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequester.java
@@ -83,6 +83,7 @@ import org.apache.hc.core5.util.Timeout;
 public class Http2MultiplexingRequester extends AsyncRequester{
 
     private final H2ConnPool connPool;
+    private final Timeout handshakeTimeout;
 
     /**
      * Use {@link Http2MultiplexingRequesterBootstrap} to create instances of this class.
@@ -94,10 +95,12 @@ public class Http2MultiplexingRequester extends AsyncRequester{
             final Decorator<IOSession> ioSessionDecorator,
             final IOSessionListener sessionListener,
             final Resolver<HttpHost, InetSocketAddress> addressResolver,
-            final TlsStrategy tlsStrategy) {
+            final TlsStrategy tlsStrategy,
+            final Timeout handshakeTimeout) {
         super(eventHandlerFactory, ioReactorConfig, ioSessionDecorator, sessionListener,
                         ShutdownCommand.GRACEFUL_IMMEDIATE_CALLBACK, DefaultAddressResolver.INSTANCE);
         this.connPool = new H2ConnPool(this, addressResolver, tlsStrategy);
+        this.handshakeTimeout = handshakeTimeout;
     }
 
     public void closeIdle(final TimeValue idleTime) {
@@ -158,7 +161,7 @@ public class Http2MultiplexingRequester extends AsyncRequester{
                         throw new ProtocolException("Request authority not specified");
                     }
                     final HttpHost target = new HttpHost(scheme, authority);
-                    connPool.getSession(target, timeout, new FutureCallback<IOSession>() {
+                    connPool.getSession(target, timeout, handshakeTimeout, new FutureCallback<IOSession>() {
 
                         @Override
                         public void completed(final IOSession ioSession) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequesterBootstrap.java
@@ -52,6 +52,7 @@ import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link Http2MultiplexingRequester} bootstrap.
@@ -67,6 +68,7 @@ public class Http2MultiplexingRequesterBootstrap {
     private CharCodingConfig charCodingConfig;
     private H2Config h2Config;
     private TlsStrategy tlsStrategy;
+    private Timeout handshakeTimeout;
     private boolean strictALPNHandshake;
     private Decorator<IOSession> ioSessionDecorator;
     private IOSessionListener sessionListener;
@@ -120,6 +122,10 @@ public class Http2MultiplexingRequesterBootstrap {
         return this;
     }
 
+    public final Http2MultiplexingRequesterBootstrap setHandshakeTimeout(final Timeout handshakeTimeout) {
+        this.handshakeTimeout = handshakeTimeout;
+        return this;
+    }
 
     public final Http2MultiplexingRequesterBootstrap setStrictALPNHandshake(final boolean strictALPNHandshake) {
         this.strictALPNHandshake = strictALPNHandshake;
@@ -212,7 +218,8 @@ public class Http2MultiplexingRequesterBootstrap {
                 ioSessionDecorator,
                 sessionListener,
                 DefaultAddressResolver.INSTANCE,
-                tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy());
+                tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy(),
+                handshakeTimeout);
     }
 
 }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -98,6 +98,7 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
     protected Future<IOSession> connectSession(
             final HttpHost namedEndpoint,
             final Timeout requestTimeout,
+            final Timeout handshakeTimeout,
             final FutureCallback<IOSession> callback) {
         final InetSocketAddress remoteAddress = addressResolver.resolve(namedEndpoint);
         return connectionInitiator.connect(namedEndpoint, remoteAddress, null, requestTimeout, null, new FutureCallback<IOSession>() {
@@ -112,7 +113,8 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
                             namedEndpoint,
                             ioSession.getLocalAddress(),
                             ioSession.getRemoteAddress(),
-                            null);
+                            null,
+                            handshakeTimeout);
                     ioSession.setSocketTimeout(requestTimeout);
                 }
                 callback.completed(ioSession);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptClientTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptClientTlsStrategy.java
@@ -39,6 +39,7 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Basic client-side implementation of {@link TlsStrategy} that upgrades to TLS for all endpoints
@@ -87,7 +88,8 @@ public class ConscryptClientTlsStrategy implements TlsStrategy {
             final HttpHost host,
             final SocketAddress localAddress,
             final SocketAddress remoteAddress,
-            final Object attachment) {
+            final Object attachment,
+            final Timeout handshakeTimeout) {
         final String scheme = host != null ? host.getSchemeName() : null;
         if (URIScheme.HTTPS.same(scheme)) {
             tlsSession.startTls(
@@ -95,7 +97,8 @@ public class ConscryptClientTlsStrategy implements TlsStrategy {
                     host,
                     sslBufferMode,
                     ConscryptSupport.initialize(attachment, initializer),
-                    ConscryptSupport.verify(verifier));
+                    ConscryptSupport.verify(verifier),
+                    handshakeTimeout);
             return true;
         }
         return false;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptServerTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptServerTlsStrategy.java
@@ -40,6 +40,7 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Basic side-side implementation of {@link TlsStrategy} that upgrades to TLS for endpoints
@@ -97,14 +98,16 @@ public class ConscryptServerTlsStrategy implements TlsStrategy {
             final HttpHost host,
             final SocketAddress localAddress,
             final SocketAddress remoteAddress,
-            final Object attachment) {
+            final Object attachment,
+            final Timeout handshakeTimeout) {
         if (securePortStrategy != null && securePortStrategy.isSecure(localAddress)) {
             tlsSession.startTls(
                     sslContext,
                     host,
                     sslBufferMode,
                     ConscryptSupport.initialize(attachment, initializer),
-                    ConscryptSupport.verify(verifier));
+                    ConscryptSupport.verify(verifier),
+                    handshakeTimeout);
             return true;
         }
         return false;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ClientTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ClientTlsStrategy.java
@@ -40,6 +40,7 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Basic client-side implementation of {@link TlsStrategy} that upgrades to TLS for all endpoints
@@ -92,7 +93,8 @@ public class H2ClientTlsStrategy implements TlsStrategy {
             final HttpHost host,
             final SocketAddress localAddress,
             final SocketAddress remoteAddress,
-            final Object attachment) {
+            final Object attachment,
+            final Timeout handshakeTimeout) {
         final String scheme = host != null ? host.getSchemeName() : null;
         if (URIScheme.HTTPS.same(scheme)) {
             tlsSession.startTls(
@@ -100,7 +102,8 @@ public class H2ClientTlsStrategy implements TlsStrategy {
                     host,
                     sslBufferMode,
                     H2TlsSupport.enforceRequirements(attachment, initializer),
-                    verifier);
+                    verifier,
+                    handshakeTimeout);
             return true;
         }
         return false;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ServerTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ServerTlsStrategy.java
@@ -41,6 +41,7 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Basic side-side implementation of {@link TlsStrategy} that upgrades to TLS for endpoints
@@ -98,14 +99,16 @@ public class H2ServerTlsStrategy implements TlsStrategy {
             final HttpHost host,
             final SocketAddress localAddress,
             final SocketAddress remoteAddress,
-            final Object attachment) {
+            final Object attachment,
+            final Timeout handshakeTimeout) {
         if (securePortStrategy != null && securePortStrategy.isSecure(localAddress)) {
             tlsSession.startTls(
                     sslContext,
                     host,
                     sslBufferMode,
                     H2TlsSupport.enforceRequirements(attachment, initializer),
-                    verifier);
+                    verifier,
+                    handshakeTimeout);
             return true;
         }
         return false;

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientHttp1EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientHttp1EventHandlerFactory.java
@@ -103,7 +103,7 @@ class InternalClientHttp1EventHandlerFactory implements IOEventHandlerFactory {
     @Override
     public IOEventHandler createHandler(final ProtocolIOSession ioSession, final Object attachment) {
         if (sslContext != null) {
-            ioSession.startTls(sslContext, null, null ,null, null);
+            ioSession.startTls(sslContext, null, null ,null, null, null);
         }
         final ClientHttp1StreamDuplexer streamDuplexer = createClientHttp1StreamDuplexer(
                 ioSession,

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientHttp2EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientHttp2EventHandlerFactory.java
@@ -76,7 +76,7 @@ class InternalClientHttp2EventHandlerFactory implements IOEventHandlerFactory {
     @Override
     public IOEventHandler createHandler(final ProtocolIOSession ioSession, final Object attachment) {
         if (sslContext != null) {
-            ioSession.startTls(sslContext, null, null ,null, null);
+            ioSession.startTls(sslContext, null, null ,null, null, null);
         }
         final ClientHttp1StreamDuplexerFactory http1StreamHandlerFactory = new ClientHttp1StreamDuplexerFactory(
                 httpProcessor != null ? httpProcessor : HttpProcessors.client(),

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp1EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp1EventHandlerFactory.java
@@ -111,7 +111,7 @@ class InternalServerHttp1EventHandlerFactory implements IOEventHandlerFactory {
     @Override
     public IOEventHandler createHandler(final ProtocolIOSession ioSession, final Object attachment) {
         if (sslContext != null) {
-            ioSession.startTls(sslContext, null, null ,null, null);
+            ioSession.startTls(sslContext, null, null ,null, null, null);
         }
         final ServerHttp1StreamDuplexer streamDuplexer = createServerHttp1StreamDuplexer(
                 ioSession,

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp2EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp2EventHandlerFactory.java
@@ -76,7 +76,7 @@ class InternalServerHttp2EventHandlerFactory implements IOEventHandlerFactory {
     @Override
     public IOEventHandler createHandler(final ProtocolIOSession ioSession, final Object attachment) {
         if (sslContext != null) {
-            ioSession.startTls(sslContext, null, null ,null, null);
+            ioSession.startTls(sslContext, null, null ,null, null, null);
         }
         final ServerHttp1StreamDuplexerFactory http1StreamHandlerFactory = new ServerHttp1StreamDuplexerFactory(
                 httpProcessor != null ? httpProcessor : HttpProcessors.server(),

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncRequesterBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncRequesterBootstrap.java
@@ -69,6 +69,7 @@ public class AsyncRequesterBootstrap {
     private PoolReusePolicy poolReusePolicy;
     private PoolConcurrencyPolicy poolConcurrencyPolicy;
     private TlsStrategy tlsStrategy;
+    private Timeout handshakeTimeout;
     private Decorator<IOSession> ioSessionDecorator;
     private IOSessionListener sessionListener;
     private Http1StreamListener streamListener;
@@ -161,6 +162,11 @@ public class AsyncRequesterBootstrap {
         return this;
     }
 
+    public final AsyncRequesterBootstrap setTlsHandshakeTimeout(final Timeout handshakeTimeout) {
+        this.handshakeTimeout = handshakeTimeout;
+        return this;
+    }
+
     /**
      * Assigns {@link IOSession} {@link Decorator} instance.
      */
@@ -223,7 +229,8 @@ public class AsyncRequesterBootstrap {
                 streamListener);
         final IOEventHandlerFactory ioEventHandlerFactory = new ClientHttp1IOEventHandlerFactory(
                 streamDuplexerFactory,
-                tlsStrategy != null ? tlsStrategy : new BasicClientTlsStrategy());
+                tlsStrategy != null ? tlsStrategy : new BasicClientTlsStrategy(),
+                handshakeTimeout);
         return new HttpAsyncRequester(
                 ioReactorConfig,
                 ioEventHandlerFactory,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
@@ -64,6 +64,7 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link HttpAsyncServer} bootstrap.
@@ -82,6 +83,7 @@ public class AsyncServerBootstrap {
     private HttpProcessor httpProcessor;
     private ConnectionReuseStrategy connStrategy;
     private TlsStrategy tlsStrategy;
+    private Timeout handshakeTimeout;
     private Decorator<IOSession> ioSessionDecorator;
     private IOSessionListener sessionListener;
     private Http1StreamListener streamListener;
@@ -148,6 +150,14 @@ public class AsyncServerBootstrap {
      */
     public final AsyncServerBootstrap setTlsStrategy(final TlsStrategy tlsStrategy) {
         this.tlsStrategy = tlsStrategy;
+        return this;
+    }
+
+    /**
+     * Assigns TLS handshake {@link Timeout}.
+     */
+    public final AsyncServerBootstrap setTlsHandshakeTimeout(final Timeout handshakeTimeout) {
+        this.handshakeTimeout = handshakeTimeout;
         return this;
     }
 
@@ -381,7 +391,8 @@ public class AsyncServerBootstrap {
                 streamListener);
         final IOEventHandlerFactory ioEventHandlerFactory = new ServerHttp1IOEventHandlerFactory(
                 streamHandlerFactory,
-                tlsStrategy);
+                tlsStrategy,
+                handshakeTimeout);
         return new HttpAsyncServer(ioEventHandlerFactory, ioReactorConfig, ioSessionDecorator, sessionListener);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1IOEventHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1IOEventHandlerFactory.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link ClientHttp1IOEventHandler} factory.
@@ -47,12 +48,15 @@ public class ClientHttp1IOEventHandlerFactory implements IOEventHandlerFactory {
 
     private final ClientHttp1StreamDuplexerFactory streamDuplexerFactory;
     private final TlsStrategy tlsStrategy;
+    private final Timeout handshakeTimeout;
 
     public ClientHttp1IOEventHandlerFactory(
             final ClientHttp1StreamDuplexerFactory streamDuplexerFactory,
-            final TlsStrategy tlsStrategy) {
+            final TlsStrategy tlsStrategy,
+            final Timeout handshakeTimeout) {
         this.streamDuplexerFactory = Args.notNull(streamDuplexerFactory, "Stream duplexer factory");
         this.tlsStrategy = tlsStrategy;
+        this.handshakeTimeout = handshakeTimeout;
     }
 
     @Override
@@ -65,7 +69,8 @@ public class ClientHttp1IOEventHandlerFactory implements IOEventHandlerFactory {
                         host,
                         ioSession.getLocalAddress(),
                         ioSession.getRemoteAddress(),
-                        attachment);
+                        attachment,
+                        handshakeTimeout);
             }
         }
         return new ClientHttp1IOEventHandler(streamDuplexerFactory.create(ioSession));

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1IOEventHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1IOEventHandlerFactory.java
@@ -35,6 +35,7 @@ import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link ServerHttp1IOEventHandler} factory.
@@ -46,12 +47,15 @@ public class ServerHttp1IOEventHandlerFactory implements IOEventHandlerFactory {
 
     private final ServerHttp1StreamDuplexerFactory streamDuplexerFactory;
     private final TlsStrategy tlsStrategy;
+    private final Timeout handshakeTimeout;
 
     public ServerHttp1IOEventHandlerFactory(
             final ServerHttp1StreamDuplexerFactory streamDuplexerFactory,
-            final TlsStrategy tlsStrategy) {
+            final TlsStrategy tlsStrategy,
+            final Timeout handshakeTimeout) {
         this.streamDuplexerFactory = Args.notNull(streamDuplexerFactory, "Stream duplexer factory");
         this.tlsStrategy = tlsStrategy;
+        this.handshakeTimeout = handshakeTimeout;
     }
 
     @Override
@@ -63,7 +67,8 @@ public class ServerHttp1IOEventHandlerFactory implements IOEventHandlerFactory {
                     null,
                     ioSession.getLocalAddress(),
                     ioSession.getRemoteAddress(),
-                    attachment);
+                    attachment,
+                    handshakeTimeout);
         } else {
             tlsSecured = false;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicClientTlsStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicClientTlsStrategy.java
@@ -39,6 +39,7 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Basic client-side implementation of {@link TlsStrategy} that upgrades to TLS for all endpoints
@@ -91,10 +92,11 @@ public class BasicClientTlsStrategy implements TlsStrategy {
             final HttpHost host,
             final SocketAddress localAddress,
             final SocketAddress remoteAddress,
-            final Object attachment) {
+            final Object attachment,
+            final Timeout handshakeTimeout) {
         final String scheme = host != null ? host.getSchemeName() : null;
         if (URIScheme.HTTPS.same(scheme)) {
-            tlsSession.startTls(sslContext, host, sslBufferMode, initializer, verifier);
+            tlsSession.startTls(sslContext, host, sslBufferMode, initializer, verifier, handshakeTimeout);
             return true;
         }
         return false;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicServerTlsStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicServerTlsStrategy.java
@@ -38,6 +38,7 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Basic side-side implementation of {@link TlsStrategy} that upgrades to TLS for endpoints
@@ -95,9 +96,10 @@ public class BasicServerTlsStrategy implements TlsStrategy {
             final HttpHost host,
             final SocketAddress localAddress,
             final SocketAddress remoteAddress,
-            final Object attachment) {
+            final Object attachment,
+            final Timeout handshakeTimeout) {
         if (securePortStrategy != null && securePortStrategy.isSecure(localAddress)) {
-            tlsSession.startTls(sslContext, host, sslBufferMode, initializer, verifier);
+            tlsSession.startTls(sslContext, host, sslBufferMode, initializer, verifier, handshakeTimeout);
             return true;
         }
         return false;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/TlsStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/TlsStrategy.java
@@ -31,6 +31,7 @@ import java.net.SocketAddress;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * TLS protocol upgrade strategy for non-blocking {@link TransportSecurityLayer} sessions.
@@ -40,13 +41,14 @@ import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 public interface TlsStrategy {
 
     /**
-     * Secures current session layer with LTS security.
+     * Secures current session layer with TLS security.
      *
      * @param sessionLayer the session layer
      * @param host the name of the opposite endpoint when givem or {@code null} otherwise.
      * @param localAddress the address of the local endpoint.
      * @param remoteAddress the address of the remote endpoint.
      * @param attachment arbitrary object passes to the TLS session initialization code.
+     * @param handshakeTimeout the timeout to use while performing the TLS handshake; may be {@code null}.
      * @return {@code true} if the session has been upgraded, {@code false} otherwise.
      */
     boolean upgrade(
@@ -54,6 +56,7 @@ public interface TlsStrategy {
             HttpHost host,
             SocketAddress localAddress,
             SocketAddress remoteAddress,
-            Object attachment);
+            Object attachment,
+            Timeout handshakeTimeout);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalDataChannel.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalDataChannel.java
@@ -218,7 +218,8 @@ final class InternalDataChannel extends InternalChannel implements ProtocolIOSes
             final NamedEndpoint endpoint,
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
-            final SSLSessionVerifier verifier) {
+            final SSLSessionVerifier verifier,
+            final Timeout handshakeTimeout) {
         if (!tlsSessionRef.compareAndSet(null, new SSLIOSession(
                 endpoint != null ? endpoint : initialEndpoint,
                 ioSession,
@@ -248,7 +249,7 @@ final class InternalDataChannel extends InternalChannel implements ProtocolIOSes
                     }
 
                 },
-                null))) {
+                handshakeTimeout))) {
             throw new IllegalStateException("TLS already activated");
         }
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/TransportSecurityLayer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/TransportSecurityLayer.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.reactor.ssl;
 import javax.net.ssl.SSLContext;
 
 import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.util.Timeout;
 
 /**
  * Represents a TLS capable session layer.
@@ -48,13 +49,15 @@ public interface TransportSecurityLayer {
      * @param sslBufferMode SSL buffer management mode.
      * @param initializer SSL session initialization callback.
      * @param verifier SSL session verification callback.
+     * @param handshakeTimeout the timeout to use while performing the TLS handshake; may be {@code null}.
      */
     void startTls(
             SSLContext sslContext,
             NamedEndpoint endpoint,
             SSLBufferMode sslBufferMode,
             SSLSessionInitializer initializer,
-            SSLSessionVerifier verifier) throws UnsupportedOperationException;
+            SSLSessionVerifier verifier,
+            Timeout handshakeTimeout) throws UnsupportedOperationException;
 
     /**
      * Returns details of a fully established TLS session.

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
@@ -76,6 +76,7 @@ public class TestAbstractIOSessionPool {
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.<Timeout>any(),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any())).thenReturn(connectFuture);
 
         Mockito.doAnswer(new Answer() {
@@ -89,7 +90,7 @@ public class TestAbstractIOSessionPool {
 
         }).when(impl).validateSession(ArgumentMatchers.<IOSession>any(), ArgumentMatchers.<Callback<Boolean>>any());
 
-        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
         Assert.assertThat(future1, CoreMatchers.notNullValue());
         Assert.assertThat(future1.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
@@ -97,15 +98,17 @@ public class TestAbstractIOSessionPool {
         Mockito.verify(impl).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
 
-        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
         Assert.assertThat(future2, CoreMatchers.notNullValue());
         Assert.assertThat(future2.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.argThat(new ArgumentMatcher<FutureCallback<IOSession>>() {
 
@@ -125,10 +128,11 @@ public class TestAbstractIOSessionPool {
 
         Mockito.verify(impl, Mockito.times(2)).validateSession(ArgumentMatchers.<IOSession>any(), ArgumentMatchers.<Callback<Boolean>>any());
 
-        final Future<IOSession> future3 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        final Future<IOSession> future3 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
 
@@ -144,9 +148,10 @@ public class TestAbstractIOSessionPool {
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.<Timeout>any(),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any())).thenReturn(connectFuture);
 
-        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
         Assert.assertThat(future1, CoreMatchers.notNullValue());
         Assert.assertThat(future1.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
@@ -154,15 +159,17 @@ public class TestAbstractIOSessionPool {
         Mockito.verify(impl).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
 
-        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
         Assert.assertThat(future2, CoreMatchers.notNullValue());
         Assert.assertThat(future2.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.argThat(new ArgumentMatcher<FutureCallback<IOSession>>() {
 
@@ -262,11 +269,12 @@ public class TestAbstractIOSessionPool {
 
         }).when(impl).validateSession(ArgumentMatchers.<IOSession>any(), ArgumentMatchers.<Callback<Boolean>>any());
 
-        impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
     }
 
@@ -278,11 +286,12 @@ public class TestAbstractIOSessionPool {
 
         Mockito.when(ioSession1.isClosed()).thenReturn(true);
 
-        impl.getSession("somehost", Timeout.ofSeconds(123L), null);
+        impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
 
         Mockito.verify(impl).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
+                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
     }
 


### PR DESCRIPTION
This change adds low-level support for TLS handshake timeouts in the
class that actually performs the handshake. The contractual
`socketTimeout`, if set, will only be applied to the underlying
IOSession after the handshake is complete.