### PR TITLE
Document TCP_NODELAY default as "true"

### DIFF
--- a/httpcore/src/main/java/org/apache/http/config/SocketConfig.java
+++ b/httpcore/src/main/java/org/apache/http/config/SocketConfig.java
@@ -129,7 +129,7 @@ public class SocketConfig implements Cloneable {
      * Determines the default value of the {@link java.net.SocketOptions#TCP_NODELAY} parameter
      * for newly created sockets.
      * <p>
-     * Default: {@code false}
+     * Default: {@code true}
      * </p>
      *
      * @return the default value of the {@link java.net.SocketOptions#TCP_NODELAY} parameter.


### PR DESCRIPTION
This reflects current actual behavior.

Context: Thread on hc-dev mailing list
  Message-ID: <3379cf792422e6b1c9df42d78d40929c0ed2603f.camel@osimis.io>
  Subject: Documented default value for TCP_NODELAY
  Date: Thu, 17 Jan 2019 21:46:35 +0100
  https://apache-hc-dev.markmail.org/message/37ldla5s6hvofztd