### PR TITLE
Allow trailing slash on creating HttpHost with a string

### DIFF
--- a/httpcore/src/main/java/org/apache/http/HttpHost.java
+++ b/httpcore/src/main/java/org/apache/http/HttpHost.java
@@ -107,6 +107,10 @@ public final class HttpHost implements Cloneable, Serializable {
     public static HttpHost create(final String s) {
         Args.containsNoBlanks(s, "HTTP Host");
         String text = s;
+        final char lastChar = text.charAt(text.length() - 1);
+        if (lastChar == '/') {
+            text = text.substring(0, text.length() - 1);
+        }
         String scheme = null;
         final int schemeIdx = text.indexOf("://");
         if (schemeIdx > 0) {

--- a/httpcore/src/test/java/org/apache/http/TestHttpHost.java
+++ b/httpcore/src/test/java/org/apache/http/TestHttpHost.java
@@ -200,7 +200,9 @@ public class TestHttpHost {
     @Test
     public void testCreateFromString() throws Exception {
         Assert.assertEquals(new HttpHost("somehost", 8080, "https"), HttpHost.create("https://somehost:8080"));
+        Assert.assertEquals(new HttpHost("somehost", 8080, "https"), HttpHost.create("https://somehost:8080/"));
         Assert.assertEquals(new HttpHost("somehost", 8080, "https"), HttpHost.create("HttpS://SomeHost:8080"));
+        Assert.assertEquals(new HttpHost("somehost", 8080, "https"), HttpHost.create("HttpS://SomeHost:8080/"));
         Assert.assertEquals(new HttpHost("somehost", 1234, null), HttpHost.create("somehost:1234"));
         Assert.assertEquals(new HttpHost("somehost", -1, null), HttpHost.create("somehost"));
     }


### PR DESCRIPTION
The static create method in HttpHost gets an error when having a string with a trailing slash. 
Now it doesn't bother anymore.