### PR TITLE
validate connections everytime

### DIFF
--- a/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
+++ b/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
@@ -251,7 +251,7 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
                                 throw new ExecutionException(operationAborted());
                             }
                             final E leasedEntry = getPoolEntryBlocking(route, state, timeout, timeUnit, this);
-                            if (validateAfterInactivity > 0)  {
+                            if (validateAfterInactivity >= 0)  {
                                 if (leasedEntry.getUpdated() + validateAfterInactivity <= System.currentTimeMillis()) {
                                     if (!validate(leasedEntry)) {
                                         leasedEntry.close();


### PR DESCRIPTION
I need a connetion pool which validates connections everytime when future.get() is called.
Invoking connpool.setValidateAfterInactivity(0) is an option to enable this.
Thanks in advance.