### PR TITLE
Execute Socket[Channel]#connect under doPrivileged

### DIFF
--- a/httpcore/src/main/java/org/apache/http/impl/pool/BasicConnFactory.java
+++ b/httpcore/src/main/java/org/apache/http/impl/pool/BasicConnFactory.java
@@ -183,13 +183,12 @@ public class BasicConnFactory implements ConnFactory<HttpHost, HttpClientConnect
         socket.setKeepAlive(this.sconfig.isSoKeepAlive());
         // Run this under a doPrivileged to support lib users that run under a SecurityManager this allows granting connect permissions
         // only to this library
-        final Socket finalSocket = socket;
         final InetSocketAddress address = new InetSocketAddress(hostname, port);
         try {
             AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
                 @Override
                 public Object run() throws IOException {
-                    finalSocket.connect(address, BasicConnFactory.this.connectTimeout);
+                    socket.connect(address, BasicConnFactory.this.connectTimeout);
                     return null;
                 }
             });


### PR DESCRIPTION
In order to allow users to run under a security manager that only grants
connect permission to the httpcore codebase the connect methods should
be executed in a doPriveledged block.
This is certainly not the only issue that users run into when they
install a SecurityManager with strict permissions but certainly the
most prominent and most likely one. Upstream components like the client
might also need to protect places accessing the proxy selector etc.

Backport of #135