### PR TITLE
ReactiveResponseConsumer: Fix empty response handling

### DIFF
--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
@@ -59,6 +59,7 @@ final class ReactiveDataConsumer implements AsyncDataConsumer, Publisher<ByteBuf
     private final BlockingQueue<ByteBuffer> buffers = new LinkedBlockingQueue<>();
     private final AtomicBoolean flushInProgress = new AtomicBoolean(false);
     private final AtomicInteger windowScalingIncrement = new AtomicInteger(0);
+    private volatile boolean buffersSent = false;
     private volatile boolean cancelled = false;
     private volatile boolean completed = false;
     private volatile Exception exception;
@@ -110,6 +111,17 @@ final class ReactiveDataConsumer implements AsyncDataConsumer, Publisher<ByteBuf
         flushToSubscriber();
     }
 
+    /**
+     * @return {@code true} iff this consumer is in a non-terminal state and has not yet sent any data to its subscriber.
+     */
+    boolean awaitingStartOfEntity() {
+        return !buffersSent && !isEnded();
+    }
+
+    private boolean isEnded() {
+        return completed || cancelled || exception != null;
+    }
+
     @Override
     public void releaseResources() {
         this.capacityChannel = null;
@@ -133,6 +145,7 @@ final class ReactiveDataConsumer implements AsyncDataConsumer, Publisher<ByteBuf
             while (requests.get() > 0 && ((next = buffers.poll()) != null)) {
                 final int bytesFreed = next.remaining();
                 s.onNext(next);
+                buffersSent = true;
                 requests.decrementAndGet();
                 windowScalingIncrement.addAndGet(bytesFreed);
             }

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
@@ -162,10 +162,14 @@ public final class ReactiveResponseConsumer implements AsyncResponseConsumer<Voi
 
     @Override
     public void releaseResources() {
-        reactiveDataConsumer.releaseResources();
-        responseFuture.cancel();
-        if (responseCompletion != null) {
-            responseCompletion.cancel();
+        if (reactiveDataConsumer.awaitingStartOfEntity()) {
+            streamEnd(null);
+        } else {
+            reactiveDataConsumer.releaseResources();
+            responseFuture.cancel();
+            if (responseCompletion != null) {
+                responseCompletion.cancel();
+            }
         }
     }
 }


### PR DESCRIPTION
Presently the contract of `AsyncDataConsumer` and its implementations is
that `streamEnd` is only called at the end of a data stream. If the HTTP
message does not enclose an entity, then no such stream actually exists;
in this case, `releaseResources` is called instead. This change teaches
`ReactiveResponseConsumer` to call `Subscriber#onComplete` in this case.