### PR TITLE
HTTPCLIENT-1978: Filter characters before byte conversion (4.4.12 backport)

### DIFF
--- a/httpcore/src/main/java/org/apache/http/util/ByteArrayBuffer.java
+++ b/httpcore/src/main/java/org/apache/http/util/ByteArrayBuffer.java
@@ -135,8 +135,14 @@ public final class ByteArrayBuffer implements Serializable {
         if (newlen > this.buffer.length) {
             expand(newlen);
         }
+
         for (int i1 = off, i2 = oldlen; i2 < newlen; i1++, i2++) {
-            this.buffer[i2] = (byte) b[i1];
+            if ((b[i1] >= 0x20 && b[i1] <= 0x7E) || // Visible ASCII
+                (b[i1] >= 0xA0 && b[i1] <= 0xFF)) { // Visible ISO-8859-1
+                this.buffer[i2] = (byte) b[i1];
+            } else {
+                this.buffer[i2] = '?';
+            }
         }
         this.len = newlen;
     }

--- a/httpcore/src/test/java/org/apache/http/util/TestByteArrayBuffer.java
+++ b/httpcore/src/test/java/org/apache/http/util/TestByteArrayBuffer.java
@@ -312,4 +312,44 @@ public class TestByteArrayBuffer {
         Assert.assertEquals(3, data[2]);
     }
 
+    @Test
+    public void testControlCharFiltering() throws Exception {
+        final char[] chars = new char[256];
+        for (char i = 0; i < 256; i++) {
+            chars[i] = i;
+        }
+
+        final byte[] bytes = asByteArray(chars);
+
+        Assert.assertEquals(
+            "????????????????????????????????"
+                + " !\"#$%&'()*+,-./0123456789:;<=>?"
+                + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+                + "`abcdefghijklmnopqrstuvwxyz"
+                + "{|}~???????????????????????"
+                + "??????????\u00A0¡¢£¤¥¦§¨©ª«¬\u00AD®¯"
+                + "°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ"
+                + "ÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîï"
+                + "ðñòóôõö÷øùúûüýþÿ",
+            new String(bytes, "ISO-8859-1"));
+    }
+
+    @Test
+    public void testUnicodeFiltering() throws Exception {
+        // Various languages
+        Assert.assertEquals("?????", new String(asByteArray("буквы".toCharArray()), "ISO-8859-1"));
+        Assert.assertEquals("????", new String(asByteArray("四字熟語".toCharArray()), "ISO-8859-1"));
+
+        // Unicode snowman
+        Assert.assertEquals("?", new String(asByteArray("☃".toCharArray()), "ISO-8859-1"));
+
+        // Emoji (surrogate pair)
+        Assert.assertEquals("??", new String(asByteArray("\uD83D\uDE00".toCharArray()), "ISO-8859-1"));
+    }
+
+    private static byte[] asByteArray(final char[] chars) {
+        final ByteArrayBuffer byteArrayBuffer = new ByteArrayBuffer(chars.length);
+        byteArrayBuffer.append(chars, 0, chars.length);
+        return byteArrayBuffer.toByteArray();
+    }
 }


### PR DESCRIPTION
This change causes ByteArrayBuffer to filter out all characters that
cannot be correctly converted to ISO-8859-1 by simple downcasting to a
byte. In addition, control characters and most whitespace characters are
filtered out. Filtered characters are replaced with a question mark,
except for surrogate pairs, which are replaced with two question marks.

https://en.wikipedia.org/wiki/ISO/IEC_8859-1
https://en.wikipedia.org/wiki/List_of_Unicode_characters