### PR TITLE
[HTTPCORE-622] JSSEProviderIntegrationTest fails if Conscrypt JNI wra…

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
@@ -116,7 +116,11 @@ public class JSSEProviderIntegrationTest {
         @Override
         protected void before() throws Throwable {
             if ("Conscrypt".equalsIgnoreCase(securityProviderName)) {
-                securityProvider = Conscrypt.newProviderBuilder().provideTrustManager(true).build();
+                try {
+                    securityProvider = Conscrypt.newProviderBuilder().provideTrustManager(true).build();
+                } catch (final UnsatisfiedLinkError e) {
+                    Assume.assumeFalse("Conscrypt provider failed to be loaded: " + e.getMessage(), true);
+                }
             } else {
                 securityProvider = null;
             }


### PR DESCRIPTION
…pper cannot be loaded

@ok2c This basically works for me on FreeBSD and on Windows where I have deleted the DLLs from the JARs. Please test yourself also.