### PR TITLE
Clean up connection window management

### DIFF
--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/reactive/ReactiveTestUtils.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/reactive/ReactiveTestUtils.java
@@ -102,7 +102,7 @@ public class ReactiveTestUtils {
                     final int bufferLength = (int) Math.min(remainingLength, 1 + random.nextInt(maximumBlockSize));
                     final byte[] bs = new byte[bufferLength];
                     for (int i = 0; i < bufferLength; i++) {
-                        final byte b = RANGE[(int) (Math.random() * RANGE.length)];
+                        final byte b = RANGE[(int) (random.nextDouble() * RANGE.length)];
                         bs[i] = b;
                     }
                     if (hash != null) {


### PR DESCRIPTION
This commit implements the following changes to input window management:

1. The `lowMark` is set according to local settings, not remote settings
2. The connection window is set to `Integer.MAX_VALUE` during `SETTINGS` exchange
3. The connection window low mark is now a constant value (10 MiB)
4. The input window update code in `onOutput` has been removed