### PR TITLE
HTTPCORE-613_2: Now allowing 0 for validaterAfterInactivity

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -63,7 +63,7 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
     private final Resolver<HttpHost, InetSocketAddress> addressResolver;
     private final TlsStrategy tlsStrategy;
 
-    private volatile TimeValue validateAfterInactivity;
+    private volatile TimeValue validateAfterInactivity = TimeValue.NEG_ONE_MILLISECOND;
 
     public H2ConnPool(
             final ConnectionInitiator connectionInitiator,
@@ -137,7 +137,7 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
             final IOSession ioSession,
             final Callback<Boolean> callback) {
         final TimeValue timeValue = validateAfterInactivity;
-        if (TimeValue.isPositive(timeValue)) {
+        if (TimeValue.ZERO_MILLISECONDS.equals(timeValue) || TimeValue.isPositive(timeValue)) {
             final long lastAccessTime = Math.min(ioSession.getLastReadTime(), ioSession.getLastWriteTime());
             final long deadline = lastAccessTime + timeValue.toMilliseconds();
             if (deadline <= System.currentTimeMillis()) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -137,7 +137,7 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
             final IOSession ioSession,
             final Callback<Boolean> callback) {
         final TimeValue timeValue = validateAfterInactivity;
-        if (TimeValue.ZERO_MILLISECONDS.equals(timeValue) || TimeValue.isPositive(timeValue)) {
+        if (TimeValue.ZERO_MILLISECONDS.compareTo(timeValue) <= 0) {
             final long lastAccessTime = Math.min(ioSession.getLastReadTime(), ioSession.getLastWriteTime());
             final long deadline = lastAccessTime + timeValue.toMilliseconds();
             if (deadline <= System.currentTimeMillis()) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -137,7 +137,7 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
             final IOSession ioSession,
             final Callback<Boolean> callback) {
         final TimeValue timeValue = validateAfterInactivity;
-        if (TimeValue.ZERO_MILLISECONDS.compareTo(timeValue) <= 0) {
+        if (TimeValue.isNonNegative(timeValue)) {
             final long lastAccessTime = Math.min(ioSession.getLastReadTime(), ioSession.getLastWriteTime());
             final long deadline = lastAccessTime + timeValue.toMilliseconds();
             if (deadline <= System.currentTimeMillis()) {


### PR DESCRIPTION
Previously only positive values were used for checking the validity of a potentially stale connection, now 0 is allowed