### PR TITLE
Allow for timeout while acquiring lock in StrictConnPool.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
@@ -171,21 +171,33 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
         Args.notNull(route, "Route");
         Args.notNull(requestTimeout, "Request timeout");
         Asserts.check(!this.isShutDown.get(), "Connection pool shut down");
+        final Deadline deadline = Deadline.calculate(requestTimeout);
         final BasicFuture<PoolEntry<T, C>> future = new BasicFuture<>(callback);
-        this.lock.lock();
+        boolean acquiredLock = false;
+
         try {
-            final LeaseRequest<T, C> request = new LeaseRequest<>(route, state, requestTimeout, future);
-            final boolean completed = processPendingRequest(request);
-            if (!request.isDone() && !completed) {
-                this.leasingRequests.add(request);
-            }
-            if (request.isDone()) {
-                this.completedRequests.add(request);
-            }
-        } finally {
-            this.lock.unlock();
+            acquiredLock = this.lock.tryLock(requestTimeout.getDuration(), requestTimeout.getTimeUnit());
+        } catch (final InterruptedException ignored) {
         }
-        fireCallbacks();
+
+        if (acquiredLock) {
+            try {
+                final LeaseRequest<T, C> request = new LeaseRequest<>(route, state, requestTimeout, future);
+                final boolean completed = processPendingRequest(request);
+                if (!request.isDone() && !completed) {
+                    this.leasingRequests.add(request);
+                }
+                if (request.isDone()) {
+                    this.completedRequests.add(request);
+                }
+            } finally {
+                this.lock.unlock();
+            }
+            fireCallbacks();
+        } else {
+            future.failed(DeadlineTimeoutException.from(deadline));
+        }
+
         return future;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
@@ -179,7 +179,7 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
             acquiredLock = this.lock.tryLock(requestTimeout.getDuration(), requestTimeout.getTimeUnit());
         } catch (final InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
-            future.failed(interruptedException);
+            future.cancel();
             return future;
         }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
@@ -27,11 +27,15 @@
 package org.apache.hc.core5.pool;
 
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.http.HttpConnection;
 import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.DeadlineTimeoutException;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.junit.Assert;
@@ -510,6 +514,43 @@ public class TestStrictConnPool {
 
         Assert.assertFalse(future2.isDone());
         Assert.assertTrue(future3.isDone());
+    }
+
+    @Test
+    public void testLeaseRequestLockTimeout() throws Exception {
+        final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(1, 1);
+        final CountDownLatch lockHeld = new CountDownLatch(1);
+        final Thread holdInternalLock = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                pool.enumLeased(new Callback<PoolEntry<String, HttpConnection>>() {
+                    @Override
+                    public void execute(final PoolEntry<String, HttpConnection> object) {
+                        try {
+                            lockHeld.countDown();
+                            Thread.sleep(Long.MAX_VALUE);
+                        } catch (final InterruptedException ignored) {
+                        }
+                    }
+                });
+            }
+        });
+
+        pool.lease("somehost", null); // lease a connection so we have something to enumLeased()
+        holdInternalLock.start(); // Start a thread to grab the internal conn pool lock
+        lockHeld.await(); // Wait until we know the internal lock is held
+
+        // Attempt to get a connection while lock is held
+        final Future<PoolEntry<String, HttpConnection>> future2 = pool.lease("somehost", null, Timeout.ofMilliseconds(10), null);
+
+        try {
+            future2.get();
+        } catch (final ExecutionException executionException) {
+            Assert.assertTrue(executionException.getCause() instanceof DeadlineTimeoutException);
+            holdInternalLock.interrupt(); // Cleanup
+            return;
+        }
+        Assert.fail("Expected deadline timeout.");
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.pool;
 
 import java.util.Collections;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -575,8 +576,7 @@ public class TestStrictConnPool {
         Assert.assertTrue(Thread.interrupted());
         try {
             future2.get();
-        } catch (final ExecutionException executionException) {
-            Assert.assertTrue(executionException.getCause() instanceof InterruptedException);
+        } catch (final CancellationException cancellationException) {
             holdInternalLock.interrupt(); // Cleanup
             return;
         }


### PR DESCRIPTION
I mentioned in the mailing list that a connection request does not fail immediately when the time to acquire the StrictConnPool lock is longer than the requestTimeout. Instead it will only fail when the lock is finally acquired and the deadline is checked in processPendingRequest(). @ok2c agreed and suggested I propose a PR.

This PR changes StrictConnPool.lease to use the requestTimeout when attempting to grab the lock. If the lock can't be acquired within the timeout the request is failed with a DeadlineTimeoutException.

A few comments:

1. tryLock(timeout) is interruptible whereas lock() is not. I'm unclear if this would break any existing behavior.
2. I don't love that acquisition of the lock is captured in a boolean, it feels slightly dangerous if this block gets more complex down the road. However I chose this over nested try catches since we need to handle the InterruptedException.

