### PR TITLE
Refactor APIs like failed(Exception) to failed(String, Exception)

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractHttp2IOEventHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractHttp2IOEventHandler.java
@@ -54,7 +54,7 @@ class AbstractHttp2IOEventHandler implements HttpConnectionEventHandler {
         try {
             streamMultiplexer.onConnect(null);
         } catch (final HttpException ex) {
-            streamMultiplexer.onException(ex);
+            streamMultiplexer.onException(null, ex);
         }
     }
 
@@ -63,7 +63,7 @@ class AbstractHttp2IOEventHandler implements HttpConnectionEventHandler {
         try {
             streamMultiplexer.onInput();
         } catch (final HttpException ex) {
-            streamMultiplexer.onException(ex);
+            streamMultiplexer.onException(null, ex);
         }
     }
 
@@ -72,7 +72,7 @@ class AbstractHttp2IOEventHandler implements HttpConnectionEventHandler {
         try {
             streamMultiplexer.onOutput();
         } catch (final HttpException ex) {
-            streamMultiplexer.onException(ex);
+            streamMultiplexer.onException(null, ex);
         }
     }
 
@@ -81,13 +81,13 @@ class AbstractHttp2IOEventHandler implements HttpConnectionEventHandler {
         try {
             streamMultiplexer.onTimeout(timeout);
         } catch (final HttpException ex) {
-            streamMultiplexer.onException(ex);
+            streamMultiplexer.onException(null, ex);
         }
     }
 
     @Override
-    public void exception(final IOSession session, final Exception cause) {
-        streamMultiplexer.onException(cause);
+    public void exception(final IOSession session, final String message, final Exception cause) {
+        streamMultiplexer.onException(message, cause);
     }
 
     @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttp2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttp2StreamHandler.java
@@ -250,11 +250,11 @@ class ClientHttp2StreamHandler implements Http2StreamHandler {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         try {
             if (failed.compareAndSet(false, true)) {
                 if (exchangeHandler != null) {
-                    exchangeHandler.failed(cause);
+                    exchangeHandler.failed(message, cause);
                 }
             }
         } finally {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiator.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiator.java
@@ -98,7 +98,7 @@ public class ClientHttpProtocolNegotiator implements HttpConnectionEventHandler 
             ioSession.upgrade(newHandler);
             newHandler.connected(session);
         } catch (final Exception ex) {
-            newHandler.exception(session, ex);
+            newHandler.exception(session, null, ex);
             session.close(CloseMode.IMMEDIATE);
         }
     }
@@ -110,7 +110,7 @@ public class ClientHttpProtocolNegotiator implements HttpConnectionEventHandler 
             ioSession.upgrade(newHandler);
             newHandler.connected(session);
         } catch (final Exception ex) {
-            newHandler.exception(session, ex);
+            newHandler.exception(session, null, ex);
             session.close(CloseMode.IMMEDIATE);
         }
     }
@@ -167,11 +167,11 @@ public class ClientHttpProtocolNegotiator implements HttpConnectionEventHandler 
 
     @Override
     public void timeout(final IOSession session, final Timeout timeout) {
-        exception(session, SocketTimeoutExceptionFactory.create(timeout));
+        exception(session, null, SocketTimeoutExceptionFactory.create(timeout));
     }
 
     @Override
-    public void exception(final IOSession session, final Exception cause) {
+    public void exception(final IOSession session, final String message, final Exception cause) {
         try {
             for (;;) {
                 final Command command = ioSession.poll();
@@ -179,7 +179,7 @@ public class ClientHttpProtocolNegotiator implements HttpConnectionEventHandler 
                     if (command instanceof RequestExecutionCommand) {
                         final RequestExecutionCommand executionCommand = (RequestExecutionCommand) command;
                         final AsyncClientExchangeHandler exchangeHandler = executionCommand.getExchangeHandler();
-                        exchangeHandler.failed(cause);
+                        exchangeHandler.failed(message, cause);
                         exchangeHandler.releaseResources();
                     } else {
                         command.cancel();
@@ -201,7 +201,7 @@ public class ClientHttpProtocolNegotiator implements HttpConnectionEventHandler 
                 if (command instanceof RequestExecutionCommand) {
                     final RequestExecutionCommand executionCommand = (RequestExecutionCommand) command;
                     final AsyncClientExchangeHandler exchangeHandler = executionCommand.getExchangeHandler();
-                    exchangeHandler.failed(new ConnectionClosedException());
+                    exchangeHandler.failed(null, new ConnectionClosedException());
                     exchangeHandler.releaseResources();
                 } else {
                     command.cancel();

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientPushHttp2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientPushHttp2StreamHandler.java
@@ -177,11 +177,11 @@ class ClientPushHttp2StreamHandler implements Http2StreamHandler {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         try {
             if (failed.compareAndSet(false, true)) {
                 if (exchangeHandler != null) {
-                    exchangeHandler.failed(cause);
+                    exchangeHandler.failed(message, cause);
                 }
             }
         } finally {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/Http2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/Http2StreamHandler.java
@@ -52,6 +52,6 @@ interface Http2StreamHandler extends ResourceHolder {
 
     HandlerFactory<AsyncPushConsumer> getPushHandlerFactory();
 
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttp2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttp2StreamHandler.java
@@ -292,11 +292,11 @@ public class ServerHttp2StreamHandler implements Http2StreamHandler {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         try {
             if (failed.compareAndSet(false, true)) {
                 if (exchangeHandler != null) {
-                    exchangeHandler.failed(cause);
+                    exchangeHandler.failed(message, cause);
                 }
             }
         } finally {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiator.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiator.java
@@ -111,7 +111,7 @@ public class ServerHttpProtocolNegotiator implements HttpConnectionEventHandler 
                     break;
             }
         } catch (final Exception ex) {
-            exception(session, ex);
+            exception(session, null, ex);
         }
     }
 
@@ -158,7 +158,7 @@ public class ServerHttpProtocolNegotiator implements HttpConnectionEventHandler 
                 }
             }
         } catch (final Exception ex) {
-            exception(session, ex);
+            exception(session, null, ex);
         }
     }
 
@@ -168,11 +168,11 @@ public class ServerHttpProtocolNegotiator implements HttpConnectionEventHandler 
 
     @Override
     public void timeout(final IOSession session, final Timeout timeout) {
-        exception(session, SocketTimeoutExceptionFactory.create(timeout));
+        exception(session, null, SocketTimeoutExceptionFactory.create(timeout));
     }
 
     @Override
-    public void exception(final IOSession session, final Exception cause) {
+    public void exception(final IOSession session, final String message, final Exception cause) {
         session.close(CloseMode.IMMEDIATE);
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerPushHttp2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerPushHttp2StreamHandler.java
@@ -228,10 +228,10 @@ class ServerPushHttp2StreamHandler implements Http2StreamHandler {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         try {
             if (failed.compareAndSet(false, true)) {
-                pushProducer.failed(cause);
+                pushProducer.failed(message, cause);
             }
         } finally {
             releaseResources();

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequester.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/Http2MultiplexingRequester.java
@@ -216,16 +216,16 @@ public class Http2MultiplexingRequester extends AsyncRequester{
                                 }
 
                                 @Override
-                                public void failed(final Exception cause) {
-                                    exchangeHandler.failed(cause);
+                                public void failed(final String message, final Exception cause) {
+                                    exchangeHandler.failed(message, cause);
                                 }
 
                             }, pushHandlerFactory, cancellableDependency, context), Command.Priority.NORMAL);
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
-                            exchangeHandler.failed(ex);
+                        public void failed(final String message, final Exception ex) {
+                            exchangeHandler.failed(message, ex);
                         }
 
                         @Override
@@ -239,7 +239,7 @@ public class Http2MultiplexingRequester extends AsyncRequester{
 
             }, context);
         } catch (final IOException | HttpException ex) {
-            exchangeHandler.failed(ex);
+            exchangeHandler.failed(null, ex);
         }
     }
 
@@ -262,8 +262,8 @@ public class Http2MultiplexingRequester extends AsyncRequester{
             }
 
             @Override
-            public void failed(final Exception ex) {
-                future.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                future.failed(message, ex);
             }
 
             @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/AsyncPingHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/AsyncPingHandler.java
@@ -54,10 +54,10 @@ public interface AsyncPingHandler {
 
     /**
      * Triggered to signal a failure in data processing.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
     /**
      * Triggered to cancel the message exchange.

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -120,8 +120,8 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
             }
 
             @Override
-            public void failed(final Exception ex) {
-                callback.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                callback.failed(message, ex);
             }
 
             @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/support/BasicPingHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/support/BasicPingHandler.java
@@ -67,7 +67,7 @@ public class BasicPingHandler implements AsyncPingHandler {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         callback.execute(Boolean.FALSE);
     }
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2ConscriptRequestExecutionExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2ConscriptRequestExecutionExample.java
@@ -139,7 +139,7 @@ public class Http2ConscriptRequestExecutionExample {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             clientEndpoint.releaseAndDiscard();
                             System.out.println(requestUri + "->" + ex);
                             latch.countDown();

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2FullDuplexClientExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2FullDuplexClientExample.java
@@ -145,7 +145,7 @@ public class Http2FullDuplexClientExample {
             }
 
             @Override
-            public void failed(final Exception cause) {
+            public void failed(final String message, final Exception cause) {
                 System.out.println(requestUri + "->" + cause);
             }
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2FullDuplexServerExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2FullDuplexServerExample.java
@@ -210,7 +210,7 @@ public class Http2FullDuplexServerExample {
                             }
 
                             @Override
-                            public void failed(final Exception cause) {
+                            public void failed(final String message, final Exception cause) {
                                 if (!(cause instanceof SocketException)) {
                                     cause.printStackTrace(System.out);
                                 }

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2MultiStreamExecutionExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2MultiStreamExecutionExample.java
@@ -138,7 +138,7 @@ public class Http2MultiStreamExecutionExample {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             latch.countDown();
                             System.out.println(requestUri + "->" + ex);
                         }

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2RequestExecutionExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2RequestExecutionExample.java
@@ -130,7 +130,7 @@ public class Http2RequestExecutionExample {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             clientEndpoint.releaseAndDiscard();
                             System.out.println(requestUri + "->" + ex);
                             latch.countDown();

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2TlsAlpnRequestExecutionExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/Http2TlsAlpnRequestExecutionExample.java
@@ -150,7 +150,7 @@ public class Http2TlsAlpnRequestExecutionExample {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             clientEndpoint.releaseAndDiscard();
                             System.out.println(requestUri + "->" + ex);
                             latch.countDown();

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveEntityProducer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveEntityProducer.java
@@ -93,7 +93,7 @@ public final class ReactiveEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         releaseResources();
     }
 

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
@@ -133,11 +133,11 @@ public final class ReactiveResponseConsumer implements AsyncResponseConsumer<Voi
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         reactiveDataConsumer.failed(cause);
-        responseFuture.failed(cause);
+        responseFuture.failed(message, cause);
         if (responseCompletion != null) {
-            responseCompletion.failed(cause);
+            responseCompletion.failed(message, cause);
         }
     }
 

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveServerExchangeHandler.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveServerExchangeHandler.java
@@ -88,7 +88,7 @@ public final class ReactiveServerExchangeHandler implements AsyncServerExchangeH
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         requestConsumer.failed(cause);
         final ReactiveDataProducer p = responseProducer.get();
         if (p != null) {

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/BenchmarkWorker.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/BenchmarkWorker.java
@@ -159,7 +159,7 @@ class BenchmarkWorker implements ResourceHolder {
             }
 
             @Override
-            public void failed(final Exception cause) {
+            public void failed(final String message, final Exception cause) {
                 stats.incFailureCount();
                 if (config.getVerbosity() >= 1) {
                     System.out.println("Failed HTTP request : " + cause.getMessage());
@@ -259,11 +259,11 @@ class BenchmarkWorker implements ResourceHolder {
             }
 
             @Override
-            public void failed(final Exception cause) {
+            public void failed(final String message, final Exception cause) {
                 stats.incFailureCount();
                 final FutureCallback<Void> resultCallback = resultCallbackRef.getAndSet(null);
                 if (resultCallback != null) {
-                    resultCallback.failed(cause);
+                    resultCallback.failed(message, cause);
                 }
                 if (config.getVerbosity() >= 1) {
                     System.out.println("HTTP response error: " + cause.getMessage());
@@ -302,7 +302,7 @@ class BenchmarkWorker implements ResourceHolder {
                                     }
 
                                     @Override
-                                    public void failed(final Exception cause) {
+                                    public void failed(final String message, final Exception cause) {
                                         execute();
                                     }
 
@@ -315,7 +315,7 @@ class BenchmarkWorker implements ResourceHolder {
                     }
 
                     @Override
-                    public void failed(final Exception cause) {
+                    public void failed(final String message, final Exception cause) {
                         stats.incFailureCount();
                         if (config.getVerbosity() >= 1) {
                             System.out.println("Connect error: " + cause.getMessage());
@@ -342,7 +342,7 @@ class BenchmarkWorker implements ResourceHolder {
                             }
 
                             @Override
-                            public void failed(final Exception cause) {
+                            public void failed(final String message, final Exception cause) {
                                 execute();
                             }
 

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingExceptionListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingExceptionListener.java
@@ -42,7 +42,7 @@ public class LoggingExceptionListener implements ExceptionListener {
     private final Logger connLog = LoggerFactory.getLogger("org.apache.hc.core5.http.connection");
 
     @Override
-    public void onError(final Exception ex) {
+    public void onError(final String message, final Exception ex) {
         if (ex instanceof SocketException) {
             connLog.debug(ex.getMessage());
         } else {
@@ -51,7 +51,7 @@ public class LoggingExceptionListener implements ExceptionListener {
     }
 
     @Override
-    public void onError(final HttpConnection conn, final Exception ex) {
+    public void onError(final HttpConnection conn, final String message, final Exception ex) {
         if (ex instanceof ConnectionClosedException) {
             connLog.debug(ex.getMessage());
         } else if (ex instanceof SocketException) {

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/ClientSessionEndpoint.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/ClientSessionEndpoint.java
@@ -106,8 +106,8 @@ public final class ClientSessionEndpoint implements ModalCloseable {
                     }
 
                     @Override
-                    public void failed(final Exception ex) {
-                        future.failed(ex);
+                    public void failed(final String message, final Exception ex) {
+                        future.failed(message, ex);
                     }
 
                     @Override

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/Http1TestClient.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/Http1TestClient.java
@@ -89,8 +89,8 @@ public class Http1TestClient extends AsyncRequester  {
             }
 
             @Override
-            public void failed(final Exception cause) {
-                future.failed(cause);
+            public void failed(final String message, final Exception cause) {
+                future.failed(message, cause);
             }
 
             @Override

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/Http2TestClient.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/Http2TestClient.java
@@ -123,8 +123,8 @@ public class Http2TestClient extends AsyncRequester {
             }
 
             @Override
-            public void failed(final Exception cause) {
-                future.failed(cause);
+            public void failed(final String message, final Exception cause) {
+                future.failed(message, cause);
             }
 
             @Override

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/Http2CompatibilityTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/Http2CompatibilityTest.java
@@ -138,7 +138,7 @@ public class Http2CompatibilityTest {
                         @Override
                         protected void handleError(
                                 final HttpRequest promise,
-                                final Exception cause) {
+                                final String message, final Exception cause) {
                             resultQueue.add(new RequestResult(promise, null, cause));
                         }
                     };
@@ -159,7 +159,7 @@ public class Http2CompatibilityTest {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             resultQueue.add(new RequestResult(request, null, ex));
                         }
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/EchoHandler.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/EchoHandler.java
@@ -136,7 +136,7 @@ public class EchoHandler implements AsyncServerExchangeHandler {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
     }
 
     @Override

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
@@ -865,7 +865,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
                     }
 
                     @Override
-                    public void failed(final Exception cause) {
+                    public void failed(final String message, final Exception cause) {
                     }
 
                     @Override
@@ -954,7 +954,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
                     }
 
                     @Override
-                    public void failed(final Exception cause) {
+                    public void failed(final String message, final Exception cause) {
                     }
 
                     @Override
@@ -1700,7 +1700,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
                     }
 
                     @Override
-                    public void failed(final Exception cause) {
+                    public void failed(final String message, final Exception cause) {
                         releaseResources();
                     }
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http2IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http2IntegrationTest.java
@@ -676,9 +676,9 @@ public class Http2IntegrationTest extends InternalHttp2ServerTestBase {
                                 context, new BasicPushProducer(new BasicAsyncEntityProducer("Pushing all sorts of stuff")) {
 
                             @Override
-                            public void failed(final Exception cause) {
+                            public void failed(final String message, final Exception cause) {
                                 pushResultQueue.add(cause);
-                                super.failed(cause);
+                                super.failed(message, cause);
                             }
 
                         });
@@ -687,9 +687,9 @@ public class Http2IntegrationTest extends InternalHttp2ServerTestBase {
                                 context, new BasicPushProducer(new MultiLineEntityProducer("Pushing lots of stuff", 500)) {
 
                             @Override
-                            public void failed(final Exception cause) {
+                            public void failed(final String message, final Exception cause) {
                                 pushResultQueue.add(cause);
-                                super.failed(cause);
+                                super.failed(message, cause);
                             }
 
                         });
@@ -889,7 +889,7 @@ public class Http2IntegrationTest extends InternalHttp2ServerTestBase {
                     }
 
                     @Override
-                    public void failed(final Exception cause) {
+                    public void failed(final String message, final Exception cause) {
                     }
 
                     @Override

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiLineEntityProducer.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiLineEntityProducer.java
@@ -76,7 +76,7 @@ public class MultiLineEntityProducer extends AbstractCharAsyncEntityProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
     }
 
     @Override

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TestDefaultListeningIOReactor.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TestDefaultListeningIOReactor.java
@@ -78,7 +78,7 @@ public class TestDefaultListeningIOReactor {
                 }
 
                 @Override
-                public void exception(final IOSession session, final Exception cause) {
+                public void exception(final IOSession session, final String message, final Exception cause) {
                 }
 
                 @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexFuture.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexFuture.java
@@ -82,8 +82,8 @@ public final class ComplexFuture<T> extends BasicFuture<T> implements Cancellabl
     }
 
     @Override
-    public boolean failed(final Exception exception) {
-        final boolean failed = super.failed(exception);
+    public boolean failed(final String message, final Exception exception) {
+        final boolean failed = super.failed(message, exception);
         dependencyRef.set(null);
         return failed;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/FutureCallback.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/FutureCallback.java
@@ -37,7 +37,7 @@ public interface FutureCallback<T> {
 
     void completed(T result);
 
-    void failed(Exception ex);
+    void failed(String message, Exception ex);
 
     void cancelled();
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ExceptionListener.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ExceptionListener.java
@@ -38,12 +38,12 @@ public interface ExceptionListener {
     ExceptionListener NO_OP = new ExceptionListener() {
 
         @Override
-        public void onError(final Exception ex) {
+        public void onError(final String message, final Exception ex) {
             // no-op
         }
 
         @Override
-        public void onError(final HttpConnection connection, final Exception ex) {
+        public void onError(final HttpConnection connection, final String message, final Exception ex) {
             // no-op
         }
 
@@ -52,19 +52,19 @@ public interface ExceptionListener {
     ExceptionListener STD_ERR = new ExceptionListener() {
 
         @Override
-        public void onError(final Exception ex) {
+        public void onError(final String message, final Exception ex) {
             ex.printStackTrace();
         }
 
         @Override
-        public void onError(final HttpConnection connection, final Exception ex) {
+        public void onError(final HttpConnection connection, final String message, final Exception ex) {
             ex.printStackTrace();
         }
 
     };
 
-    void onError(Exception ex);
+    void onError(String message, Exception ex);
 
-    void onError(HttpConnection connection, Exception ex);
+    void onError(HttpConnection connection, String message, Exception ex);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
@@ -194,9 +194,9 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
                         }
 
                         @Override
-                        public void failed(final Exception cause) {
+                        public void failed(final String message, final Exception cause) {
                             try {
-                                resultFuture.failed(cause);
+                                resultFuture.failed(message, cause);
                             } finally {
                                 endpoint.releaseAndDiscard();
                             }
@@ -217,8 +217,8 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             }
 
             @Override
-            public void failed(final Exception ex) {
-                resultFuture.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                resultFuture.failed(message, ex);
             }
 
             @Override
@@ -269,9 +269,9 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
                                 }
 
                                 @Override
-                                public void failed(final Exception cause) {
+                                public void failed(final String message, final Exception cause) {
                                     endpoint.releaseAndDiscard();
-                                    exchangeHandler.failed(cause);
+                                    exchangeHandler.failed(message, cause);
                                 }
 
                                 @Override
@@ -330,8 +330,8 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
-                            exchangeHandler.failed(ex);
+                        public void failed(final String message, final Exception ex) {
+                            exchangeHandler.failed(message, ex);
                         }
 
                         @Override
@@ -346,7 +346,7 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             }, executeContext);
 
         } catch (final IOException | HttpException ex) {
-            exchangeHandler.failed(ex);
+            exchangeHandler.failed(null, ex);
         }
     }
 
@@ -376,8 +376,8 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             }
 
             @Override
-            public void failed(final Exception ex) {
-                future.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                future.failed(message, ex);
             }
 
             @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpServer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpServer.java
@@ -166,7 +166,7 @@ public class HttpServer implements ModalCloseable {
                 try {
                     local.terminate();
                 } catch (final IOException ex) {
-                    this.exceptionListener.onError(ex);
+                    this.exceptionListener.onError(null, null, ex);
                 }
             }
             this.workerThreads.interrupt();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/RequestListener.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/RequestListener.java
@@ -86,7 +86,7 @@ class RequestListener implements Runnable {
                 this.executorService.execute(worker);
             }
         } catch (final Exception ex) {
-            this.exceptionListener.onError(ex);
+            this.exceptionListener.onError(null, null, ex);
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/Worker.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/Worker.java
@@ -64,7 +64,7 @@ class Worker implements Runnable {
             }
             this.conn.close();
         } catch (final Exception ex) {
-            this.exceptionListener.onError(this.conn, ex);
+            this.exceptionListener.onError(this.conn, null, ex);
         } finally {
             this.conn.close(CloseMode.IMMEDIATE);
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1IOEventHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1IOEventHandler.java
@@ -85,7 +85,7 @@ class AbstractHttp1IOEventHandler implements HttpConnectionEventHandler {
     }
 
     @Override
-    public void exception(final IOSession session, final Exception cause) {
+    public void exception(final IOSession session, final String message, final Exception cause) {
         streamDuplexer.onException(cause);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1StreamDuplexer.java
@@ -386,7 +386,7 @@ abstract class AbstractHttp1StreamDuplexer<IncomingMessage extends HttpMessage, 
             if (command != null) {
                 if (command instanceof RequestExecutionCommand) {
                     final AsyncClientExchangeHandler exchangeHandler = ((RequestExecutionCommand) command).getExchangeHandler();
-                    exchangeHandler.failed(ex);
+                    exchangeHandler.failed(null, ex);
                     exchangeHandler.releaseResources();
                 } else {
                     command.cancel();
@@ -404,7 +404,7 @@ abstract class AbstractHttp1StreamDuplexer<IncomingMessage extends HttpMessage, 
             if (command != null) {
                 if (command instanceof RequestExecutionCommand) {
                     final AsyncClientExchangeHandler exchangeHandler = ((RequestExecutionCommand) command).getExchangeHandler();
-                    exchangeHandler.failed(new ConnectionClosedException());
+                    exchangeHandler.failed(null, new ConnectionClosedException());
                     exchangeHandler.releaseResources();
                 } else {
                     command.cancel();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
@@ -180,19 +180,19 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     @Override
     void terminate(final Exception exception) {
         if (incoming != null) {
-            incoming.failed(exception);
+            incoming.failed(null, exception);
             incoming.releaseResources();
             incoming = null;
         }
         if (outgoing != null) {
-            outgoing.failed(exception);
+            outgoing.failed(null, exception);
             outgoing.releaseResources();
             outgoing = null;
         }
         for (;;) {
             final ClientHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
-                handler.failed(exception);
+                handler.failed(null, exception);
                 handler.releaseResources();
             } else {
                 break;
@@ -204,14 +204,14 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     void disconnected() {
         if (incoming != null) {
             if (!incoming.isCompleted()) {
-                incoming.failed(new ConnectionClosedException());
+                incoming.failed(null, new ConnectionClosedException());
             }
             incoming.releaseResources();
             incoming = null;
         }
         if (outgoing != null) {
             if (!outgoing.isCompleted()) {
-                outgoing.failed(new ConnectionClosedException());
+                outgoing.failed(null, new ConnectionClosedException());
             }
             outgoing.releaseResources();
             outgoing = null;
@@ -219,7 +219,7 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
         for (;;) {
             final ClientHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
-                handler.failed(new ConnectionClosedException());
+                handler.failed(null, new ConnectionClosedException());
                 handler.releaseResources();
             } else {
                 break;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamHandler.java
@@ -289,9 +289,9 @@ class ClientHttp1StreamHandler implements ResourceHolder {
         return false;
     }
 
-    void failed(final Exception cause) {
+    void failed(final String message, final Exception cause) {
         if (!done.get()) {
-            exchangeHandler.failed(cause);
+            exchangeHandler.failed(message, cause);
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
@@ -187,19 +187,19 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     @Override
     void terminate(final Exception exception) {
         if (incoming != null) {
-            incoming.failed(exception);
+            incoming.failed(null, exception);
             incoming.releaseResources();
             incoming = null;
         }
         if (outgoing != null) {
-            outgoing.failed(exception);
+            outgoing.failed(null, exception);
             outgoing.releaseResources();
             outgoing = null;
         }
         for (;;) {
             final ServerHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
-                handler.failed(exception);
+                handler.failed(null, exception);
                 handler.releaseResources();
             } else {
                 break;
@@ -211,14 +211,14 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     void disconnected() {
         if (incoming != null) {
             if (!incoming.isCompleted()) {
-                incoming.failed(new ConnectionClosedException());
+                incoming.failed(null, new ConnectionClosedException());
             }
             incoming.releaseResources();
             incoming = null;
         }
         if (outgoing != null) {
             if (!outgoing.isCompleted()) {
-                outgoing.failed(new ConnectionClosedException());
+                outgoing.failed(null, new ConnectionClosedException());
             }
             outgoing.releaseResources();
             outgoing = null;
@@ -226,7 +226,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
         for (;;) {
             final ServerHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
-                handler.failed(new ConnectionClosedException());
+                handler.failed(null, new ConnectionClosedException());
                 handler.releaseResources();
             } else {
                 break;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
@@ -300,9 +300,9 @@ class ServerHttp1StreamHandler implements ResourceHolder {
         exchangeHandler.streamEnd(trailers);
     }
 
-    void failed(final Exception cause) {
+    void failed(final String message, final Exception cause) {
         if (!done.get()) {
-            exchangeHandler.failed(cause);
+            exchangeHandler.failed(message, cause);
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/TerminalServerFilter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/TerminalServerFilter.java
@@ -64,7 +64,7 @@ public final class TerminalServerFilter implements HttpFilterHandler {
     }
 
     @Override
-    public final void handle(
+    public void handle(
             final ClassicHttpRequest request,
             final HttpFilterChain.ResponseTrigger responseTrigger,
             final HttpContext context,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncClientEndpoint.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncClientEndpoint.java
@@ -108,8 +108,8 @@ public abstract class AsyncClientEndpoint {
                             }
 
                             @Override
-                            public void failed(final Exception ex) {
-                                future.failed(ex);
+                            public void failed(final String message, final Exception ex) {
+                                future.failed(message, ex);
                             }
 
                             @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncDataExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncDataExchangeHandler.java
@@ -37,8 +37,9 @@ public interface AsyncDataExchangeHandler extends AsyncDataConsumer, AsyncDataPr
     /**
      * Triggered to signal a failure in data processing.
      *
+     * @param message the description of the failure if different from the cause's message.
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncEntityConsumer.java
@@ -51,10 +51,10 @@ public interface AsyncEntityConsumer<T> extends AsyncDataConsumer {
 
     /**
      * Triggered to signal a failure in data processing.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
     /**
      * Returns the result of entity processing when it becomes available or {@code null}

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncEntityProducer.java
@@ -43,9 +43,9 @@ public interface AsyncEntityProducer extends AsyncDataProducer, EntityDetails {
 
     /**
      * Triggered to signal a failure in data generation.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncPushConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncPushConsumer.java
@@ -56,9 +56,9 @@ public interface AsyncPushConsumer extends AsyncDataConsumer {
 
     /**
      * Triggered to signal a failure in data processing.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncPushProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncPushProducer.java
@@ -52,9 +52,9 @@ public interface AsyncPushProducer extends AsyncDataProducer {
 
     /**
      * Triggered to signal a failure in data generation.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncRequestConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncRequestConsumer.java
@@ -58,10 +58,10 @@ public interface AsyncRequestConsumer<T> extends AsyncDataConsumer {
 
     /**
      * Triggered to signal a failure in data processing.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
     /**
      * Returns the result of request processing when it becomes available or {@code null}

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncRequestProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncRequestProducer.java
@@ -57,9 +57,9 @@ public interface AsyncRequestProducer extends AsyncDataProducer {
 
     /**
      * Triggered to signal a failure in data generation.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncResponseConsumer.java
@@ -66,10 +66,10 @@ public interface AsyncResponseConsumer<T> extends AsyncDataConsumer {
 
     /**
      * Triggered to signal a failure in data processing.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
     /**
      * Returns the result of response processing when it becomes available or {@code null}

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncResponseProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncResponseProducer.java
@@ -51,9 +51,9 @@ public interface AsyncResponseProducer extends AsyncDataProducer {
 
     /**
      * Triggered to signal a failure in data generation.
-     *
+     * @param message TODO
      * @param cause the cause of the failure.
      */
-    void failed(Exception cause);
+    void failed(String message, Exception cause);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicPushProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicPushProducer.java
@@ -77,7 +77,7 @@ public class BasicPushProducer implements AsyncPushProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicRequestConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicRequestConsumer.java
@@ -77,9 +77,9 @@ public class BasicRequestConsumer<T> implements AsyncRequestConsumer<Message<Htt
                 }
 
                 @Override
-                public void failed(final Exception ex) {
+                public void failed(final String message, final Exception ex) {
                     if (resultCallback != null) {
-                        resultCallback.failed(ex);
+                        resultCallback.failed(message, ex);
                     }
                     dataConsumer.releaseResources();
                 }
@@ -121,7 +121,7 @@ public class BasicRequestConsumer<T> implements AsyncRequestConsumer<Message<Htt
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicRequestProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicRequestProducer.java
@@ -90,10 +90,10 @@ public class BasicRequestProducer implements AsyncRequestProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         try {
             if (dataProducer != null) {
-                dataProducer.failed(cause);
+                dataProducer.failed(message, cause);
             }
         } finally {
             releaseResources();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicResponseConsumer.java
@@ -76,9 +76,9 @@ public class BasicResponseConsumer<T> implements AsyncResponseConsumer<Message<H
                 }
 
                 @Override
-                public void failed(final Exception ex) {
+                public void failed(final String message, final Exception ex) {
                     if (resultCallback != null) {
-                        resultCallback.failed(ex);
+                        resultCallback.failed(message, ex);
                     }
                 }
 
@@ -119,7 +119,7 @@ public class BasicResponseConsumer<T> implements AsyncResponseConsumer<Message<H
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicResponseProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/BasicResponseProducer.java
@@ -100,7 +100,7 @@ public class BasicResponseProducer implements AsyncResponseProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/ExecutableCommand.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/ExecutableCommand.java
@@ -43,6 +43,6 @@ public abstract class ExecutableCommand implements Command {
 
     public abstract CancellableDependency getCancellableDependency();
 
-    public abstract void failed(Exception ex);
+    public abstract void failed(String message, Exception ex);
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/RequestExecutionCommand.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/RequestExecutionCommand.java
@@ -90,9 +90,9 @@ public final class RequestExecutionCommand extends ExecutableCommand {
     }
 
     @Override
-    public void failed(final Exception ex) {
+    public void failed(final String message, final Exception ex) {
         try {
-            exchangeHandler.failed(ex);
+            exchangeHandler.failed(message, ex);
         } finally {
             exchangeHandler.releaseResources();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityConsumer.java
@@ -87,9 +87,9 @@ public abstract class AbstractBinAsyncEntityConsumer<T> extends AbstractBinDataC
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         if (resultCallback != null) {
-            resultCallback.failed(cause);
+            resultCallback.failed(message, cause);
         }
         releaseResources();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityConsumer.java
@@ -94,9 +94,9 @@ public abstract class AbstractCharAsyncEntityConsumer<T> extends AbstractCharDat
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         if (resultCallback != null) {
-            resultCallback.failed(cause);
+            resultCallback.failed(message, cause);
         }
         releaseResources();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
@@ -137,7 +137,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
             releaseResources();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityConsumer.java
@@ -94,8 +94,8 @@ public class DigestingEntityConsumer<T> implements AsyncEntityConsumer<T> {
     }
 
     @Override
-    public void failed(final Exception cause) {
-        wrapped.failed(cause);
+    public void failed(final String message, final Exception cause) {
+        wrapped.failed(message, cause);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityProducer.java
@@ -149,8 +149,8 @@ public class DigestingEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
-        wrapped.failed(cause);
+    public void failed(final String message, final Exception cause) {
+        wrapped.failed(message, cause);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/FileEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/FileEntityProducer.java
@@ -140,7 +140,7 @@ public final class FileEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
             releaseResources();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/NoopEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/NoopEntityConsumer.java
@@ -47,7 +47,7 @@ public final class NoopEntityConsumer implements AsyncEntityConsumer<Void> {
     private volatile FutureCallback<Void> resultCallback;
 
     @Override
-    public final void streamStart(
+    public void streamStart(
             final EntityDetails entityDetails,
             final FutureCallback<Void> resultCallback) throws IOException, HttpException {
         this.resultCallback = resultCallback;
@@ -59,20 +59,20 @@ public final class NoopEntityConsumer implements AsyncEntityConsumer<Void> {
     }
 
     @Override
-    public final void consume(final ByteBuffer src) throws IOException {
+    public void consume(final ByteBuffer src) throws IOException {
     }
 
     @Override
-    public final void streamEnd(final List<? extends Header> trailers) throws IOException {
+    public void streamEnd(final List<? extends Header> trailers) throws IOException {
         if (resultCallback != null) {
             resultCallback.completed(null);
         }
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         if (resultCallback != null) {
-            resultCallback.failed(cause);
+            resultCallback.failed(message, cause);
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
@@ -89,7 +89,7 @@ public class StringAsyncEntityProducer extends AbstractCharAsyncEntityProducer {
     }
 
     @Override
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
             releaseResources();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncPushHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncPushHandler.java
@@ -70,9 +70,10 @@ public abstract class AbstractAsyncPushHandler<T> implements AsyncPushConsumer {
      * Triggered to handle the exception thrown while processing a push response.
      *
      * @param promise the promised request message.
+     * @param message TODO
      * @param cause the cause of error.
      */
-    protected void handleError(final HttpRequest promise, final Exception cause) {
+    protected void handleError(final HttpRequest promise, final String message, final Exception cause) {
     }
 
     @Override
@@ -88,13 +89,13 @@ public abstract class AbstractAsyncPushHandler<T> implements AsyncPushConsumer {
                 try {
                     handleResponse(promise, result);
                 } catch (final Exception ex) {
-                    failed(ex);
+                    failed(null, ex);
                 }
             }
 
             @Override
-            public void failed(final Exception cause) {
-                handleError(promise, cause);
+            public void failed(final String message, final Exception cause) {
+                handleError(promise, message, cause);
                 releaseResources();
             }
 
@@ -122,8 +123,8 @@ public abstract class AbstractAsyncPushHandler<T> implements AsyncPushConsumer {
     }
 
     @Override
-    public final void failed(final Exception cause) {
-        responseConsumer.failed(cause);
+    public final void failed(final String message, final Exception cause) {
+        responseConsumer.failed(message, cause);
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncRequesterConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncRequesterConsumer.java
@@ -88,13 +88,13 @@ public abstract class AbstractAsyncRequesterConsumer<T, E> implements AsyncReque
                         result = buildResult(request, entity, contentType);
                         resultCallback.completed(result);
                     } catch (final UnsupportedCharsetException ex) {
-                        resultCallback.failed(ex);
+                        resultCallback.failed(null, ex);
                     }
                 }
 
                 @Override
-                public void failed(final Exception ex) {
-                    resultCallback.failed(ex);
+                public void failed(final String message, final Exception ex) {
+                    resultCallback.failed(message, ex);
                 }
 
                 @Override
@@ -131,7 +131,7 @@ public abstract class AbstractAsyncRequesterConsumer<T, E> implements AsyncReque
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncResponseConsumer.java
@@ -96,16 +96,16 @@ public abstract class AbstractAsyncResponseConsumer<T, E> implements AsyncRespon
                     } catch (final UnsupportedCharsetException ex) {
                         exceptionRef.compareAndSet(null, ex);
                         if (resultCallback != null) {
-                            resultCallback.failed(ex);
+                            resultCallback.failed(null, ex);
                         }
                     }
                 }
 
                 @Override
-                public void failed(final Exception ex) {
+                public void failed(final String message, final Exception ex) {
                     exceptionRef.compareAndSet(null, ex);
                     if (resultCallback != null) {
-                        resultCallback.failed(ex);
+                        resultCallback.failed(message, ex);
                     }
                 }
 
@@ -153,7 +153,7 @@ public abstract class AbstractAsyncResponseConsumer<T, E> implements AsyncRespon
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         exceptionRef.compareAndSet(null, cause);
         releaseResources();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractServerExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractServerExchangeHandler.java
@@ -142,16 +142,16 @@ public abstract class AbstractServerExchangeHandler<T> implements AsyncServerExc
                         responseTrigger.submitResponse(
                                 new BasicResponseProducer(HttpStatus.SC_INTERNAL_SERVER_ERROR, ex.getMessage()), context);
                     } catch (final HttpException | IOException ex2) {
-                        failed(ex2);
+                        failed(null, ex2);
                     }
                 } catch (final IOException ex) {
-                    failed(ex);
+                    failed(null, ex);
                 }
             }
 
             @Override
-            public void failed(final Exception ex) {
-                AbstractServerExchangeHandler.this.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                AbstractServerExchangeHandler.this.failed(message, ex);
             }
 
             @Override
@@ -198,15 +198,15 @@ public abstract class AbstractServerExchangeHandler<T> implements AsyncServerExc
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         try {
             final AsyncRequestConsumer<T> requestConsumer = requestConsumerRef.get();
             if (requestConsumer != null) {
-                requestConsumer.failed(cause);
+                requestConsumer.failed(message, cause);
             }
             final AsyncResponseProducer dataProducer = responseProducerRef.get();
             if (dataProducer != null) {
-                dataProducer.failed(cause);
+                dataProducer.failed(message, cause);
             }
         } finally {
             releaseResources();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncServerFilterChainExchangeHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncServerFilterChainExchangeHandlerFactory.java
@@ -105,10 +105,10 @@ public final class AsyncServerFilterChainExchangeHandlerFactory implements Handl
             }
 
             @Override
-            public void failed(final Exception cause) {
+            public void failed(final String message, final Exception cause) {
                 final AsyncResponseProducer handler = responseProducerRef.get();
                 if (handler != null) {
-                    handler.failed(cause);
+                    handler.failed(message, cause);
                 }
             }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicAsyncServerExpectationDecorator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicAsyncServerExpectationDecorator.java
@@ -133,12 +133,12 @@ public class BasicAsyncServerExpectationDecorator implements AsyncServerExchange
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         try {
-            handler.failed(cause);
+            handler.failed(message, cause);
             final AsyncResponseProducer dataProducer = responseProducerRef.getAndSet(null);
             if (dataProducer != null) {
-                dataProducer.failed(cause);
+                dataProducer.failed(message, cause);
             }
         } finally {
             releaseResources();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicClientExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicClientExchangeHandler.java
@@ -111,10 +111,10 @@ public final class BasicClientExchangeHandler<T> implements AsyncClientExchangeH
             }
 
             @Override
-            public void failed(final Exception ex) {
+            public void failed(final String message, final Exception ex) {
                 releaseResources();
                 if (resultCallback != null) {
-                    resultCallback.failed(ex);
+                    resultCallback.failed(message, ex);
                 }
             }
 
@@ -153,20 +153,20 @@ public final class BasicClientExchangeHandler<T> implements AsyncClientExchangeH
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         try {
-            requestProducer.failed(cause);
-            responseConsumer.failed(cause);
+            requestProducer.failed(message, cause);
+            responseConsumer.failed(message, cause);
         } finally {
             releaseResources();
             if (resultCallback != null) {
-                resultCallback.failed(cause);
+                resultCallback.failed(message, cause);
             }
         }
     }
 
     @Override
-    public final void releaseResources() {
+    public void releaseResources() {
         requestProducer.releaseResources();
         responseConsumer.releaseResources();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/ImmediateResponseExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/ImmediateResponseExchangeHandler.java
@@ -93,23 +93,23 @@ public final class ImmediateResponseExchangeHandler implements AsyncServerExchan
     }
 
     @Override
-    public final int available() {
+    public int available() {
         return responseProducer.available();
     }
 
     @Override
-    public final void produce(final DataStreamChannel channel) throws IOException {
+    public void produce(final DataStreamChannel channel) throws IOException {
         responseProducer.produce(channel);
     }
 
     @Override
-    public final void failed(final Exception cause) {
-        responseProducer.failed(cause);
+    public void failed(final String message, final Exception cause) {
+        responseProducer.failed(message, cause);
         releaseResources();
     }
 
     @Override
-    public final void releaseResources() {
+    public void releaseResources() {
         responseProducer.releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/TerminalAsyncServerFilter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/TerminalAsyncServerFilter.java
@@ -87,8 +87,8 @@ public final class TerminalAsyncServerFilter implements AsyncFilterHandler {
                     responseTrigger.submitResponse(response, entityDetails != null ? new AsyncEntityProducer() {
 
                         @Override
-                        public void failed(final Exception cause) {
-                            exchangeHandler.failed(cause);
+                        public void failed(final String message, final Exception cause) {
+                            exchangeHandler.failed(message, cause);
                         }
 
                         @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityConsumer.java
@@ -104,7 +104,7 @@ public abstract class AbstractClassicEntityConsumer<T> implements AsyncEntityCon
                         resultCallback.completed(result);
                     } catch (final Exception ex) {
                         buffer.abort();
-                        resultCallback.failed(ex);
+                        resultCallback.failed(null, ex);
                     } finally {
                         state.set(State.COMPLETED);
                     }
@@ -125,7 +125,7 @@ public abstract class AbstractClassicEntityConsumer<T> implements AsyncEntityCon
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         if (exceptionRef.compareAndSet(null, cause)) {
             releaseResources();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityProducer.java
@@ -128,7 +128,7 @@ public abstract class AbstractClassicEntityProducer implements AsyncEntityProduc
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
             releaseResources();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicServerExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicServerExchangeHandler.java
@@ -287,7 +287,7 @@ public abstract class AbstractClassicServerExchangeHandler implements AsyncServe
     }
 
     @Override
-    public final void failed(final Exception cause) {
+    public final void failed(final String message, final Exception cause) {
         exception.compareAndSet(null, cause);
         releaseResources();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/HttpContext.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/HttpContext.java
@@ -50,7 +50,7 @@ import org.apache.hc.core5.http.ProtocolVersion;
 public interface HttpContext {
 
     /** The prefix reserved for use by HTTP components. "http." */
-    public static final String RESERVED_PREFIX  = "http.";
+    String RESERVED_PREFIX  = "http.";
 
     /**
      * Returns protocol version used in this context.

--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/LaxConnPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/LaxConnPool.java
@@ -102,8 +102,7 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
     @Override
     public void close(final CloseMode closeMode) {
         if (isShutDown.compareAndSet(false, true)) {
-            for (final Iterator<PerRoutePool<T, C>> it = routeToPool.values().iterator(); it.hasNext(); ) {
-                final PerRoutePool<T, C> routePool = it.next();
+            for (final PerRoutePool<T, C> routePool : routeToPool.values()) {
                 routePool.shutdown(closeMode);
             }
             routeToPool.clear();
@@ -326,8 +325,8 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
             future.completed(result);
         }
 
-        public void failed(final Exception ex) {
-            future.failed(ex);
+        public void failed(final String message, final Exception ex) {
+            future.failed(message, ex);
         }
 
         @Override
@@ -466,7 +465,7 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
                 final Deadline deadline = leaseRequest.getDeadline();
 
                 if (deadline.isExpired()) {
-                    leaseRequest.failed(DeadlineTimeoutException.from(deadline));
+                    leaseRequest.failed(null, DeadlineTimeoutException.from(deadline));
                 } else {
                     final PoolEntry<T, C> availableEntry = getAvailableEntry(state);
                     if (availableEntry != null) {
@@ -492,7 +491,7 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
                 } else {
                     final Deadline deadline = request.getDeadline();
                     if (deadline.isExpired()) {
-                        request.failed(DeadlineTimeoutException.from(deadline));
+                        request.failed(null, DeadlineTimeoutException.from(deadline));
                     }
                     if (request.isDone()) {
                         it.remove();

--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
@@ -348,7 +348,7 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
             final PoolEntry<T, C> result = request.getResult();
             boolean successfullyCompleted = false;
             if (ex != null) {
-                future.failed(ex);
+                future.failed(null, ex);
             } else if (result != null) {
                 if (future.completed(result)) {
                     successfullyCompleted = true;

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOSessionPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOSessionPool.java
@@ -148,8 +148,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
                                 }
 
                                 @Override
-                                public void failed(final Exception ex) {
-                                    future.failed(ex);
+                                public void failed(final String message, final Exception ex) {
+                                    future.failed(message, ex);
                                 }
 
                                 @Override
@@ -165,8 +165,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
             }
 
             @Override
-            public void failed(final Exception ex) {
-                future.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                future.failed(message, ex);
             }
 
             @Override
@@ -219,14 +219,14 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
                                 }
 
                                 @Override
-                                public void failed(final Exception ex) {
+                                public void failed(final String message, final Exception ex) {
                                     synchronized (poolEntry) {
                                         poolEntry.session = null;
                                         poolEntry.sessionFuture = null;
                                         for (;;) {
                                             final FutureCallback<IOSession> callback = poolEntry.requestQueue.poll();
                                             if (callback != null) {
-                                                callback.failed(ex);
+                                                callback.failed(message, ex);
                                             } else {
                                                 break;
                                             }
@@ -236,7 +236,7 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
 
                                 @Override
                                 public void cancelled() {
-                                    failed(new ConnectionClosedException("Connection request cancelled"));
+                                    failed(null, new ConnectionClosedException("Connection request cancelled"));
                                 }
 
                             });

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/EventMask.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/EventMask.java
@@ -39,16 +39,16 @@ public interface EventMask {
     /**
      * Interest in data input.
      */
-    public static final int READ = SelectionKey.OP_READ;
+    int READ = SelectionKey.OP_READ;
 
     /**
      * Interest in data output.
      */
-    public static final int WRITE = SelectionKey.OP_WRITE;
+    int WRITE = SelectionKey.OP_WRITE;
 
     /**
      * Interest in data input/output.
      */
-    public static final int READ_WRITE = READ | WRITE;
+    int READ_WRITE = READ | WRITE;
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOEventHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOEventHandler.java
@@ -75,8 +75,9 @@ public interface IOEventHandler {
      * Triggered when the given session throws a exception.
      *
      * @param session the I/O session.
+     * @param message TODO
      */
-    void exception(IOSession session, Exception cause);
+    void exception(IOSession session, String message, Exception cause);
 
     /**
      * Triggered when the given session has been terminated.

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionRequest.java
@@ -74,8 +74,8 @@ final class IOSessionRequest implements Future<IOSession> {
         closeableRef.set(null);
     }
 
-    public void failed(final Exception cause) {
-        future.failed(cause);
+    public void failed(final String message, final Exception cause) {
+        future.failed(message, cause);
         closeableRef.set(null);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalChannel.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalChannel.java
@@ -40,7 +40,7 @@ abstract class InternalChannel implements ModalCloseable {
 
     abstract void onTimeout(Timeout timeout) throws IOException;
 
-    abstract void onException(final Exception cause);
+    abstract void onException(String message, final Exception cause);
 
     abstract Timeout getTimeout();
 
@@ -52,7 +52,7 @@ abstract class InternalChannel implements ModalCloseable {
         } catch (final CancelledKeyException ex) {
             close(CloseMode.GRACEFUL);
         } catch (final Exception ex) {
-            onException(ex);
+            onException(null, ex);
             close(CloseMode.IMMEDIATE);
         }
     }
@@ -68,7 +68,7 @@ abstract class InternalChannel implements ModalCloseable {
                 } catch (final CancelledKeyException ex) {
                     close(CloseMode.GRACEFUL);
                 } catch (final Exception ex) {
-                    onException(ex);
+                    onException(null, ex);
                     close(CloseMode.IMMEDIATE);
                 }
                 return false;

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalConnectChannel.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalConnectChannel.java
@@ -90,13 +90,13 @@ final class InternalConnectChannel extends InternalChannel {
 
     @Override
     void onTimeout(final Timeout timeout) throws IOException {
-        sessionRequest.failed(SocketTimeoutExceptionFactory.create(timeout));
+        sessionRequest.failed(null, SocketTimeoutExceptionFactory.create(timeout));
         close();
     }
 
     @Override
-    void onException(final Exception cause) {
-        sessionRequest.failed(cause);
+    void onException(final String message, final Exception cause) {
+        sessionRequest.failed(message, cause);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalDataChannel.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/InternalDataChannel.java
@@ -196,12 +196,12 @@ final class InternalDataChannel extends InternalChannel implements ProtocolIOSes
     }
 
     @Override
-    void onException(final Exception cause) {
+    void onException(final String message, final Exception cause) {
         final IOEventHandler handler = ensureHandler();
         if (sessionListener != null) {
             sessionListener.exception(this, cause);
         }
-        handler.exception(this, cause);
+        handler.exception(this, null, cause);
     }
 
     void disconnected() {
@@ -243,7 +243,7 @@ final class InternalDataChannel extends InternalChannel implements ProtocolIOSes
                                 if (sessionListener != null) {
                                     sessionListener.exception(InternalDataChannel.this, ex);
                                 }
-                                handler.exception(InternalDataChannel.this, ex);
+                                handler.exception(InternalDataChannel.this, null, ex);
                             }
                         }
                     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ListenerEndpointRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ListenerEndpointRequest.java
@@ -48,9 +48,9 @@ final class ListenerEndpointRequest implements Closeable {
         }
     }
 
-    public void failed(final Exception cause) {
+    public void failed(final String message, final Exception cause) {
         if (future != null) {
-            future.failed(cause);
+            future.failed(message, cause);
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/SingleCoreIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/SingleCoreIOReactor.java
@@ -288,14 +288,14 @@ class SingleCoreIOReactor extends AbstractSingleCoreIOReactor implements Connect
                 try {
                     socketChannel = SocketChannel.open();
                 } catch (final IOException ex) {
-                    sessionRequest.failed(ex);
+                    sessionRequest.failed(null, ex);
                     return;
                 }
                 try {
                     processConnectionRequest(socketChannel, sessionRequest);
                 } catch (final IOException | SecurityException ex) {
                     Closer.closeQuietly(socketChannel);
-                    sessionRequest.failed(ex);
+                    sessionRequest.failed(null, ex);
                 }
             }
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -81,8 +81,7 @@ public final class TextUtils {
             return null;
         }
         final StringBuffer buffer = new StringBuffer();
-        for (int i = 0; i < bytes.length; i++) {
-            final byte b = bytes[i];
+        for (final byte b : bytes) {
             if (b < 16) {
                 buffer.append('0');
             }

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/BasicFutureCallback.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/BasicFutureCallback.java
@@ -50,7 +50,7 @@ class BasicFutureCallback<T> implements FutureCallback<T> {
     }
 
     @Override
-    public void failed(final Exception ex) {
+    public void failed(final String message, final Exception ex) {
         this.ex = ex;
         this.failed = true;
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestBasicFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestBasicFuture.java
@@ -47,7 +47,7 @@ public class TestBasicFuture {
         final Object result = new Object();
         final Exception boom = new Exception();
         future.completed(result);
-        future.failed(boom);
+        future.failed(null, boom);
         Assert.assertTrue(callback.isCompleted());
         Assert.assertSame(result, callback.getResult());
         Assert.assertFalse(callback.isFailed());
@@ -70,7 +70,7 @@ public class TestBasicFuture {
         final Object result = new Object();
         final Exception boom = new Exception();
         future.completed(result);
-        future.failed(boom);
+        future.failed(null, boom);
         Assert.assertTrue(callback.isCompleted());
         Assert.assertSame(result, callback.getResult());
         Assert.assertFalse(callback.isFailed());
@@ -88,7 +88,7 @@ public class TestBasicFuture {
         final BasicFuture<Object> future = new BasicFuture<>(callback);
         final Object result = new Object();
         final Exception boom = new Exception();
-        future.failed(boom);
+        future.failed(null, boom);
         future.completed(result);
         Assert.assertFalse(callback.isCompleted());
         Assert.assertNull(callback.getResult());
@@ -112,7 +112,7 @@ public class TestBasicFuture {
         final Object result = new Object();
         final Exception boom = new Exception();
         future.cancel(true);
-        future.failed(boom);
+        future.failed(null, boom);
         future.completed(result);
         Assert.assertFalse(callback.isCompleted());
         Assert.assertNull(callback.getResult());
@@ -164,7 +164,7 @@ public class TestBasicFuture {
             public void run() {
                 try {
                     Thread.sleep(100);
-                    future.failed(boom);
+                    future.failed(null, boom);
                 } catch (final InterruptedException ex) {
                 }
             }

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
@@ -81,8 +81,8 @@ public class TestComplexFuture {
             }
 
             @Override
-            public void failed(final Exception ex) {
-                future.failed(ex);
+            public void failed(final String message, final Exception ex) {
+                future.failed(message, ex);
             }
 
             @Override

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexClientExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexClientExample.java
@@ -142,7 +142,7 @@ public class AsyncFullDuplexClientExample {
             }
 
             @Override
-            public void failed(final Exception cause) {
+            public void failed(final String message, final Exception cause) {
                 System.out.println(requestUri + "->" + cause);
             }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexServerExample.java
@@ -191,7 +191,7 @@ public class AsyncFullDuplexServerExample {
                             }
 
                             @Override
-                            public void failed(final Exception cause) {
+                            public void failed(final String message, final Exception cause) {
                                 if (!(cause instanceof SocketException)) {
                                     cause.printStackTrace(System.out);
                                 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncPipelinedRequestExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncPipelinedRequestExecutionExample.java
@@ -120,7 +120,7 @@ public class AsyncPipelinedRequestExecutionExample {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             latch.countDown();
                             System.out.println(requestUri + "->" + ex);
                         }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncRequestExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncRequestExecutionExample.java
@@ -115,7 +115,7 @@ public class AsyncRequestExecutionExample {
                         }
 
                         @Override
-                        public void failed(final Exception ex) {
+                        public void failed(final String message, final Exception ex) {
                             System.out.println(requestUri + "->" + ex);
                             latch.countDown();
                         }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
@@ -316,7 +316,7 @@ public class AsyncReverseProxyExample {
                 }
 
                 @Override
-                public void failed(final Exception cause) {
+                public void failed(final String message, final Exception cause) {
                     final HttpResponse outgoingResponse = new BasicHttpResponse(HttpStatus.SC_SERVICE_UNAVAILABLE);
                     outgoingResponse.addHeader(HttpHeaders.CONNECTION, HeaderElements.CLOSE);
                     final ByteBuffer msg = StandardCharsets.US_ASCII.encode(CharBuffer.wrap(cause.getMessage()));
@@ -340,7 +340,7 @@ public class AsyncReverseProxyExample {
 
                 @Override
                 public void cancelled() {
-                    failed(new InterruptedIOException());
+                    failed(null, new InterruptedIOException());
                 }
 
             });
@@ -440,7 +440,7 @@ public class AsyncReverseProxyExample {
         }
 
         @Override
-        public void failed(final Exception cause) {
+        public void failed(final String message, final Exception cause) {
             println("[client<-proxy] " + exchangeState.id + " " + cause.getMessage());
             if (!(cause instanceof ConnectionClosedException)) {
                 cause.printStackTrace(System.out);
@@ -652,7 +652,7 @@ public class AsyncReverseProxyExample {
         }
 
         @Override
-        public void failed(final Exception cause) {
+        public void failed(final String message, final Exception cause) {
             println("[client<-proxy] " + exchangeState.id + " " + cause.getMessage());
             if (!(cause instanceof ConnectionClosedException)) {
                 cause.printStackTrace(System.out);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicFileServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicFileServerExample.java
@@ -104,12 +104,12 @@ public class ClassicFileServerExample {
                 .setExceptionListener(new ExceptionListener() {
 
                     @Override
-                    public void onError(final Exception ex) {
+                    public void onError(final String message, final Exception ex) {
                         ex.printStackTrace();
                     }
 
                     @Override
-                    public void onError(final HttpConnection conn, final Exception ex) {
+                    public void onError(final HttpConnection conn, final String message, final Exception ex) {
                         if (ex instanceof SocketTimeoutException) {
                             System.err.println("Connection timed out");
                         } else if (ex instanceof ConnectionClosedException) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicReverseProxyExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicReverseProxyExample.java
@@ -151,7 +151,7 @@ public class ClassicReverseProxyExample {
                 .setExceptionListener(new ExceptionListener() {
 
                     @Override
-                    public void onError(final Exception ex) {
+                    public void onError(final String message, final Exception ex) {
                         if (ex instanceof SocketException) {
                             System.out.println("[client->proxy] " + Thread.currentThread() + " " + ex.getMessage());
                         } else {
@@ -161,7 +161,7 @@ public class ClassicReverseProxyExample {
                     }
 
                     @Override
-                    public void onError(final HttpConnection connection, final Exception ex) {
+                    public void onError(final HttpConnection connection, final String message, final Exception ex) {
                         if (ex instanceof SocketTimeoutException) {
                             System.out.println("[client->proxy] " + Thread.currentThread() + " time out");
                         } else if (ex instanceof SocketException || ex instanceof ConnectionClosedException) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityConsumer.java
@@ -99,7 +99,7 @@ public class TestAbstractBinAsyncEntityConsumer {
             }
 
             @Override
-            public void failed(final Exception ex) {
+            public void failed(final String message, final Exception ex) {
                 count.incrementAndGet();
             }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityProducer.java
@@ -77,7 +77,7 @@ public class TestAbstractBinAsyncEntityProducer {
         }
 
         @Override
-        public void failed(final Exception cause) {
+        public void failed(final String message, final Exception cause) {
         }
 
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityConsumer.java
@@ -91,7 +91,7 @@ public class TestAbstractCharAsyncEntityConsumer {
             }
 
             @Override
-            public void failed(final Exception ex) {
+            public void failed(final String message, final Exception ex) {
                 count.incrementAndGet();
             }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityProducer.java
@@ -78,7 +78,7 @@ public class TestAbstractCharAsyncEntityProducer {
         }
 
         @Override
-        public void failed(final Exception cause) {
+        public void failed(final String message, final Exception cause) {
         }
 
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
@@ -168,7 +168,7 @@ public class TestAbstractIOSessionPool {
 
                     @Override
                     public boolean matches(final FutureCallback<IOSession> callback) {
-                        callback.failed(new Exception("Boom"));
+                        callback.failed(null, new Exception("Boom"));
                         return true;
                     }
 


### PR DESCRIPTION
Better error reporting with this patch gives us:
```
Exception in thread "main" java.util.concurrent.ExecutionException:
Socket bind failure for socket ServerSocket[unbound],
address=0.0.0.0/0.0.0.0:8080, BacklogSize=0: java.net.BindException:
Address already in use: bind
	at org.apache.hc.core5.concurrent.BasicFuture.getResult(BasicFuture.java:74)
	at org.apache.hc.core5.concurrent.BasicFuture.get(BasicFuture.java:87)
	at org.apache.hc.core5.http.examples.AsyncFileServerExample.main(AsyncFileServerExample.java:165)
Caused by: java.net.BindException: Address already in use: bind
	at sun.nio.ch.Net.bind0(Native Method)
	at sun.nio.ch.Net.bind(Unknown Source)
	at sun.nio.ch.Net.bind(Unknown Source)
	at sun.nio.ch.ServerSocketChannelImpl.bind(Unknown Source)
	at sun.nio.ch.ServerSocketAdaptor.bind(Unknown Source)
	at org.apache.hc.core5.reactor.SingleCoreListeningIOReactor.processSessionRequests(SingleCoreListeningIOReactor.java:164)
	at org.apache.hc.core5.reactor.SingleCoreListeningIOReactor.processEvents(SingleCoreListeningIOReactor.java:102)
	at org.apache.hc.core5.reactor.SingleCoreListeningIOReactor.doExecute(SingleCoreListeningIOReactor.java:96)
	at org.apache.hc.core5.reactor.AbstractSingleCoreIOReactor.execute(AbstractSingleCoreIOReactor.java:81)
	at org.apache.hc.core5.reactor.IOReactorWorker.run(IOReactorWorker.java:44)
	at java.lang.Thread.run(Unknown Source)
Thu, 04 Apr 2019 20:17:06 GMT | HTTP server shutting down
```
Instead of just the BindException.