### PR TITLE
(HTTPCORE-578) Incorrect serialization of HeaderGroup

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/HeaderGroup.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/HeaderGroup.java
@@ -50,7 +50,7 @@ public class HeaderGroup implements MessageHeaders, Serializable {
 
     private static final long serialVersionUID = 2608834160639271617L;
 
-    private final Header[] EMPTY = new Header[] {};
+    private static final Header[] EMPTY = new Header[] {};
 
     /** The list of headers for this group, in the order in which they were added */
     private final List<Header> headers;


### PR DESCRIPTION
Make HeaderGroup.EMPTY static.