### PR TITLE
HTTPCORE-573 FileContentDecoder don't always enforce the maximum number of bytes to transfer

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/IdentityDecoder.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/IdentityDecoder.java
@@ -93,8 +93,9 @@ public class IdentityDecoder extends AbstractContentDecoder
 
         long bytesRead;
         if (this.buffer.hasData()) {
+            final int maxLen = this.buffer.length();
             dst.position(position);
-            bytesRead = this.buffer.read(dst);
+            bytesRead = this.buffer.read(dst, count < maxLen ? (int)count : maxLen);
         } else {
             if (this.channel.isOpen()) {
                 if (position > dst.size()) {

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/LengthDelimitedDecoder.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/LengthDelimitedDecoder.java
@@ -117,7 +117,7 @@ public class LengthDelimitedDecoder extends AbstractContentDecoder
         if (this.buffer.hasData()) {
             final int maxLen = Math.min(chunk, this.buffer.length());
             dst.position(position);
-            bytesRead = this.buffer.read(dst, maxLen);
+            bytesRead = this.buffer.read(dst, count < maxLen ? (int)count : maxLen);
         } else {
             if (this.channel.isOpen()) {
                 if (position > dst.size()) {

--- a/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestIdentityDecoder.java
+++ b/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestIdentityDecoder.java
@@ -257,6 +257,74 @@ public class TestIdentityDecoder {
     }
 
     @Test
+    public void testDecodingFileWithLimit() throws Exception {
+        final ReadableByteChannel channel = new ReadableByteChannelMock(
+                new String[] {"stuff; more stuff; ", "a lot more stuff!"}, Consts.ASCII);
+
+        final SessionInputBuffer inbuf = new SessionInputBufferImpl(1024, 256, Consts.ASCII);
+        final HttpTransportMetricsImpl metrics = new HttpTransportMetricsImpl();
+        final IdentityDecoder decoder = new IdentityDecoder(
+                channel, inbuf, metrics);
+
+        final int i = inbuf.fill(channel);
+        Assert.assertEquals(19, i);
+
+        createTempFile();
+        final RandomAccessFile testfile = new RandomAccessFile(this.tmpfile, "rw");
+        try {
+            final FileChannel fchannel = testfile.getChannel();
+            long pos = 0;
+
+            // transferred from buffer
+            long bytesRead = decoder.transfer(fchannel, pos, 1);
+            Assert.assertEquals(1, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(0, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 2);
+            Assert.assertEquals(2, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(0, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 17);
+            Assert.assertEquals(16, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(0, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            // transferred from channel
+            bytesRead = decoder.transfer(fchannel, pos, 1);
+            Assert.assertEquals(1, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(1, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 2);
+            Assert.assertEquals(2, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(3, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 15);
+            Assert.assertEquals(14, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(17, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 1);
+            Assert.assertEquals(-1, bytesRead);
+            Assert.assertTrue(decoder.isCompleted());
+            Assert.assertEquals(17, metrics.getBytesTransferred());
+        } finally {
+            testfile.close();
+        }
+        Assert.assertEquals("stuff; more stuff; a lot more stuff!",
+                CodecTestUtils.readFromFile(this.tmpfile));
+    }
+
+    @Test
     public void testWriteBeyondFileSize() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"a"}, Consts.ASCII);

--- a/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestLengthDelimitedDecoder.java
+++ b/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestLengthDelimitedDecoder.java
@@ -365,6 +365,74 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
+    public void testDecodingFileWithLimit() throws Exception {
+        final ReadableByteChannel channel = new ReadableByteChannelMock(
+                new String[] {"stuff; more stuff; ", "a lot more stuff!!!"}, Consts.ASCII);
+
+        final SessionInputBuffer inbuf = new SessionInputBufferImpl(1024, 256, Consts.ASCII);
+        final HttpTransportMetricsImpl metrics = new HttpTransportMetricsImpl();
+        final LengthDelimitedDecoder decoder = new LengthDelimitedDecoder(
+                channel, inbuf, metrics, 36);
+
+        final int i = inbuf.fill(channel);
+        Assert.assertEquals(19, i);
+
+        createTempFile();
+        final RandomAccessFile testfile = new RandomAccessFile(this.tmpfile, "rw");
+        try {
+            final FileChannel fchannel = testfile.getChannel();
+            long pos = 0;
+
+            // transferred from buffer
+            long bytesRead = decoder.transfer(fchannel, pos, 1);
+            Assert.assertEquals(1, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(0, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 2);
+            Assert.assertEquals(2, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(0, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 17);
+            Assert.assertEquals(16, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(0, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            // transferred from channel
+            bytesRead = decoder.transfer(fchannel, pos, 1);
+            Assert.assertEquals(1, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(1, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 2);
+            Assert.assertEquals(2, bytesRead);
+            Assert.assertFalse(decoder.isCompleted());
+            Assert.assertEquals(3, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 15);
+            Assert.assertEquals(14, bytesRead);
+            Assert.assertTrue(decoder.isCompleted());
+            Assert.assertEquals(17, metrics.getBytesTransferred());
+            pos += bytesRead;
+
+            bytesRead = decoder.transfer(fchannel, pos, 1);
+            Assert.assertEquals(-1, bytesRead);
+            Assert.assertTrue(decoder.isCompleted());
+            Assert.assertEquals(17, metrics.getBytesTransferred());
+        } finally {
+            testfile.close();
+        }
+        Assert.assertEquals("stuff; more stuff; a lot more stuff!",
+                CodecTestUtils.readFromFile(this.tmpfile));
+    }
+
+    @Test
     public void testWriteBeyondFileSize() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"a"}, Consts.ASCII);


### PR DESCRIPTION
Limit the number of bytes read from the internal buffer when
transferring, so that the maximum requested ('count') is respected.