### PR TITLE
Propagate BasicResponse{Consumer,Producer}#failed() to data{Consumer,Producer}

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseConsumer.java
@@ -142,6 +142,10 @@ public class BasicResponseConsumer<T> implements AsyncResponseConsumer<Message<H
 
     @Override
     public void failed(final Exception cause) {
+        final AsyncEntityConsumer<T> dataConsumer = dataConsumerRef.get();
+        if (dataConsumer != null) {
+            dataConsumer.failed(cause);
+        }
         releaseResources();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseProducer.java
@@ -105,6 +105,9 @@ public class BasicResponseProducer implements AsyncResponseProducer {
 
     @Override
     public void failed(final Exception cause) {
+        if (dataProducer != null) {
+            dataProducer.failed(cause);
+        }
         releaseResources();
     }
 


### PR DESCRIPTION
Wrapped AsyncEntityConsumers and AsyncEntityProducers were not receiving failed()
calls before releaseResources() when an exchange was abnormally terminated.


Note that AsyncEntityProducer behavior is slightly different from AsyncEntityConsumer behavior in that consumers can receive no further calls from BasicResponseConsumer after releaseResources() is called because the consumer reference is atomically discarded, but producers can. I didn't want to change the member variable state without guidance.