### PR TITLE
Merge connect and handshake timeouts in AbstractIOSessionPool

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequester.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequester.java
@@ -83,7 +83,6 @@ import org.apache.hc.core5.util.Timeout;
 public class Http2MultiplexingRequester extends AsyncRequester{
 
     private final H2ConnPool connPool;
-    private final Timeout handshakeTimeout;
 
     /**
      * Use {@link Http2MultiplexingRequesterBootstrap} to create instances of this class.
@@ -95,12 +94,10 @@ public class Http2MultiplexingRequester extends AsyncRequester{
             final Decorator<IOSession> ioSessionDecorator,
             final IOSessionListener sessionListener,
             final Resolver<HttpHost, InetSocketAddress> addressResolver,
-            final TlsStrategy tlsStrategy,
-            final Timeout handshakeTimeout) {
+            final TlsStrategy tlsStrategy) {
         super(eventHandlerFactory, ioReactorConfig, ioSessionDecorator, sessionListener,
                         ShutdownCommand.GRACEFUL_IMMEDIATE_CALLBACK, DefaultAddressResolver.INSTANCE);
         this.connPool = new H2ConnPool(this, addressResolver, tlsStrategy);
-        this.handshakeTimeout = handshakeTimeout;
     }
 
     public void closeIdle(final TimeValue idleTime) {
@@ -161,7 +158,7 @@ public class Http2MultiplexingRequester extends AsyncRequester{
                         throw new ProtocolException("Request authority not specified");
                     }
                     final HttpHost target = new HttpHost(scheme, authority);
-                    connPool.getSession(target, timeout, handshakeTimeout, new FutureCallback<IOSession>() {
+                    connPool.getSession(target, timeout, new FutureCallback<IOSession>() {
 
                         @Override
                         public void completed(final IOSession ioSession) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequesterBootstrap.java
@@ -52,7 +52,6 @@ import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.Timeout;
 
 /**
  * {@link Http2MultiplexingRequester} bootstrap.
@@ -68,7 +67,6 @@ public class Http2MultiplexingRequesterBootstrap {
     private CharCodingConfig charCodingConfig;
     private H2Config h2Config;
     private TlsStrategy tlsStrategy;
-    private Timeout handshakeTimeout;
     private boolean strictALPNHandshake;
     private Decorator<IOSession> ioSessionDecorator;
     private IOSessionListener sessionListener;
@@ -119,11 +117,6 @@ public class Http2MultiplexingRequesterBootstrap {
      */
     public final Http2MultiplexingRequesterBootstrap setTlsStrategy(final TlsStrategy tlsStrategy) {
         this.tlsStrategy = tlsStrategy;
-        return this;
-    }
-
-    public final Http2MultiplexingRequesterBootstrap setHandshakeTimeout(final Timeout handshakeTimeout) {
-        this.handshakeTimeout = handshakeTimeout;
         return this;
     }
 
@@ -218,8 +211,7 @@ public class Http2MultiplexingRequesterBootstrap {
                 ioSessionDecorator,
                 sessionListener,
                 DefaultAddressResolver.INSTANCE,
-                tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy(),
-                handshakeTimeout);
+                tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy());
     }
 
 }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -97,11 +97,10 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
     @Override
     protected Future<IOSession> connectSession(
             final HttpHost namedEndpoint,
-            final Timeout requestTimeout,
-            final Timeout handshakeTimeout,
+            final Timeout connectTimeout,
             final FutureCallback<IOSession> callback) {
         final InetSocketAddress remoteAddress = addressResolver.resolve(namedEndpoint);
-        return connectionInitiator.connect(namedEndpoint, remoteAddress, null, requestTimeout, null, new FutureCallback<IOSession>() {
+        return connectionInitiator.connect(namedEndpoint, remoteAddress, null, connectTimeout, null, new FutureCallback<IOSession>() {
 
             @Override
             public void completed(final IOSession ioSession) {
@@ -114,8 +113,8 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
                             ioSession.getLocalAddress(),
                             ioSession.getRemoteAddress(),
                             null,
-                            handshakeTimeout);
-                    ioSession.setSocketTimeout(requestTimeout);
+                            connectTimeout);
+                    ioSession.setSocketTimeout(connectTimeout);
                 }
                 callback.completed(ioSession);
             }

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
@@ -76,7 +76,6 @@ public class TestAbstractIOSessionPool {
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.<Timeout>any(),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any())).thenReturn(connectFuture);
 
         Mockito.doAnswer(new Answer() {
@@ -90,7 +89,7 @@ public class TestAbstractIOSessionPool {
 
         }).when(impl).validateSession(ArgumentMatchers.<IOSession>any(), ArgumentMatchers.<Callback<Boolean>>any());
 
-        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
         Assert.assertThat(future1, CoreMatchers.notNullValue());
         Assert.assertThat(future1.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
@@ -98,17 +97,15 @@ public class TestAbstractIOSessionPool {
         Mockito.verify(impl).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
 
-        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
         Assert.assertThat(future2, CoreMatchers.notNullValue());
         Assert.assertThat(future2.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.argThat(new ArgumentMatcher<FutureCallback<IOSession>>() {
 
@@ -128,11 +125,10 @@ public class TestAbstractIOSessionPool {
 
         Mockito.verify(impl, Mockito.times(2)).validateSession(ArgumentMatchers.<IOSession>any(), ArgumentMatchers.<Callback<Boolean>>any());
 
-        final Future<IOSession> future3 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        final Future<IOSession> future3 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
 
@@ -148,10 +144,9 @@ public class TestAbstractIOSessionPool {
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.<Timeout>any(),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any())).thenReturn(connectFuture);
 
-        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        final Future<IOSession> future1 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
         Assert.assertThat(future1, CoreMatchers.notNullValue());
         Assert.assertThat(future1.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
@@ -159,17 +154,15 @@ public class TestAbstractIOSessionPool {
         Mockito.verify(impl).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
 
-        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        final Future<IOSession> future2 = impl.getSession("somehost", Timeout.ofSeconds(123L), null);
         Assert.assertThat(future2, CoreMatchers.notNullValue());
         Assert.assertThat(future2.isDone(), CoreMatchers.equalTo(false));
         Assert.assertThat(impl.getRoutes(), CoreMatchers.hasItem("somehost"));
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.argThat(new ArgumentMatcher<FutureCallback<IOSession>>() {
 
@@ -269,12 +262,11 @@ public class TestAbstractIOSessionPool {
 
         }).when(impl).validateSession(ArgumentMatchers.<IOSession>any(), ArgumentMatchers.<Callback<Boolean>>any());
 
-        impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        impl.getSession("somehost", Timeout.ofSeconds(123L), null);
 
         Mockito.verify(impl, Mockito.times(1)).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
     }
 
@@ -286,12 +278,11 @@ public class TestAbstractIOSessionPool {
 
         Mockito.when(ioSession1.isClosed()).thenReturn(true);
 
-        impl.getSession("somehost", Timeout.ofSeconds(123L), null, null);
+        impl.getSession("somehost", Timeout.ofSeconds(123L), null);
 
         Mockito.verify(impl).connectSession(
                 ArgumentMatchers.eq("somehost"),
                 ArgumentMatchers.eq(Timeout.ofSeconds(123L)),
-                ArgumentMatchers.<Timeout>any(),
                 ArgumentMatchers.<FutureCallback<IOSession>>any());
     }
 


### PR DESCRIPTION
This change essentially reverts a portion of 40cae2275 that appears to
have been unnecessary. Since the `requestTimeout` parameter is always a
connection timeout (at least in the client-side code), we don't need to
dedicate an additional parameter to the TLS handshake timeout value: we
simply use the `requestTimeout` (which has been renamed `connectTimeout`
for clarity).