### PR TITLE
Refactor ClassicHttpRequest and ClassicHttpResponse interfaces to extend

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ClassicHttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ClassicHttpRequest.java
@@ -32,23 +32,6 @@ package org.apache.hc.core5.http;
  *
  * @since 5.0
  */
-public interface ClassicHttpRequest extends HttpRequest {
-
-    /**
-     * Obtains the message entity, if available.
-     *
-     * @return  the message entity, or {@code null} if not available
-     */
-    HttpEntity getEntity();
-
-    /**
-     * Sets an entity for this message.
-     * <p>
-     * Please note that if an entity has already been set it is responsibility of the caller
-     * to ensure release of the resources that may be associated with that entity.
-     *
-     * @param entity    the entity to set of this message, or {@code null} to unset
-     */
-    void setEntity(HttpEntity entity);
-
+public interface ClassicHttpRequest extends HttpRequest, HttpEntityContainer {
+    // empty
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpEntityContainer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpEntityContainer.java
@@ -27,13 +27,29 @@
 
 package org.apache.hc.core5.http;
 
-import java.io.Closeable;
-
 /**
- * 'Classic' {@link HttpResponse} message that can enclose {@link HttpEntity}.
+ * Contains an {@link HttpEntity}.
  *
  * @since 5.0
  */
-public interface ClassicHttpResponse extends HttpResponse, HttpEntityContainer, Closeable {
-    // empty
+public interface HttpEntityContainer {
+
+    /**
+     * Obtains the message entity, if available.
+     *
+     * @return  the message entity, or {@code null} if not available
+     */
+    HttpEntity getEntity();
+
+    /**
+     * Sets an entity for this message.
+     * <p>
+     * Please note that if an entity has already been set it is responsibility of the caller
+     * to ensure release of the resources that may be associated with that entity.
+     * </p>
+     *
+     * @param entity    the entity to set of this message, or {@code null} to unset
+     */
+    void setEntity(HttpEntity entity);
+
 }


### PR DESCRIPTION
Refactor **ClassicHttpRequest** and **ClassicHttpResponse** interfaces to extend a new interface called **HttpEntityContainer**. This permits for writing common entity code for both requests and responses without testing and casting for two cases.