### PR TITLE
Don't apply INITIAL_WINDOW_SIZE to connection window

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -1215,17 +1215,14 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         final int delta = localConfig.getInitialWindowSize() - initInputWinSize;
         initInputWinSize = localConfig.getInitialWindowSize();
 
-        if (delta != 0) {
-            updateInputWindow(0, connInputWindow, delta);
-            if (!streamMap.isEmpty()) {
-                for (final Iterator<Map.Entry<Integer, H2Stream>> it = streamMap.entrySet().iterator(); it.hasNext(); ) {
-                    final Map.Entry<Integer, H2Stream> entry = it.next();
-                    final H2Stream stream = entry.getValue();
-                    try {
-                        updateInputWindow(stream.getId(), stream.getInputWindow(), delta);
-                    } catch (final ArithmeticException ex) {
-                        throw new H2ConnectionException(H2Error.FLOW_CONTROL_ERROR, ex.getMessage());
-                    }
+        if (delta != 0 && !streamMap.isEmpty()) {
+            for (final Iterator<Map.Entry<Integer, H2Stream>> it = streamMap.entrySet().iterator(); it.hasNext(); ) {
+                final Map.Entry<Integer, H2Stream> entry = it.next();
+                final H2Stream stream = entry.getValue();
+                try {
+                    updateInputWindow(stream.getId(), stream.getInputWindow(), delta);
+                } catch (final ArithmeticException ex) {
+                    throw new H2ConnectionException(H2Error.FLOW_CONTROL_ERROR, ex.getMessage());
                 }
             }
         }


### PR DESCRIPTION
According to RFC7540 §6.9.2 ("Initial Flow-Control Window Size"), "the
connection flow-control window can only be changed using WINDOW_UPDATE
frames." Furthermore, according to §6.9 ("WINDOW_UPDATE"), the window
size increment must be an unsigned integer, with a legal range being "1
to 2^31-1 (2,147,483,647) octets." In other words, when the client uses
a SETTINGS frame to shrink the initial window size to a value smaller
than the default (65,535 bytes), the resulting delta must only be
applied to the existing child streams, and not the connection window
itself. (While a *positive* delta can be applied to the connection
window, this must be done explicitly by sending a WINDOW_UPDATE frame.)