### PR TITLE
Set accessiblity flag on reflected methods in ReflectionUtils

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
@@ -233,7 +233,7 @@ public class H2ProtocolNegotiationTest {
         final HttpResponse response1 = message1.getHead();
         Assert.assertThat(response1.getCode(), CoreMatchers.equalTo(HttpStatus.SC_OK));
 
-        if (javaVersion >= 9 && javaVersion < 11) {
+        if (javaVersion >= 9) {
             Assert.assertThat(response1.getVersion(), CoreMatchers.<ProtocolVersion>equalTo(HttpVersion.HTTP_2));
         } else {
             Assert.assertThat(response1.getVersion(), CoreMatchers.<ProtocolVersion>equalTo(HttpVersion.HTTP_1_1));

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/ReflectionUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/ReflectionUtils.java
@@ -28,6 +28,8 @@
 package org.apache.hc.core5.util;
 
 import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 import org.apache.hc.core5.annotation.Internal;
 
@@ -38,6 +40,7 @@ public final class ReflectionUtils {
         try {
             final Class<?> clazz = object.getClass();
             final Method method = clazz.getMethod("set" + setterName, type);
+            setAccessible(method);
             method.invoke(object, value);
         } catch (final Exception ignore) {
         }
@@ -47,10 +50,21 @@ public final class ReflectionUtils {
         try {
             final Class<?> clazz = object.getClass();
             final Method method = clazz.getMethod("get" + getterName);
+            setAccessible(method);
             return resultType.cast(method.invoke(object));
         } catch (final Exception ignore) {
             return null;
         }
+    }
+
+    private static void setAccessible(final Method method) {
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            @Override
+            public Object run() {
+                method.setAccessible(true);
+                return null;
+            }
+        });
     }
 
     public static int determineJRELevel() {


### PR DESCRIPTION
Prior to this change, attempts to reflectively invoke methods on
protected classes in other modules could fail on JDK9 and above.

Currently, the methods in ReflectionUtils are only used to get and set
properties related to ALPN on SSLEngine instances at runtime. On JDK11,
reflectively invoking the `getApplicationProtocol` method on
`SSLEngineImpl`, a protected class, throws an `IllegalAccessException`.
`callGetter` swallows this and returns `null`, causing the client
runtime to ignore whatever protocol was negotiated with ALPN and default
to HTTP/1.1.

This specific reflective access is still illegal and will eventually
break in a future Java release. A proper fix would require creating a
multi-release jar with a dedicated SSLEngine accessor class for JDK9+
that can natively invoke these methods.