### PR TITLE
Add SOAP xml content type

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -72,6 +72,8 @@ public final class ContentType implements Serializable {
             "application/json", StandardCharsets.UTF_8);
     public static final ContentType APPLICATION_OCTET_STREAM = create(
             "application/octet-stream", (Charset) null);
+    public static final ContentType APPLICATION_SOAP_XML = create(
+            "application/soap+xml", StandardCharsets.ISO_8859_1);
     public static final ContentType APPLICATION_SVG_XML = create(
             "application/svg+xml", StandardCharsets.ISO_8859_1);
     public static final ContentType APPLICATION_XHTML_XML = create(

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -73,7 +73,7 @@ public final class ContentType implements Serializable {
     public static final ContentType APPLICATION_OCTET_STREAM = create(
             "application/octet-stream", (Charset) null);
     public static final ContentType APPLICATION_SOAP_XML = create(
-            "application/soap+xml", StandardCharsets.ISO_8859_1);
+            "application/soap+xml", StandardCharsets.UTF_8);
     public static final ContentType APPLICATION_SVG_XML = create(
             "application/svg+xml", StandardCharsets.ISO_8859_1);
     public static final ContentType APPLICATION_XHTML_XML = create(


### PR DESCRIPTION
While using core 4.4 with `StringEntity(string,mimetype,charset)` constructor deprecated we can no longer specify `application/soap+xml` although some apis require this
- Add `application/soap+xml` as a content type