### PR TITLE
Deprecate org.apache.hc.core5.util.Args.notNull(T, String) in favor of

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/H2ConnectionException.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/H2ConnectionException.java
@@ -27,8 +27,7 @@
 package org.apache.hc.core5.http2;
 
 import java.io.IOException;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * Signals fatal HTTP/2 protocol violation that renders the actual
@@ -44,7 +43,7 @@ public class H2ConnectionException extends IOException {
 
     public H2ConnectionException(final H2Error error, final String message) {
         super(message);
-        Args.notNull(error, "H2 Error code may not be null");
+        Objects.requireNonNull(error, "H2 Error code may not be null");
         this.code = error.getCode();
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/H2StreamResetException.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/H2StreamResetException.java
@@ -26,8 +26,9 @@
  */
 package org.apache.hc.core5.http2;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.http.HttpStreamResetException;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Signals HTTP/2 protocol error that renders the actual HTTP/2 data stream
@@ -41,7 +42,7 @@ public class H2StreamResetException extends HttpStreamResetException {
 
     public H2StreamResetException(final H2Error error, final String message) {
         super(message);
-        Args.notNull(error, "H2 Error code may not be null");
+        Objects.requireNonNull(error, "H2 Error code may not be null");
         this.code = error.getCode();
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/config/H2Config.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/config/H2Config.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http2.config;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http2.frame.FrameConsts;
@@ -126,7 +128,7 @@ public class H2Config {
     }
 
     public static H2Config.Builder copy(final H2Config config) {
-        Args.notNull(config, "Connection config");
+        Objects.requireNonNull(config, "Connection config");
         return new Builder()
                 .setHeaderTableSize(config.getHeaderTableSize())
                 .setPushEnabled(config.isPushEnabled())

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/config/H2Setting.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/config/H2Setting.java
@@ -26,6 +26,8 @@
  */
 package org.apache.hc.core5.http2.config;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -39,7 +41,7 @@ public final class H2Setting {
     private final int value;
 
     public H2Setting(final H2Param param, final int value) {
-        Args.notNull(param, "Setting parameter");
+        Objects.requireNonNull(param, "Setting parameter");
         Args.notNegative(value, "Setting value must be a non-negative value");
         this.param = param;
         this.value = value;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/frame/FrameFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/frame/FrameFactory.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http2.frame;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import org.apache.hc.core5.http2.H2Error;
 import org.apache.hc.core5.http2.config.H2Setting;
@@ -57,7 +58,7 @@ public abstract class FrameFactory {
     }
 
     public RawFrame createResetStream(final int streamId, final H2Error error) {
-        Args.notNull(error, "Error");
+        Objects.requireNonNull(error, "Error");
         return createResetStream(streamId, error.getCode());
     }
 
@@ -70,13 +71,13 @@ public abstract class FrameFactory {
     }
 
     public RawFrame createPing(final ByteBuffer opaqueData) {
-        Args.notNull(opaqueData, "Opaque data");
+        Objects.requireNonNull(opaqueData, "Opaque data");
         Args.check(opaqueData.remaining() == 8, "Opaque data length must be equal 8");
         return new RawFrame(FrameType.PING.getValue(), 0, 0, opaqueData);
     }
 
     public RawFrame createPingAck(final ByteBuffer opaqueData) {
-        Args.notNull(opaqueData, "Opaque data");
+        Objects.requireNonNull(opaqueData, "Opaque data");
         Args.check(opaqueData.remaining() == 8, "Opaque data length must be equal 8");
         return new RawFrame(FrameType.PING.getValue(), FrameFlag.ACK.value, 0, opaqueData);
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/HPackEncoder.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/HPackEncoder.java
@@ -35,6 +35,7 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.http.Header;
@@ -317,21 +318,21 @@ public final class HPackEncoder {
 
     public void encodeHeader(
             final ByteArrayBuffer dst, final Header header) throws CharacterCodingException {
-        Args.notNull(dst, "ByteArrayBuffer");
-        Args.notNull(header, "Header");
+        Objects.requireNonNull(dst, "ByteArrayBuffer");
+        Objects.requireNonNull(header, "Header");
         encodeHeader(dst, header.getName(), header.getValue(), header.isSensitive());
     }
 
     public void encodeHeader(
             final ByteArrayBuffer dst, final String name, final String value, final boolean sensitive) throws CharacterCodingException {
-        Args.notNull(dst, "ByteArrayBuffer");
+        Objects.requireNonNull(dst, "ByteArrayBuffer");
         Args.notEmpty(name, "Header name");
         encodeHeader(dst, name, value, sensitive, false, true);
     }
 
     public void encodeHeaders(
             final ByteArrayBuffer dst, final List<? extends Header> headers, final boolean useHuffman) throws CharacterCodingException {
-        Args.notNull(dst, "ByteArrayBuffer");
+        Objects.requireNonNull(dst, "ByteArrayBuffer");
         Args.notEmpty(headers, "Header list");
         encodeHeaders(dst, headers, false, useHuffman);
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/FrameInputBuffer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/FrameInputBuffer.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http2.impl.io;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http2.H2ConnectionException;
@@ -57,7 +58,7 @@ public final class FrameInputBuffer {
     private int dataLen;
 
     FrameInputBuffer(final BasicH2TransportMetrics metrics, final int bufferLen, final int maxFramePayloadSize) {
-        Args.notNull(metrics, "HTTP2 transport metrcis");
+        Objects.requireNonNull(metrics, "HTTP2 transport metrcis");
         Args.positive(maxFramePayloadSize, "Maximum payload size");
         this.metrics = metrics;
         this.maxFramePayloadSize = maxFramePayloadSize;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/FrameOutputBuffer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/FrameOutputBuffer.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http2.impl.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import org.apache.hc.core5.http2.H2ConnectionException;
 import org.apache.hc.core5.http2.H2Error;
@@ -53,7 +54,7 @@ public final class FrameOutputBuffer {
 
     public FrameOutputBuffer(final BasicH2TransportMetrics metrics, final int maxFramePayloadSize) {
         super();
-        Args.notNull(metrics, "HTTP2 transport metrcis");
+        Objects.requireNonNull(metrics, "HTTP2 transport metrcis");
         Args.positive(maxFramePayloadSize, "Maximum payload size");
         this.metrics = metrics;
         this.maxFramePayloadSize = maxFramePayloadSize;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/FrameOutputStream.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/FrameOutputStream.java
@@ -30,8 +30,7 @@ package org.apache.hc.core5.http2.impl.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * @since 5.0
@@ -45,7 +44,7 @@ abstract class FrameOutputStream extends OutputStream {
 
     public FrameOutputStream(final int minChunkSize, final OutputStream outputStream) {
         super();
-        this.outputStream = Args.notNull(outputStream, "Output stream");
+        this.outputStream = Objects.requireNonNull(outputStream, "Output stream");
         this.cache = new byte[minChunkSize];
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2IOEventHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2IOEventHandler.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http2.impl.nio;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import javax.net.ssl.SSLSession;
 
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.impl.nio.HttpConnectionEventHandler;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 class AbstractH2IOEventHandler implements HttpConnectionEventHandler {
@@ -47,7 +47,7 @@ class AbstractH2IOEventHandler implements HttpConnectionEventHandler {
     final AbstractH2StreamMultiplexer streamMultiplexer;
 
     AbstractH2IOEventHandler(final AbstractH2StreamMultiplexer streamMultiplexer) {
-        this.streamMultiplexer = Args.notNull(streamMultiplexer, "Stream multiplexer");
+        this.streamMultiplexer = Objects.requireNonNull(streamMultiplexer, "Stream multiplexer");
     }
 
     @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -36,6 +36,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,7 +86,6 @@ import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.ByteArrayBuffer;
 import org.apache.hc.core5.util.Identifiable;
 import org.apache.hc.core5.util.Timeout;
@@ -142,10 +142,10 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
             final CharCodingConfig charCodingConfig,
             final H2Config h2Config,
             final H2StreamListener streamListener) {
-        this.ioSession = Args.notNull(ioSession, "IO session");
-        this.frameFactory = Args.notNull(frameFactory, "Frame factory");
-        this.idGenerator = Args.notNull(idGenerator, "Stream id generator");
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.ioSession = Objects.requireNonNull(ioSession, "IO session");
+        this.frameFactory = Objects.requireNonNull(frameFactory, "Frame factory");
+        this.idGenerator = Objects.requireNonNull(idGenerator, "Stream id generator");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
         this.localConfig = h2Config != null ? h2Config : H2Config.DEFAULT;
         this.inputMetrics = new BasicH2TransportMetrics();
         this.outputMetrics = new BasicH2TransportMetrics();
@@ -249,7 +249,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
     }
 
     private void commitFrame(final RawFrame frame) throws IOException {
-        Args.notNull(frame, "Frame");
+        Objects.requireNonNull(frame, "Frame");
         ioSession.getLock().lock();
         try {
             commitFrameInternal(frame);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamMultiplexerFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamMultiplexerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http2.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +39,6 @@ import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.http2.frame.DefaultFrameFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link ClientH2StreamMultiplexer} factory.
@@ -60,7 +61,7 @@ public final class ClientH2StreamMultiplexerFactory {
             final H2Config h2Config,
             final CharCodingConfig charCodingConfig,
             final H2StreamListener streamListener) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
         this.pushHandlerFactory = pushHandlerFactory;
         this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiator.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiator.java
@@ -32,6 +32,7 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.SelectionKey;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLSession;
@@ -52,7 +53,6 @@ import org.apache.hc.core5.io.SocketTimeoutExceptionFactory;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -85,9 +85,9 @@ public class ClientHttpProtocolNegotiator implements HttpConnectionEventHandler 
             final ClientHttp1StreamDuplexerFactory http1StreamHandlerFactory,
             final ClientH2StreamMultiplexerFactory http2StreamHandlerFactory,
             final HttpVersionPolicy versionPolicy) {
-        this.ioSession = Args.notNull(ioSession, "I/O session");
-        this.http1StreamHandlerFactory = Args.notNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
-        this.http2StreamHandlerFactory = Args.notNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
+        this.ioSession = Objects.requireNonNull(ioSession, "I/O session");
+        this.http1StreamHandlerFactory = Objects.requireNonNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
+        this.http2StreamHandlerFactory = Objects.requireNonNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.protocolHandlerRef = new AtomicReference<>(null);
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiatorFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientHttpProtocolNegotiatorFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http2.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +39,6 @@ import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -61,8 +62,8 @@ public class ClientHttpProtocolNegotiatorFactory implements IOEventHandlerFactor
             final HttpVersionPolicy versionPolicy,
             final TlsStrategy tlsStrategy,
             final Timeout handshakeTimeout) {
-        this.http1StreamHandlerFactory = Args.notNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
-        this.http2StreamHandlerFactory = Args.notNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
+        this.http1StreamHandlerFactory = Objects.requireNonNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
+        this.http2StreamHandlerFactory = Objects.requireNonNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.tlsStrategy = tlsStrategy;
         this.handshakeTimeout = handshakeTimeout;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/FrameInputBuffer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/FrameInputBuffer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http2.impl.nio;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http2.H2ConnectionException;
@@ -62,7 +63,7 @@ public final class FrameInputBuffer {
     private int streamId;
 
     FrameInputBuffer(final BasicH2TransportMetrics metrics, final int bufferLen, final int maxFramePayloadSize) {
-        Args.notNull(metrics, "HTTP2 transport metrcis");
+        Objects.requireNonNull(metrics, "HTTP2 transport metrcis");
         Args.positive(maxFramePayloadSize, "Maximum payload size");
         this.metrics = metrics;
         this.maxFramePayloadSize = Math.max(maxFramePayloadSize, FrameConsts.MIN_FRAME_SIZE);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/FrameOutputBuffer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/FrameOutputBuffer.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.Objects;
 
 import org.apache.hc.core5.http2.H2ConnectionException;
 import org.apache.hc.core5.http2.H2Error;
@@ -51,7 +52,7 @@ public final class FrameOutputBuffer {
     private final ByteBuffer buffer;
 
     public FrameOutputBuffer(final BasicH2TransportMetrics metrics, final int maxFramePayloadSize) {
-        Args.notNull(metrics, "HTTP2 transport metrcis");
+        Objects.requireNonNull(metrics, "HTTP2 transport metrcis");
         Args.positive(maxFramePayloadSize, "Maximum payload size");
         this.metrics = metrics;
         this.maxFramePayloadSize = maxFramePayloadSize;
@@ -63,7 +64,7 @@ public final class FrameOutputBuffer {
     }
 
     public void write(final RawFrame frame, final WritableByteChannel channel) throws IOException {
-        Args.notNull(frame, "Frame");
+        Objects.requireNonNull(frame, "Frame");
 
         final ByteBuffer payload = frame.getPayload();
         if (payload != null && payload.remaining() > maxFramePayloadSize) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/H2OnlyClientProtocolNegotiator.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/H2OnlyClientProtocolNegotiator.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.util.Objects;
 
 import javax.net.ssl.SSLSession;
 
@@ -47,7 +48,6 @@ import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TextUtils;
 import org.apache.hc.core5.util.Timeout;
 
@@ -71,8 +71,8 @@ public class H2OnlyClientProtocolNegotiator implements HttpConnectionEventHandle
             final ProtocolIOSession ioSession,
             final ClientH2StreamMultiplexerFactory http2StreamHandlerFactory,
             final boolean strictALPNHandshake) {
-        this.ioSession = Args.notNull(ioSession, "I/O session");
-        this.http2StreamHandlerFactory = Args.notNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
+        this.ioSession = Objects.requireNonNull(ioSession, "I/O session");
+        this.http2StreamHandlerFactory = Objects.requireNonNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
         this.strictALPNHandshake = strictALPNHandshake;
         this.preface = ByteBuffer.wrap(ClientHttpProtocolNegotiator.PREFACE);
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http2.impl.nio;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.http.Header;
@@ -50,7 +51,6 @@ import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.http2.frame.StreamIdGenerator;
 import org.apache.hc.core5.http2.hpack.HeaderListConstraintException;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 
 /**
  * I/O event handler for events fired by {@link ProtocolIOSession} that implements
@@ -73,7 +73,7 @@ public class ServerH2StreamMultiplexer extends AbstractH2StreamMultiplexer {
             final H2Config h2Config,
             final H2StreamListener streamListener) {
         super(ioSession, frameFactory, StreamIdGenerator.EVEN, httpProcessor, charCodingConfig, h2Config, streamListener);
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Handler factory");
+        this.exchangeHandlerFactory = Objects.requireNonNull(exchangeHandlerFactory, "Handler factory");
     }
 
     public ServerH2StreamMultiplexer(

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexerFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http2.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +39,6 @@ import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.http2.frame.DefaultFrameFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link ServerH2StreamMultiplexer} factory.
@@ -60,8 +61,8 @@ public final class ServerH2StreamMultiplexerFactory {
             final H2Config h2Config,
             final CharCodingConfig charCodingConfig,
             final H2StreamListener streamListener) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
+        this.exchangeHandlerFactory = Objects.requireNonNull(exchangeHandlerFactory, "Exchange handler factory");
         this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.streamListener = streamListener;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiator.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiator.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http2.impl.nio;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLSession;
@@ -53,7 +54,6 @@ import org.apache.hc.core5.io.SocketTimeoutExceptionFactory;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -82,9 +82,9 @@ public class ServerHttpProtocolNegotiator implements HttpConnectionEventHandler 
             final ServerHttp1StreamDuplexerFactory http1StreamHandlerFactory,
             final ServerH2StreamMultiplexerFactory http2StreamHandlerFactory,
             final HttpVersionPolicy versionPolicy) {
-        this.ioSession = Args.notNull(ioSession, "I/O session");
-        this.http1StreamHandlerFactory = Args.notNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
-        this.http2StreamHandlerFactory = Args.notNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
+        this.ioSession = Objects.requireNonNull(ioSession, "I/O session");
+        this.http1StreamHandlerFactory = Objects.requireNonNull(http1StreamHandlerFactory, "HTTP/1.1 stream handler factory");
+        this.http2StreamHandlerFactory = Objects.requireNonNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.inBuf = BufferedData.allocate(1024);
         this.protocolHandlerRef = new AtomicReference<>(null);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiatorFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerHttpProtocolNegotiatorFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http2.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -35,7 +37,6 @@ import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -59,8 +60,8 @@ public class ServerHttpProtocolNegotiatorFactory implements IOEventHandlerFactor
             final HttpVersionPolicy versionPolicy,
             final TlsStrategy tlsStrategy,
             final Timeout handshakeTimeout) {
-        this.http1StreamDuplexerFactory = Args.notNull(http1StreamDuplexerFactory, "HTTP/1.1 stream handler factory");
-        this.http2StreamMultiplexerFactory = Args.notNull(http2StreamMultiplexerFactory, "HTTP/2 stream handler factory");
+        this.http1StreamDuplexerFactory = Objects.requireNonNull(http1StreamDuplexerFactory, "HTTP/1.1 stream handler factory");
+        this.http2StreamMultiplexerFactory = Objects.requireNonNull(http2StreamMultiplexerFactory, "HTTP/2 stream handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.tlsStrategy = tlsStrategy;
         this.handshakeTimeout = handshakeTimeout;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequester.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequester.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
 
@@ -73,7 +74,6 @@ import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -124,9 +124,9 @@ public class H2MultiplexingRequester extends AsyncRequester{
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
             final Timeout timeout,
             final HttpContext context) {
-        Args.notNull(exchangeHandler, "Exchange handler");
-        Args.notNull(timeout, "Timeout");
-        Args.notNull(context, "Context");
+        Objects.requireNonNull(exchangeHandler, "Exchange handler");
+        Objects.requireNonNull(timeout, "Timeout");
+        Objects.requireNonNull(context, "Context");
         final CancellableExecution cancellableExecution = new CancellableExecution();
         execute(exchangeHandler, pushHandlerFactory, cancellableExecution, timeout, context);
         return cancellableExecution;
@@ -145,9 +145,9 @@ public class H2MultiplexingRequester extends AsyncRequester{
             final CancellableDependency cancellableDependency,
             final Timeout timeout,
             final HttpContext context) {
-        Args.notNull(exchangeHandler, "Exchange handler");
-        Args.notNull(timeout, "Timeout");
-        Args.notNull(context, "Context");
+        Objects.requireNonNull(exchangeHandler, "Exchange handler");
+        Objects.requireNonNull(timeout, "Timeout");
+        Objects.requireNonNull(context, "Context");
         try {
             exchangeHandler.produceRequest(new RequestChannel() {
 
@@ -256,9 +256,9 @@ public class H2MultiplexingRequester extends AsyncRequester{
             final Timeout timeout,
             final HttpContext context,
             final FutureCallback<T> callback) {
-        Args.notNull(requestProducer, "Request producer");
-        Args.notNull(responseConsumer, "Response consumer");
-        Args.notNull(timeout, "Timeout");
+        Objects.requireNonNull(requestProducer, "Request producer");
+        Objects.requireNonNull(responseConsumer, "Response consumer");
+        Objects.requireNonNull(timeout, "Timeout");
         final ComplexFuture<T> future = new ComplexFuture<>(callback);
         final AsyncClientExchangeHandler exchangeHandler = new BasicClientExchangeHandler<>(requestProducer, responseConsumer, new FutureCallback<T>() {
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequesterBootstrap.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http2.impl.nio.bootstrap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Decorator;
@@ -176,7 +177,7 @@ public class H2MultiplexingRequesterBootstrap {
      */
     public final H2MultiplexingRequesterBootstrap register(final String uriPattern, final Supplier<AsyncPushConsumer> supplier) {
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         pushConsumerList.add(new HandlerEntry<>(null, uriPattern, supplier));
         return this;
     }
@@ -192,7 +193,7 @@ public class H2MultiplexingRequesterBootstrap {
     public final H2MultiplexingRequesterBootstrap registerVirtual(final String hostname, final String uriPattern, final Supplier<AsyncPushConsumer> supplier) {
         Args.notBlank(hostname, "Hostname");
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         pushConsumerList.add(new HandlerEntry<>(hostname, uriPattern, supplier));
         return this;
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http2.impl.nio.bootstrap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.function.Callback;
@@ -262,7 +263,7 @@ public class H2RequesterBootstrap {
      */
     public final H2RequesterBootstrap register(final String uriPattern, final Supplier<AsyncPushConsumer> supplier) {
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         pushConsumerList.add(new HandlerEntry<>(null, uriPattern, supplier));
         return this;
     }
@@ -278,7 +279,7 @@ public class H2RequesterBootstrap {
     public final H2RequesterBootstrap registerVirtual(final String hostname, final String uriPattern, final Supplier<AsyncPushConsumer> supplier) {
         Args.notBlank(hostname, "Hostname");
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         pushConsumerList.add(new HandlerEntry<>(hostname, uriPattern, supplier));
         return this;
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http2.impl.nio.bootstrap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Decorator;
@@ -237,7 +238,7 @@ public class H2ServerBootstrap {
      */
     public final H2ServerBootstrap register(final String uriPattern, final Supplier<AsyncServerExchangeHandler> supplier) {
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         handlerList.add(new HandlerEntry<>(null, uriPattern, supplier));
         return this;
     }
@@ -253,7 +254,7 @@ public class H2ServerBootstrap {
     public final H2ServerBootstrap registerVirtual(final String hostname, final String uriPattern, final Supplier<AsyncServerExchangeHandler> supplier) {
         Args.notBlank(hostname, "Hostname");
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         handlerList.add(new HandlerEntry<>(hostname, uriPattern, supplier));
         return this;
     }
@@ -308,7 +309,7 @@ public class H2ServerBootstrap {
     public final H2ServerBootstrap addFilterBefore(final String existing, final String name, final AsyncFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
         Args.notBlank(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.BEFORE, name, filterHandler, existing));
         return this;
     }
@@ -319,7 +320,7 @@ public class H2ServerBootstrap {
     public final H2ServerBootstrap addFilterAfter(final String existing, final String name, final AsyncFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
         Args.notBlank(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.AFTER, name, filterHandler, existing));
         return this;
     }
@@ -329,7 +330,7 @@ public class H2ServerBootstrap {
      */
     public final H2ServerBootstrap replaceFilter(final String existing, final AsyncFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.REPLACE, existing, filterHandler, existing));
         return this;
     }
@@ -338,8 +339,8 @@ public class H2ServerBootstrap {
      * Add an filter to the head of the processing list.
      */
     public final H2ServerBootstrap addFilterFirst(final String name, final AsyncFilterHandler filterHandler) {
-        Args.notNull(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(name, "Name");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.FIRST, name, filterHandler, null));
         return this;
     }
@@ -348,8 +349,8 @@ public class H2ServerBootstrap {
      * Add an filter to the tail of the processing list.
      */
     public final H2ServerBootstrap addFilterLast(final String name, final AsyncFilterHandler filterHandler) {
-        Args.notNull(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(name, "Name");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.LAST, name, filterHandler, null));
         return this;
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/command/PingCommand.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/command/PingCommand.java
@@ -27,10 +27,11 @@
 
 package org.apache.hc.core5.http2.nio.command;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.http2.nio.AsyncPingHandler;
 import org.apache.hc.core5.reactor.Command;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 ping command.
@@ -43,7 +44,7 @@ public final class PingCommand implements Command {
     private final AsyncPingHandler handler;
 
     public PingCommand(final AsyncPingHandler handler) {
-        this.handler = Args.notNull(handler, "Handler");
+        this.handler = Objects.requireNonNull(handler, "Handler");
     }
 
     public AsyncPingHandler getHandler() {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.http2.nio.pool;
 
 import java.net.InetSocketAddress;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -47,7 +48,6 @@ import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.ConnectionInitiator;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -70,7 +70,7 @@ public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
             final Resolver<HttpHost, InetSocketAddress> addressResolver,
             final TlsStrategy tlsStrategy) {
         super();
-        this.connectionInitiator = Args.notNull(connectionInitiator, "Connection initiator");
+        this.connectionInitiator = Objects.requireNonNull(connectionInitiator, "Connection initiator");
         this.addressResolver = addressResolver != null ? addressResolver : DefaultAddressResolver.INSTANCE;
         this.tlsStrategy = tlsStrategy;
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/support/BasicPingHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/support/BasicPingHandler.java
@@ -28,11 +28,11 @@ package org.apache.hc.core5.http2.nio.support;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http2.nio.AsyncPingHandler;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic {@link AsyncPingHandler} implementation.
@@ -46,7 +46,7 @@ public class BasicPingHandler implements AsyncPingHandler {
     private final Callback<Boolean> callback;
 
     public BasicPingHandler(final Callback<Boolean> callback) {
-        this.callback = Args.notNull(callback, "Callback");
+        this.callback = Objects.requireNonNull(callback, "Callback");
     }
 
     @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/support/DefaultAsyncPushConsumerFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/support/DefaultAsyncPushConsumerFactory.java
@@ -26,6 +26,8 @@
  */
 package org.apache.hc.core5.http2.nio.support;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
@@ -34,7 +36,6 @@ import org.apache.hc.core5.http.MisdirectedRequestException;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Factory for {@link AsyncPushConsumer} instances that make use
@@ -48,7 +49,7 @@ public final class DefaultAsyncPushConsumerFactory implements HandlerFactory<Asy
     private final HttpRequestMapper<Supplier<AsyncPushConsumer>> mapper;
 
     public DefaultAsyncPushConsumerFactory(final HttpRequestMapper<Supplier<AsyncPushConsumer>> mapper) {
-        this.mapper = Args.notNull(mapper, "Request handler mapper");
+        this.mapper = Objects.requireNonNull(mapper, "Request handler mapper");
     }
 
     @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestConnControl.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestConnControl.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.RequestConnControl;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestConnControl}.
@@ -52,7 +52,7 @@ public class H2RequestConnControl extends RequestConnControl {
             final HttpRequest request,
             final EntityDetails entity,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion ver = context.getProtocolVersion();
         if (ver.getMajor() < 2) {
             super.process(request, entity, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestContent.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestContent.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -40,7 +41,6 @@ import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.RequestContent;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestContent}.
@@ -63,7 +63,7 @@ public class H2RequestContent extends RequestContent {
             final HttpRequest request,
             final EntityDetails entity,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion ver = context.getProtocolVersion();
         if (ver.getMajor() < 2) {
             super.process(request, entity, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestTargetHost.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestTargetHost.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.RequestTargetHost;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestTargetHost}.
@@ -52,7 +52,7 @@ public class H2RequestTargetHost extends RequestTargetHost {
             final HttpRequest request,
             final EntityDetails entity,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion ver = context.getProtocolVersion();
         if (ver.getMajor() < 2) {
             super.process(request, entity, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestValidateHost.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestValidateHost.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.RequestValidateHost;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestValidateHost}.
@@ -52,7 +52,7 @@ public class H2RequestValidateHost extends RequestValidateHost {
             final HttpRequest request,
             final EntityDetails entity,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion ver = context.getProtocolVersion();
         if (ver.getMajor() < 2) {
             super.process(request, entity, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseConnControl.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseConnControl.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.ResponseConnControl;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link ResponseConnControl}.
@@ -52,7 +52,7 @@ public class H2ResponseConnControl extends ResponseConnControl {
             final HttpResponse response,
             final EntityDetails entity,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion ver = context.getProtocolVersion();
         if (ver.getMajor() < 2) {
             super.process(response, entity, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseContent.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseContent.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -38,7 +39,6 @@ import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.ResponseContent;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link ResponseContent}.
@@ -61,7 +61,7 @@ public class H2ResponseContent extends ResponseContent {
             final HttpResponse response,
             final EntityDetails entity,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion ver = context.getProtocolVersion();
         if (ver.getMajor() < 2) {
             super.process(response, entity, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptClientTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptClientTlsStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.ssl;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -38,7 +39,6 @@ import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -59,7 +59,7 @@ public class ConscryptClientTlsStrategy implements TlsStrategy {
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
             final SSLSessionVerifier verifier) {
-        this.sslContext = Args.notNull(sslContext, "SSL context");
+        this.sslContext = Objects.requireNonNull(sslContext, "SSL context");
         this.sslBufferMode = sslBufferMode;
         this.initializer = initializer;
         this.verifier = verifier;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptServerTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptServerTlsStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.ssl;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -39,7 +40,6 @@ import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -62,7 +62,7 @@ public class ConscryptServerTlsStrategy implements TlsStrategy {
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
             final SSLSessionVerifier verifier) {
-        this.sslContext = Args.notNull(sslContext, "SSL context");
+        this.sslContext = Objects.requireNonNull(sslContext, "SSL context");
         this.securePortStrategy = securePortStrategy;
         this.sslBufferMode = sslBufferMode;
         this.initializer = initializer;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ClientTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ClientTlsStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.ssl;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -39,7 +40,6 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -60,7 +60,7 @@ public class H2ClientTlsStrategy implements TlsStrategy {
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
             final SSLSessionVerifier verifier) {
-        this.sslContext = Args.notNull(sslContext, "SSL context");
+        this.sslContext = Objects.requireNonNull(sslContext, "SSL context");
         this.sslBufferMode = sslBufferMode;
         this.initializer = initializer;
         this.verifier = verifier;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ServerTlsStrategy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2ServerTlsStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http2.ssl;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -40,7 +41,6 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -63,7 +63,7 @@ public class H2ServerTlsStrategy implements TlsStrategy {
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
             final SSLSessionVerifier verifier) {
-        this.sslContext = Args.notNull(sslContext, "SSL context");
+        this.sslContext = Objects.requireNonNull(sslContext, "SSL context");
         this.securePortStrategy = securePortStrategy;
         this.sslBufferMode = sslBufferMode;
         this.initializer = initializer;

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.reactive;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,7 +42,6 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpStreamResetException;
 import org.apache.hc.core5.http.nio.AsyncDataConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
-import org.apache.hc.core5.util.Args;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -160,7 +160,7 @@ final class ReactiveDataConsumer implements AsyncDataConsumer, Publisher<ByteBuf
 
     @Override
     public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
-        this.subscriber = Args.notNull(subscriber, "subscriber");
+        this.subscriber = Objects.requireNonNull(subscriber, "subscriber");
         subscriber.onSubscribe(new Subscription() {
             @Override
             public void request(final long increment) {

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataProducer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataProducer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.reactive;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -37,7 +38,6 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpStreamResetException;
 import org.apache.hc.core5.http.nio.AsyncDataProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
-import org.apache.hc.core5.util.Args;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -60,7 +60,7 @@ final class ReactiveDataProducer implements AsyncDataProducer, Subscriber<ByteBu
     private final ArrayDeque<ByteBuffer> buffers = new ArrayDeque<>(); // This field requires synchronization
 
     public ReactiveDataProducer(final Publisher<ByteBuffer> publisher) {
-        this.publisher = Args.notNull(publisher, "publisher");
+        this.publisher = Objects.requireNonNull(publisher, "publisher");
     }
 
     void setChannel(final DataStreamChannel channel) {

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -44,7 +45,6 @@ import org.apache.hc.core5.http.Message;
 import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 import org.reactivestreams.Publisher;
 
 /**
@@ -81,7 +81,7 @@ public final class ReactiveResponseConsumer implements AsyncResponseConsumer<Voi
      * @param responseCallback the callback to invoke when the response is available for consumption.
      */
     public ReactiveResponseConsumer(final FutureCallback<Message<HttpResponse, Publisher<ByteBuffer>>> responseCallback) {
-        this.responseFuture = new BasicFuture<>(Args.notNull(responseCallback, "responseCallback"));
+        this.responseFuture = new BasicFuture<>(Objects.requireNonNull(responseCallback, "responseCallback"));
     }
 
     public Future<Message<HttpResponse, Publisher<ByteBuffer>>> getResponseFuture() {

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/BenchmarkConfig.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/BenchmarkConfig.java
@@ -29,9 +29,9 @@ package org.apache.hc.core5.benchmark;
 import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -236,7 +236,7 @@ public class BenchmarkConfig {
     }
 
     public static BenchmarkConfig.Builder copy(final BenchmarkConfig config) {
-        Args.notNull(config, "Socket config");
+        Objects.requireNonNull(config, "Socket config");
         return new Builder()
                 .setUri(config.getUri())
                 .setRequests(config.getRequests())

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/AsyncRequester.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/AsyncRequester.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.testing.nio;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 
@@ -43,7 +44,6 @@ import org.apache.hc.core5.reactor.DefaultConnectingIOReactor;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 public class AsyncRequester extends IOReactorExecutor<DefaultConnectingIOReactor> implements ConnectionInitiator {
@@ -83,7 +83,7 @@ public class AsyncRequester extends IOReactorExecutor<DefaultConnectingIOReactor
     }
 
     public Future<IOSession> requestSession(final HttpHost host, final Timeout timeout, final FutureCallback<IOSession> callback) {
-        Args.notNull(host, "Host");
+        Objects.requireNonNull(host, "Host");
         return reactor().connect(host, toSocketAddress(host), null, timeout, null, callback);
     }
 

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/H2TestClient.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/H2TestClient.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.testing.nio;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import javax.net.ssl.SSLContext;
@@ -50,7 +51,6 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 public class H2TestClient extends AsyncRequester {
@@ -77,8 +77,8 @@ public class H2TestClient extends AsyncRequester {
     }
 
     public void register(final String uriPattern, final Supplier<AsyncPushConsumer> supplier) {
-        Args.notNull(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(uriPattern, "URI pattern");
+        Objects.requireNonNull(supplier, "Supplier");
         registry.register(null, uriPattern, supplier);
     }
 

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/IOReactorExecutor.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/IOReactorExecutor.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.testing.nio;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,7 +40,6 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOReactorService;
 import org.apache.hc.core5.reactor.IOReactorStatus;
 import org.apache.hc.core5.reactor.IOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.TimeValue;
 
@@ -67,7 +67,7 @@ abstract class IOReactorExecutor<T extends IOReactorService> implements AutoClos
             Callback<IOSession> sessionShutdownCallback) throws IOException;
 
     protected void execute(final IOEventHandlerFactory ioEventHandlerFactory) throws IOException {
-        Args.notNull(ioEventHandlerFactory, "Handler factory");
+        Objects.requireNonNull(ioEventHandlerFactory, "Handler factory");
         if (ioReactorRef.compareAndSet(null, createIOReactor(
                 ioEventHandlerFactory,
                 ioReactorConfig,
@@ -97,7 +97,7 @@ abstract class IOReactorExecutor<T extends IOReactorService> implements AutoClos
     }
 
     public void awaitShutdown(final TimeValue waitTime) throws InterruptedException {
-        Args.notNull(waitTime, "Wait time");
+        Objects.requireNonNull(waitTime, "Wait time");
         final T ioReactor = ioReactorRef.get();
         if (ioReactor != null) {
             ioReactor.awaitShutdown(waitTime);
@@ -114,7 +114,7 @@ abstract class IOReactorExecutor<T extends IOReactorService> implements AutoClos
     }
 
     public void shutdown(final TimeValue graceTime) {
-        Args.notNull(graceTime, "Grace time");
+        Objects.requireNonNull(graceTime, "Grace time");
         final T ioReactor = ioReactorRef.get();
         if (ioReactor != null) {
             if (status.compareAndSet(Status.RUNNING, Status.TERMINATED)) {

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientH2EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientH2EventHandlerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.testing.nio;
 
+import java.util.Objects;
+
 import javax.net.ssl.SSLContext;
 
 import org.apache.hc.core5.http.config.CharCodingConfig;
@@ -46,7 +48,6 @@ import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
-import org.apache.hc.core5.util.Args;
 
 class InternalClientH2EventHandlerFactory implements IOEventHandlerFactory {
 
@@ -70,7 +71,7 @@ class InternalClientH2EventHandlerFactory implements IOEventHandlerFactory {
             final SSLContext sslContext,
             final SSLSessionInitializer sslSessionInitializer,
             final SSLSessionVerifier sslSessionVerifier) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
         this.exchangeHandlerFactory = exchangeHandlerFactory;
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientHttp1EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalClientHttp1EventHandlerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.testing.nio;
 
+import java.util.Objects;
+
 import javax.net.ssl.SSLContext;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -54,7 +56,6 @@ import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
-import org.apache.hc.core5.util.Args;
 
 /**
  * @since 5.0
@@ -80,7 +81,7 @@ class InternalClientHttp1EventHandlerFactory implements IOEventHandlerFactory {
             final SSLContext sslContext,
             final SSLSessionInitializer sslSessionInitializer,
             final SSLSessionVerifier sslSessionVerifier) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerH2EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerH2EventHandlerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.testing.nio;
 
+import java.util.Objects;
+
 import javax.net.ssl.SSLContext;
 
 import org.apache.hc.core5.http.config.CharCodingConfig;
@@ -46,7 +48,6 @@ import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
-import org.apache.hc.core5.util.Args;
 
 class InternalServerH2EventHandlerFactory implements IOEventHandlerFactory {
 
@@ -70,8 +71,8 @@ class InternalServerH2EventHandlerFactory implements IOEventHandlerFactory {
             final SSLContext sslContext,
             final SSLSessionInitializer sslSessionInitializer,
             final SSLSessionVerifier sslSessionVerifier) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
+        this.exchangeHandlerFactory = Objects.requireNonNull(exchangeHandlerFactory, "Exchange handler factory");
         this.versionPolicy = versionPolicy != null ? versionPolicy : HttpVersionPolicy.NEGOTIATE;
         this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp1EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp1EventHandlerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.testing.nio;
 
+import java.util.Objects;
+
 import javax.net.ssl.SSLContext;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -57,7 +59,6 @@ import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
-import org.apache.hc.core5.util.Args;
 
 /**
  * @since 5.0
@@ -85,8 +86,8 @@ class InternalServerHttp1EventHandlerFactory implements IOEventHandlerFactory {
             final SSLContext sslContext,
             final SSLSessionInitializer sslSessionInitializer,
             final SSLSessionVerifier sslSessionVerifier) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
+        this.exchangeHandlerFactory = Objects.requireNonNull(exchangeHandlerFactory, "Exchange handler factory");
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/BasicFuture.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/BasicFuture.java
@@ -26,13 +26,13 @@
  */
 package org.apache.hc.core5.concurrent;
 
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeoutValueException;
 
 /**
@@ -88,7 +88,7 @@ public class BasicFuture<T> implements Future<T>, Cancellable {
     @Override
     public synchronized T get(final long timeout, final TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        Args.notNull(unit, "Time unit");
+        Objects.requireNonNull(unit, "Time unit");
         final long msecs = unit.toMillis(timeout);
         final long startTime = (msecs <= 0) ? 0 : System.currentTimeMillis();
         long waitTime = msecs;

--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexCancellable.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexCancellable.java
@@ -26,9 +26,8 @@
  */
 package org.apache.hc.core5.concurrent;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicMarkableReference;
-
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link Cancellable} that has a dependency on another {@link Cancellable}
@@ -52,7 +51,7 @@ public final class ComplexCancellable implements CancellableDependency {
 
     @Override
     public void setDependency(final Cancellable dependency) {
-        Args.notNull(dependency, "dependency");
+        Objects.requireNonNull(dependency, "dependency");
         final Cancellable actualDependency = dependencyRef.getReference();
         if (!dependencyRef.compareAndSet(actualDependency, dependency, false, false)) {
             dependency.cancel();

--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexFuture.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexFuture.java
@@ -26,10 +26,9 @@
  */
 package org.apache.hc.core5.concurrent;
 
+import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
-
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link Future} whose result depends on another {@link Cancellable} process
@@ -50,7 +49,7 @@ public final class ComplexFuture<T> extends BasicFuture<T> implements Cancellabl
 
     @Override
     public void setDependency(final Cancellable dependency) {
-        Args.notNull(dependency, "dependency");
+        Objects.requireNonNull(dependency, "dependency");
         if (isDone()) {
             dependency.cancel();
         } else {
@@ -59,7 +58,7 @@ public final class ComplexFuture<T> extends BasicFuture<T> implements Cancellabl
     }
 
     public void setDependency(final Future<?> dependency) {
-        Args.notNull(dependency, "dependency");
+        Objects.requireNonNull(dependency, "dependency");
         if (dependency instanceof Cancellable) {
             setDependency((Cancellable) dependency);
         } else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHost.java
@@ -32,6 +32,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -224,7 +225,7 @@ public final class HttpHost implements NamedEndpoint, Serializable {
      * @since 5.0
      */
     public HttpHost(final String scheme, final InetAddress address, final int port) {
-        this(scheme, Args.notNull(address,"Inet address"), address.getHostName(), port);
+        this(scheme, Objects.requireNonNull(address, "Inet address"), address.getHostName(), port);
     }
 
     /**
@@ -269,7 +270,7 @@ public final class HttpHost implements NamedEndpoint, Serializable {
      * @since 5.0
      */
     public HttpHost(final String scheme, final NamedEndpoint namedEndpoint) {
-        this(scheme, Args.notNull(namedEndpoint, "Named endpoint").getHostName(), namedEndpoint.getPort());
+        this(scheme, Objects.requireNonNull(namedEndpoint, "Named endpoint").getHostName(), namedEndpoint.getPort());
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Message.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Message.java
@@ -27,7 +27,7 @@
 
 package org.apache.hc.core5.http;
 
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * Generic message consisting of a message head and a message body.
@@ -43,7 +43,7 @@ public final class Message<H extends MessageHeaders, B> {
     private final B body;
 
     public Message(final H head, final B body) {
-        this.head = Args.notNull(head, "Message head");
+        this.head = Objects.requireNonNull(head, "Message head");
         this.body = body;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -28,8 +28,7 @@
 package org.apache.hc.core5.http;
 
 import java.util.Locale;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * Common HTTP methods defined by the HTTP spec.
@@ -93,7 +92,7 @@ public enum Method {
      * @return the Method for the given method name.
      */
     public static Method normalizedValueOf(final String method) {
-        return valueOf(Args.notNull(method, "method").toUpperCase(Locale.ROOT));
+        return valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
     }
 
     public boolean isSame(final String value) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ProtocolVersion.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ProtocolVersion.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -68,7 +69,7 @@ public class ProtocolVersion implements Serializable {
      * @param minor      the minor version number of the protocol
      */
     public ProtocolVersion(final String protocol, final int major, final int minor) {
-        this.protocol = Args.notNull(protocol, "Protocol name");
+        this.protocol = Objects.requireNonNull(protocol, "Protocol name");
         this.major = Args.notNegative(major, "Protocol minor version");
         this.minor = Args.notNegative(minor, "Protocol minor version");
     }
@@ -199,7 +200,7 @@ public class ProtocolVersion implements Serializable {
      *         or if the argument is {@code null}
      */
     public int compareToVersion(final ProtocolVersion that) {
-        Args.notNull(that, "Protocol version");
+        Objects.requireNonNull(that, "Protocol version");
         Args.check(this.protocol.equals(that.protocol),
                 "Versions for different protocols cannot be compared: %s %s", this, that);
         int delta = getMajor() - that.getMajor();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/CharCodingConfig.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/CharCodingConfig.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.http.config;
 import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/1.1 char coding configuration.
@@ -86,7 +86,7 @@ public class CharCodingConfig {
     }
 
     public static CharCodingConfig.Builder copy(final CharCodingConfig config) {
-        Args.notNull(config, "Config");
+        Objects.requireNonNull(config, "Config");
         return new Builder()
             .setCharset(config.getCharset())
             .setMalformedInputAction(config.getMalformedInputAction())

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
@@ -27,7 +27,8 @@
 
 package org.apache.hc.core5.http.config;
 
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
+
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -112,7 +113,7 @@ public class Http1Config {
     }
 
     public static Http1Config.Builder copy(final Http1Config config) {
-        Args.notNull(config, "Config");
+        Objects.requireNonNull(config, "Config");
         return new Builder()
                 .setBufferSize(config.getBufferSize())
                 .setChunkSizeHint(config.getChunkSizeHint())

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/NamedElementChain.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/NamedElementChain.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.config;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -58,7 +60,7 @@ public class NamedElementChain<E> {
 
     public Node addFirst(final E value, final String name) {
         Args.notBlank(name, "Name");
-        Args.notNull(value, "Value");
+        Objects.requireNonNull(value, "Value");
         final Node newNode = new Node(name, value);
         final Node oldNode = master.next;
         master.next = newNode;
@@ -71,7 +73,7 @@ public class NamedElementChain<E> {
 
     public Node addLast(final E value, final String name) {
         Args.notBlank(name, "Name");
-        Args.notNull(value, "Value");
+        Objects.requireNonNull(value, "Value");
         final Node newNode = new Node(name, value);
         final Node oldNode = master.previous;
         master.previous = newNode;
@@ -100,7 +102,7 @@ public class NamedElementChain<E> {
 
     public Node addBefore(final String existing, final E value, final String name) {
         Args.notBlank(name, "Name");
-        Args.notNull(value, "Value");
+        Objects.requireNonNull(value, "Value");
         final Node current = doFind(existing);
         if (current == null) {
             return null;
@@ -117,7 +119,7 @@ public class NamedElementChain<E> {
 
     public Node addAfter(final String existing, final E value, final String name) {
         Args.notBlank(name, "Name");
-        Args.notNull(value, "Value");
+        Objects.requireNonNull(value, "Value");
         final Node current = doFind(existing);
         if (current == null) {
             return null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/RegistryBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/RegistryBuilder.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.config;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.hc.core5.util.Args;
 
@@ -53,7 +54,7 @@ public final class RegistryBuilder<I> {
 
     public RegistryBuilder<I> register(final String id, final I item) {
         Args.notEmpty(id, "ID");
-        Args.notNull(item, "Item");
+        Objects.requireNonNull(item, "Item");
         items.put(id.toLowerCase(Locale.ROOT), item);
         return this;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultConnectionReuseStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultConnectionReuseStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -43,7 +44,6 @@ import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.BasicTokenIterator;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default implementation of a strategy deciding about connection re-use. The strategy
@@ -78,7 +78,7 @@ public class DefaultConnectionReuseStrategy implements ConnectionReuseStrategy {
     @Override
     public boolean keepAlive(
             final HttpRequest request, final HttpResponse response, final HttpContext context) {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
 
         if (request != null) {
             final Iterator<String> ti = new BasicTokenIterator(request.headerIterator(HttpHeaders.CONNECTION));

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultContentLengthStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultContentLengthStrategy.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentLengthStrategy;
@@ -37,7 +39,6 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpMessage;
 import org.apache.hc.core5.http.NotImplementedException;
 import org.apache.hc.core5.http.ProtocolException;
-import org.apache.hc.core5.util.Args;
 
 /**
  * The default implementation of the content length strategy. This class
@@ -63,7 +64,7 @@ public class DefaultContentLengthStrategy implements ContentLengthStrategy {
 
     @Override
     public long determineLength(final HttpMessage message) throws HttpException {
-        Args.notNull(message, "HTTP message");
+        Objects.requireNonNull(message, "HTTP message");
         // Although Transfer-Encoding is specified as a list, in practice
         // it is either missing or has the single value "chunked". So we
         // treat it as a single-valued header here.

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/IncomingEntityDetails.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/IncomingEntityDetails.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Internal;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.MessageHeaders;
 import org.apache.hc.core5.http.message.MessageSupport;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP message entity details.
@@ -50,7 +50,7 @@ public class IncomingEntityDetails implements EntityDetails {
     private final long contentLength;
 
     public IncomingEntityDetails(final MessageHeaders message, final long contentLength) {
-        this.message = Args.notNull(message, "Message");
+        this.message = Objects.requireNonNull(message, "Message");
         this.contentLength = contentLength;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncRequester.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncRequester.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.core5.annotation.Internal;
@@ -48,7 +49,6 @@ import org.apache.hc.core5.reactor.IOReactorService;
 import org.apache.hc.core5.reactor.IOReactorStatus;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -92,8 +92,8 @@ public class AsyncRequester extends AbstractConnectionInitiatorBase implements I
             final Timeout timeout,
             final Object attachment,
             final FutureCallback<IOSession> callback) {
-        Args.notNull(host, "Host");
-        Args.notNull(timeout, "Timeout");
+        Objects.requireNonNull(host, "Host");
+        Objects.requireNonNull(timeout, "Timeout");
         return connect(host, addressResolver.resolve(host), null, timeout, attachment, callback);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Decorator;
@@ -215,7 +216,7 @@ public class AsyncServerBootstrap {
      */
     public final AsyncServerBootstrap register(final String uriPattern, final Supplier<AsyncServerExchangeHandler> supplier) {
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         handlerList.add(new HandlerEntry<>(null, uriPattern, supplier));
         return this;
     }
@@ -231,7 +232,7 @@ public class AsyncServerBootstrap {
     public final AsyncServerBootstrap registerVirtual(final String hostname, final String uriPattern, final Supplier<AsyncServerExchangeHandler> supplier) {
         Args.notBlank(hostname, "Hostname");
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(supplier, "Supplier");
+        Objects.requireNonNull(supplier, "Supplier");
         handlerList.add(new HandlerEntry<>(hostname, uriPattern, supplier));
         return this;
     }
@@ -286,7 +287,7 @@ public class AsyncServerBootstrap {
     public final AsyncServerBootstrap addFilterBefore(final String existing, final String name, final AsyncFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
         Args.notBlank(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.BEFORE, name, filterHandler, existing));
         return this;
     }
@@ -297,7 +298,7 @@ public class AsyncServerBootstrap {
     public final AsyncServerBootstrap addFilterAfter(final String existing, final String name, final AsyncFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
         Args.notBlank(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.AFTER, name, filterHandler, existing));
         return this;
     }
@@ -307,7 +308,7 @@ public class AsyncServerBootstrap {
      */
     public final AsyncServerBootstrap replaceFilter(final String existing, final AsyncFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.REPLACE, existing, filterHandler, existing));
         return this;
     }
@@ -316,8 +317,8 @@ public class AsyncServerBootstrap {
      * Add an filter to the head of the processing list.
      */
     public final AsyncServerBootstrap addFilterFirst(final String name, final AsyncFilterHandler filterHandler) {
-        Args.notNull(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(name, "Name");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.FIRST, name, filterHandler, null));
         return this;
     }
@@ -326,8 +327,8 @@ public class AsyncServerBootstrap {
      * Add an filter to the tail of the processing list.
      */
     public final AsyncServerBootstrap addFilterLast(final String name, final AsyncFilterHandler filterHandler) {
-        Args.notNull(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(name, "Name");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.LAST, name, filterHandler, null));
         return this;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
@@ -74,7 +75,6 @@ import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.IOSessionListener;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -100,7 +100,7 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             final ManagedConnPool<HttpHost, IOSession> connPool) {
         super(eventHandlerFactory, ioReactorConfig, ioSessionDecorator, exceptionCallback, sessionListener,
                         ShutdownCommand.GRACEFUL_IMMEDIATE_CALLBACK, DefaultAddressResolver.INSTANCE);
-        this.connPool = Args.notNull(connPool, "Connection pool");
+        this.connPool = Objects.requireNonNull(connPool, "Connection pool");
     }
 
     @Override
@@ -171,8 +171,8 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             final Timeout timeout,
             final Object attachment,
             final FutureCallback<AsyncClientEndpoint> callback) {
-        Args.notNull(host, "Host");
-        Args.notNull(timeout, "Timeout");
+        Objects.requireNonNull(host, "Host");
+        Objects.requireNonNull(timeout, "Timeout");
         final ComplexFuture<AsyncClientEndpoint> resultFuture = new ComplexFuture<>(callback);
         final Future<PoolEntry<HttpHost, IOSession>> leaseFuture = connPool.lease(
                 host, null, timeout, new FutureCallback<PoolEntry<HttpHost, IOSession>>() {
@@ -243,9 +243,9 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
             final Timeout timeout,
             final HttpContext executeContext) {
-        Args.notNull(exchangeHandler, "Exchange handler");
-        Args.notNull(timeout, "Timeout");
-        Args.notNull(executeContext, "Context");
+        Objects.requireNonNull(exchangeHandler, "Exchange handler");
+        Objects.requireNonNull(timeout, "Timeout");
+        Objects.requireNonNull(executeContext, "Context");
         try {
             exchangeHandler.produceRequest(new RequestChannel() {
 
@@ -367,9 +367,9 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
             final Timeout timeout,
             final HttpContext context,
             final FutureCallback<T> callback) {
-        Args.notNull(requestProducer, "Request producer");
-        Args.notNull(responseConsumer, "Response consumer");
-        Args.notNull(timeout, "Timeout");
+        Objects.requireNonNull(requestProducer, "Request producer");
+        Objects.requireNonNull(responseConsumer, "Response consumer");
+        Objects.requireNonNull(timeout, "Timeout");
         final BasicFuture<T> future = new BasicFuture<>(callback);
         final AsyncClientExchangeHandler exchangeHandler = new BasicClientExchangeHandler<>(requestProducer, responseConsumer, new FutureCallback<T>() {
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpRequester.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpRequester.java
@@ -36,6 +36,7 @@ import java.net.Socket;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -84,7 +85,6 @@ import org.apache.hc.core5.pool.ConnPoolControl;
 import org.apache.hc.core5.pool.ManagedConnPool;
 import org.apache.hc.core5.pool.PoolEntry;
 import org.apache.hc.core5.pool.PoolStats;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -120,9 +120,9 @@ public class HttpRequester implements ConnPoolControl<HttpHost>, ModalCloseable 
             final Callback<SSLParameters> sslSetupHandler,
             final SSLSessionVerifier sslSessionVerifier,
             final Resolver<HttpHost, InetSocketAddress> addressResolver) {
-        this.requestExecutor = Args.notNull(requestExecutor, "Request executor");
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.connPool = Args.notNull(connPool, "Connection pool");
+        this.requestExecutor = Objects.requireNonNull(requestExecutor, "Request executor");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
+        this.connPool = Objects.requireNonNull(connPool, "Connection pool");
         this.socketConfig = socketConfig != null ? socketConfig : SocketConfig.DEFAULT;
         this.connectFactory = connectFactory != null ? connectFactory : new DefaultBHttpClientConnectionFactory(
                 Http1Config.DEFAULT, CharCodingConfig.DEFAULT);
@@ -192,9 +192,9 @@ public class HttpRequester implements ConnPoolControl<HttpHost>, ModalCloseable 
             final ClassicHttpRequest request,
             final HttpResponseInformationCallback informationCallback,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(connection, "HTTP connection");
-        Args.notNull(request, "HTTP request");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(connection, "HTTP connection");
+        Objects.requireNonNull(request, "HTTP request");
+        Objects.requireNonNull(context, "HTTP context");
         if (!connection.isOpen()) {
             throw new ConnectionClosedException();
         }
@@ -313,8 +313,8 @@ public class HttpRequester implements ConnPoolControl<HttpHost>, ModalCloseable 
             final HttpResponseInformationCallback informationCallback,
             final Timeout connectTimeout,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(targetHost, "HTTP host");
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(targetHost, "HTTP host");
+        Objects.requireNonNull(request, "HTTP request");
         final Future<PoolEntry<HttpHost, HttpClientConnection>> leaseFuture = connPool.lease(targetHost, null, connectTimeout, null);
         final PoolEntry<HttpHost, HttpClientConnection> poolEntry;
         final Timeout timeout = Timeout.defaultsToDisabled(connectTimeout);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpServer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpServer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -94,7 +95,7 @@ public class HttpServer implements ModalCloseable {
             final Callback<SSLParameters> sslSetupHandler,
             final ExceptionListener exceptionListener) {
         this.port = Args.notNegative(port, "Port value is negative");
-        this.httpService = Args.notNull(httpService, "HTTP service");
+        this.httpService = Objects.requireNonNull(httpService, "HTTP service");
         this.ifAddress = ifAddress;
         this.socketConfig = socketConfig != null ? socketConfig : SocketConfig.DEFAULT;
         this.serverSocketFactory = serverSocketFactory != null ? serverSocketFactory : ServerSocketFactory.getDefault();
@@ -178,7 +179,7 @@ public class HttpServer implements ModalCloseable {
     }
 
     public void awaitTermination(final TimeValue waitTime) throws InterruptedException {
-        Args.notNull(waitTime, "Wait time");
+        Objects.requireNonNull(waitTime, "Wait time");
         this.workerExecutorService.awaitTermination(waitTime.getDuration(), waitTime.getTimeUnit());
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
@@ -197,7 +198,7 @@ public class ServerBootstrap {
      */
     public final ServerBootstrap register(final String uriPattern, final HttpRequestHandler requestHandler) {
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(requestHandler, "Supplier");
+        Objects.requireNonNull(requestHandler, "Supplier");
         handlerList.add(new HandlerEntry<>(null, uriPattern, requestHandler));
         return this;
     }
@@ -213,7 +214,7 @@ public class ServerBootstrap {
     public final ServerBootstrap registerVirtual(final String hostname, final String uriPattern, final HttpRequestHandler requestHandler) {
         Args.notBlank(hostname, "Hostname");
         Args.notBlank(uriPattern, "URI pattern");
-        Args.notNull(requestHandler, "Supplier");
+        Objects.requireNonNull(requestHandler, "Supplier");
         handlerList.add(new HandlerEntry<>(hostname, uriPattern, requestHandler));
         return this;
     }
@@ -276,7 +277,7 @@ public class ServerBootstrap {
     public final ServerBootstrap addFilterBefore(final String existing, final String name, final HttpFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
         Args.notBlank(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.BEFORE, name, filterHandler, existing));
         return this;
     }
@@ -287,7 +288,7 @@ public class ServerBootstrap {
     public final ServerBootstrap addFilterAfter(final String existing, final String name, final HttpFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
         Args.notBlank(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.AFTER, name, filterHandler, existing));
         return this;
     }
@@ -297,7 +298,7 @@ public class ServerBootstrap {
      */
     public final ServerBootstrap replaceFilter(final String existing, final HttpFilterHandler filterHandler) {
         Args.notBlank(existing, "Existing");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.REPLACE, existing, filterHandler, existing));
         return this;
     }
@@ -306,8 +307,8 @@ public class ServerBootstrap {
      * Add an filter to the head of the processing list.
      */
     public final ServerBootstrap addFilterFirst(final String name, final HttpFilterHandler filterHandler) {
-        Args.notNull(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(name, "Name");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.FIRST, name, filterHandler, null));
         return this;
     }
@@ -316,8 +317,8 @@ public class ServerBootstrap {
      * Add an filter to the tail of the processing list.
      */
     public final ServerBootstrap addFilterLast(final String name, final HttpFilterHandler filterHandler) {
-        Args.notNull(name, "Name");
-        Args.notNull(filterHandler, "Filter handler");
+        Objects.requireNonNull(name, "Name");
+        Objects.requireNonNull(filterHandler, "Filter handler");
         filters.add(new FilterEntry<>(FilterEntry.Postion.LAST, name, filterHandler, null));
         return this;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/AbstractMessageParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/AbstractMessageParser.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
@@ -41,7 +42,6 @@ import org.apache.hc.core5.http.io.HttpMessageParser;
 import org.apache.hc.core5.http.io.SessionInputBuffer;
 import org.apache.hc.core5.http.message.LazyLineParser;
 import org.apache.hc.core5.http.message.LineParser;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -149,10 +149,10 @@ public abstract class AbstractMessageParser<T extends HttpMessage> implements Ht
             final int maxLineLen,
             final LineParser parser,
             final List<CharArrayBuffer> headerLines) throws HttpException, IOException {
-        Args.notNull(inBuffer, "Session input buffer");
-        Args.notNull(inputStream, "Input stream");
-        Args.notNull(parser, "Line parser");
-        Args.notNull(headerLines, "Header line list");
+        Objects.requireNonNull(inBuffer, "Session input buffer");
+        Objects.requireNonNull(inputStream, "Input stream");
+        Objects.requireNonNull(parser, "Line parser");
+        Objects.requireNonNull(headerLines, "Header line list");
 
         CharArrayBuffer current = null;
         CharArrayBuffer previous = null;
@@ -231,8 +231,8 @@ public abstract class AbstractMessageParser<T extends HttpMessage> implements Ht
 
     @Override
     public T parse(final SessionInputBuffer buffer, final InputStream inputStream) throws IOException, HttpException {
-        Args.notNull(buffer, "Session input buffer");
-        Args.notNull(inputStream, "Input stream");
+        Objects.requireNonNull(buffer, "Session input buffer");
+        Objects.requireNonNull(inputStream, "Input stream");
         final int st = this.state;
         switch (st) {
         case HEAD_LINE:

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/AbstractMessageWriter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/AbstractMessageWriter.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.FormattedHeader;
 import org.apache.hc.core5.http.Header;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.io.HttpMessageWriter;
 import org.apache.hc.core5.http.io.SessionOutputBuffer;
 import org.apache.hc.core5.http.message.BasicLineFormatter;
 import org.apache.hc.core5.http.message.LineFormatter;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -83,9 +83,9 @@ public abstract class AbstractMessageWriter<T extends HttpMessage> implements Ht
 
     @Override
     public void write(final T message, final SessionOutputBuffer buffer, final OutputStream outputStream) throws IOException, HttpException {
-        Args.notNull(message, "HTTP message");
-        Args.notNull(buffer, "Session output buffer");
-        Args.notNull(outputStream, "Output stream");
+        Objects.requireNonNull(message, "HTTP message");
+        Objects.requireNonNull(buffer, "Session output buffer");
+        Objects.requireNonNull(outputStream, "Output stream");
         writeHeadLine(message, this.lineBuf);
         buffer.writeLine(this.lineBuf, outputStream);
         for (final Iterator<Header> it = message.headerIterator(); it.hasNext(); ) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/BHttpConnectionBase.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/BHttpConnectionBase.java
@@ -37,6 +37,7 @@ import java.net.SocketTimeoutException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLSession;
@@ -61,7 +62,6 @@ import org.apache.hc.core5.http.io.SessionOutputBuffer;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.Closer;
 import org.apache.hc.core5.net.InetAddressUtils;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 class BHttpConnectionBase implements BHttpConnection {
@@ -111,12 +111,12 @@ class BHttpConnectionBase implements BHttpConnection {
      * @throws IOException in case of an I/O error.
      */
     protected void bind(final Socket socket) throws IOException {
-        Args.notNull(socket, "Socket");
+        Objects.requireNonNull(socket, "Socket");
         bind(new SocketHolder(socket));
     }
 
     protected void bind(final SocketHolder socketHolder) throws IOException {
-        Args.notNull(socketHolder, "Socket holder");
+        Objects.requireNonNull(socketHolder, "Socket holder");
         this.socketHolderRef.set(socketHolder);
         this.endpointDetails = null;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.Header;
@@ -38,7 +39,6 @@ import org.apache.hc.core5.http.StreamClosedException;
 import org.apache.hc.core5.http.TruncatedChunkException;
 import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.io.SessionInputBuffer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -98,8 +98,8 @@ public class ChunkedInputStream extends InputStream {
      */
     public ChunkedInputStream(final SessionInputBuffer buffer, final InputStream inputStream, final Http1Config http1Config) {
         super();
-        this.buffer = Args.notNull(buffer, "Session input buffer");
-        this.inputStream = Args.notNull(inputStream, "Input stream");
+        this.buffer = Objects.requireNonNull(buffer, "Session input buffer");
+        this.inputStream = Objects.requireNonNull(inputStream, "Input stream");
         this.pos = 0L;
         this.lineBuffer = new CharArrayBuffer(16);
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.FormattedHeader;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.StreamClosedException;
 import org.apache.hc.core5.http.io.SessionOutputBuffer;
 import org.apache.hc.core5.http.message.BasicLineFormatter;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -80,8 +80,8 @@ public class ChunkedOutputStream extends OutputStream {
             final int chunkSizeHint,
             final Supplier<List<? extends Header>> trailerSupplier) {
         super();
-        this.buffer = Args.notNull(buffer, "Session output buffer");
-        this.outputStream = Args.notNull(outputStream, "Output stream");
+        this.buffer = Objects.requireNonNull(buffer, "Session output buffer");
+        this.outputStream = Objects.requireNonNull(outputStream, "Output stream");
         this.cache = new byte[chunkSizeHint > 0 ? chunkSizeHint : 2048];
         this.lineBuffer = new CharArrayBuffer(32);
         this.trailerSupplier = trailerSupplier;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.StreamClosedException;
@@ -80,8 +81,8 @@ public class ContentLengthInputStream extends InputStream {
      */
     public ContentLengthInputStream(final SessionInputBuffer buffer, final InputStream inputStream, final long contentLength) {
         super();
-        this.buffer = Args.notNull(buffer, "Session input buffer");
-        this.inputStream = Args.notNull(inputStream, "Input stream");
+        this.buffer = Objects.requireNonNull(buffer, "Session input buffer");
+        this.inputStream = Objects.requireNonNull(inputStream, "Input stream");
         this.contentLength = Args.notNegative(contentLength, "Content length");
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthOutputStream.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.StreamClosedException;
 import org.apache.hc.core5.http.io.SessionOutputBuffer;
@@ -76,8 +77,8 @@ public class ContentLengthOutputStream extends OutputStream {
      */
     public ContentLengthOutputStream(final SessionOutputBuffer buffer, final OutputStream outputStream, final long contentLength) {
         super();
-        this.buffer = Args.notNull(buffer, "Session output buffer");
-        this.outputStream = Args.notNull(outputStream, "Output stream");
+        this.buffer = Objects.requireNonNull(buffer, "Session output buffer");
+        this.outputStream = Objects.requireNonNull(outputStream, "Output stream");
         this.contentLength = Args.notNegative(contentLength, "Content length");
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -51,7 +52,6 @@ import org.apache.hc.core5.http.io.HttpMessageParser;
 import org.apache.hc.core5.http.io.HttpMessageParserFactory;
 import org.apache.hc.core5.http.io.HttpMessageWriter;
 import org.apache.hc.core5.http.io.HttpMessageWriterFactory;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default implementation of {@link HttpClientConnection}.
@@ -130,7 +130,7 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
     @Override
     public void sendRequestHeader(final ClassicHttpRequest request)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         final SocketHolder socketHolder = ensureOpen();
         this.requestWriter.write(request, this.outbuffer, socketHolder.getOutputStream());
         onRequestSubmitted(request);
@@ -139,7 +139,7 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
 
     @Override
     public void sendRequestEntity(final ClassicHttpRequest request) throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         final SocketHolder socketHolder = ensureOpen();
         final HttpEntity entity = request.getEntity();
         if (entity == null) {
@@ -161,7 +161,7 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
 
     @Override
     public void terminateRequest(final ClassicHttpRequest request) throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         final SocketHolder socketHolder = ensureOpen();
         final HttpEntity entity = request.getEntity();
         if (entity == null) {
@@ -203,7 +203,7 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
 
     @Override
     public void receiveResponseEntity( final ClassicHttpResponse response) throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
         final SocketHolder socketHolder = ensureOpen();
         final long len = this.incomingContentStrategy.determineLength(response);
         response.setEntity(createIncomingEntity(response, this.inBuffer, socketHolder.getInputStream(), len));

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnection.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnection.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -49,7 +50,6 @@ import org.apache.hc.core5.http.io.HttpMessageParserFactory;
 import org.apache.hc.core5.http.io.HttpMessageWriter;
 import org.apache.hc.core5.http.io.HttpMessageWriterFactory;
 import org.apache.hc.core5.http.io.HttpServerConnection;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default implementation of {@link HttpServerConnection}.
@@ -147,7 +147,7 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase implements
     @Override
     public void receiveRequestEntity(final ClassicHttpRequest request)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         final SocketHolder socketHolder = ensureOpen();
 
         final long len = this.incomingContentStrategy.determineLength(request);
@@ -160,7 +160,7 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase implements
     @Override
     public void sendResponseHeader(final ClassicHttpResponse response)
             throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
         final SocketHolder socketHolder = ensureOpen();
         this.responseWriter.write(response, this.outbuffer, socketHolder.getOutputStream());
         onResponseSubmitted(response);
@@ -172,7 +172,7 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase implements
     @Override
     public void sendResponseEntity(final ClassicHttpResponse response)
             throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
         final SocketHolder socketHolder = ensureOpen();
         final HttpEntity entity = response.getEntity();
         if (entity == null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultClassicHttpResponseFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultClassicHttpResponseFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl.io;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -34,7 +36,6 @@ import org.apache.hc.core5.http.HttpResponseFactory;
 import org.apache.hc.core5.http.ReasonPhraseCatalog;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default factory for creating {@link ClassicHttpResponse} objects.
@@ -54,7 +55,7 @@ public class DefaultClassicHttpResponseFactory implements HttpResponseFactory<Cl
      * @param catalog   the catalog of reason phrases
      */
     public DefaultClassicHttpResponseFactory(final ReasonPhraseCatalog catalog) {
-        this.reasonCatalog = Args.notNull(catalog, "Reason phrase catalog");
+        this.reasonCatalog = Objects.requireNonNull(catalog, "Reason phrase catalog");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -121,9 +122,9 @@ public class HttpRequestExecutor {
             final HttpClientConnection conn,
             final HttpResponseInformationCallback informationCallback,
             final HttpContext context) throws IOException, HttpException {
-        Args.notNull(request, "HTTP request");
-        Args.notNull(conn, "Client connection");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(request, "HTTP request");
+        Objects.requireNonNull(conn, "Client connection");
+        Objects.requireNonNull(context, "HTTP context");
         try {
             context.setAttribute(HttpCoreContext.SSL_SESSION, conn.getSSLSession());
             context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, conn.getEndpointDetails());
@@ -241,9 +242,9 @@ public class HttpRequestExecutor {
             final ClassicHttpRequest request,
             final HttpProcessor processor,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
-        Args.notNull(processor, "HTTP processor");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(request, "HTTP request");
+        Objects.requireNonNull(processor, "HTTP processor");
+        Objects.requireNonNull(context, "HTTP context");
         context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
         processor.process(request, request.getEntity(), context);
     }
@@ -269,9 +270,9 @@ public class HttpRequestExecutor {
             final ClassicHttpResponse response,
             final HttpProcessor processor,
             final HttpContext context) throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
-        Args.notNull(processor, "HTTP processor");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(response, "HTTP response");
+        Objects.requireNonNull(processor, "HTTP processor");
+        Objects.requireNonNull(context, "HTTP context");
         final ProtocolVersion transportVersion = response.getVersion();
         if (transportVersion != null) {
             context.setProtocolVersion(transportVersion);
@@ -295,10 +296,10 @@ public class HttpRequestExecutor {
             final ClassicHttpResponse response,
             final HttpClientConnection connection,
             final HttpContext context) throws IOException {
-        Args.notNull(connection, "HTTP connection");
-        Args.notNull(request, "HTTP request");
-        Args.notNull(response, "HTTP response");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(connection, "HTTP connection");
+        Objects.requireNonNull(request, "HTTP request");
+        Objects.requireNonNull(response, "HTTP response");
+        Objects.requireNonNull(context, "HTTP context");
         final boolean keepAlive = connection.isConsistent() && connReuseStrategy.keepAlive(request, response, context);
         if (streamListener != null) {
             streamListener.onExchangeComplete(connection, keepAlive);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpService.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpService.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -58,7 +59,6 @@ import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@code HttpService} is a server side HTTP protocol handler based on
@@ -140,8 +140,8 @@ public class HttpService {
             final ConnectionReuseStrategy connReuseStrategy,
             final Http1StreamListener streamListener) {
         super();
-        this.processor =  Args.notNull(processor, "HTTP processor");
-        this.requestHandler =  Args.notNull(requestHandler, "Request handler");
+        this.processor =  Objects.requireNonNull(processor, "HTTP processor");
+        this.requestHandler =  Objects.requireNonNull(requestHandler, "Request handler");
         this.connReuseStrategy = connReuseStrategy != null ? connReuseStrategy : DefaultConnectionReuseStrategy.INSTANCE;
         this.streamListener = streamListener;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/IdentityInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/IdentityInputStream.java
@@ -29,10 +29,10 @@ package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.StreamClosedException;
 import org.apache.hc.core5.http.io.SessionInputBuffer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Input stream that reads data without any transformation. The end of the
@@ -61,8 +61,8 @@ public class IdentityInputStream extends InputStream {
      */
     public IdentityInputStream(final SessionInputBuffer buffer, final InputStream inputStream) {
         super();
-        this.buffer = Args.notNull(buffer, "Session input buffer");
-        this.inputStream = Args.notNull(inputStream, "Input stream");
+        this.buffer = Objects.requireNonNull(buffer, "Session input buffer");
+        this.inputStream = Objects.requireNonNull(inputStream, "Input stream");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/IdentityOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/IdentityOutputStream.java
@@ -29,10 +29,10 @@ package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.StreamClosedException;
 import org.apache.hc.core5.http.io.SessionOutputBuffer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Output stream that writes data without any transformation. The end of
@@ -62,8 +62,8 @@ public class IdentityOutputStream extends OutputStream {
      */
     public IdentityOutputStream(final SessionOutputBuffer buffer, final OutputStream outputStream) {
         super();
-        this.buffer = Args.notNull(buffer, "Session output buffer");
-        this.outputStream = Args.notNull(outputStream, "Output stream");
+        this.buffer = Objects.requireNonNull(buffer, "Session output buffer");
+        this.outputStream = Objects.requireNonNull(outputStream, "Output stream");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Chars;
 import org.apache.hc.core5.http.MessageConstraintException;
@@ -87,7 +88,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
             final int minChunkLimit,
             final int maxLineLen,
             final CharsetDecoder charDecoder) {
-        Args.notNull(metrics, "HTTP transport metrcis");
+        Objects.requireNonNull(metrics, "HTTP transport metrcis");
         Args.positive(bufferSize, "Buffer size");
         this.metrics = metrics;
         this.buffer = new byte[bufferSize];
@@ -133,7 +134,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
     }
 
     public int fillBuffer(final InputStream inputStream) throws IOException {
-        Args.notNull(inputStream, "Input stream");
+        Objects.requireNonNull(inputStream, "Input stream");
         // compact the buffer if necessary
         if (this.bufferPos > 0) {
             final int len = this.bufferLen - this.bufferPos;
@@ -166,7 +167,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
 
     @Override
     public int read(final InputStream inputStream) throws IOException {
-        Args.notNull(inputStream, "Input stream");
+        Objects.requireNonNull(inputStream, "Input stream");
         int readLen;
         while (!hasBufferedData()) {
             readLen = fillBuffer(inputStream);
@@ -179,7 +180,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
 
     @Override
     public int read(final byte[] b, final int off, final int len, final InputStream inputStream) throws IOException {
-        Args.notNull(inputStream, "Input stream");
+        Objects.requireNonNull(inputStream, "Input stream");
         if (b == null) {
             return 0;
         }
@@ -238,8 +239,8 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
      */
     @Override
     public int readLine(final CharArrayBuffer charBuffer, final InputStream inputStream) throws IOException {
-        Args.notNull(charBuffer, "Char array buffer");
-        Args.notNull(inputStream, "Input stream");
+        Objects.requireNonNull(charBuffer, "Char array buffer");
+        Objects.requireNonNull(inputStream, "Input stream");
         int readLen = 0;
         boolean retry = true;
         while (retry) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionOutputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionOutputBufferImpl.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Chars;
 import org.apache.hc.core5.http.impl.BasicHttpTransportMetrics;
@@ -81,7 +82,7 @@ public class SessionOutputBufferImpl implements SessionOutputBuffer {
             final CharsetEncoder charEncoder) {
         super();
         Args.positive(bufferSize, "Buffer size");
-        Args.notNull(metrics, "HTTP transport metrcis");
+        Objects.requireNonNull(metrics, "HTTP transport metrcis");
         this.metrics = metrics;
         this.buffer = new ByteArrayBuffer(bufferSize);
         this.fragementSizeHint = fragementSizeHint >= 0 ? fragementSizeHint : bufferSize;
@@ -122,7 +123,7 @@ public class SessionOutputBufferImpl implements SessionOutputBuffer {
 
     @Override
     public void flush(final OutputStream outputStream) throws IOException {
-        Args.notNull(outputStream, "Output stream");
+        Objects.requireNonNull(outputStream, "Output stream");
         flushBuffer(outputStream);
         outputStream.flush();
     }
@@ -132,7 +133,7 @@ public class SessionOutputBufferImpl implements SessionOutputBuffer {
         if (b == null) {
             return;
         }
-        Args.notNull(outputStream, "Output stream");
+        Objects.requireNonNull(outputStream, "Output stream");
         // Do not want to buffer large-ish chunks
         // if the byte array is larger then MIN_CHUNK_LIMIT
         // write it directly to the output stream
@@ -164,7 +165,7 @@ public class SessionOutputBufferImpl implements SessionOutputBuffer {
 
     @Override
     public void write(final int b, final OutputStream outputStream) throws IOException {
-        Args.notNull(outputStream, "Output stream");
+        Objects.requireNonNull(outputStream, "Output stream");
         if (this.fragementSizeHint > 0) {
             if (this.buffer.isFull()) {
                 flushBuffer(outputStream);
@@ -190,7 +191,7 @@ public class SessionOutputBufferImpl implements SessionOutputBuffer {
         if (charbuffer == null) {
             return;
         }
-        Args.notNull(outputStream, "Output stream");
+        Objects.requireNonNull(outputStream, "Output stream");
         if (this.encoder == null) {
             int off = 0;
             int remaining = charbuffer.length();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SocketHolder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SocketHolder.java
@@ -31,9 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-
-import org.apache.hc.core5.util.Args;
 
 /**
  * Utility class that holds a {@link Socket} along with copies of its {@link InputStream}
@@ -48,7 +47,7 @@ public class SocketHolder {
     private final AtomicReference<OutputStream> outputStreamRef;
 
     public SocketHolder(final Socket socket) {
-        this.socket = Args.notNull(socket, "Socket");
+        this.socket = Objects.requireNonNull(socket, "Socket");
         this.inputStreamRef = new AtomicReference<>(null);
         this.outputStreamRef = new AtomicReference<>(null);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractContentDecoder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractContentDecoder.java
@@ -31,12 +31,12 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.impl.BasicHttpTransportMetrics;
 import org.apache.hc.core5.http.nio.ContentDecoder;
 import org.apache.hc.core5.http.nio.SessionInputBuffer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract {@link ContentDecoder} that serves as a base for all content
@@ -65,9 +65,9 @@ public abstract class AbstractContentDecoder implements ContentDecoder {
             final SessionInputBuffer buffer,
             final BasicHttpTransportMetrics metrics) {
         super();
-        Args.notNull(channel, "Channel");
-        Args.notNull(buffer, "Session input buffer");
-        Args.notNull(metrics, "Transport metrics");
+        Objects.requireNonNull(channel, "Channel");
+        Objects.requireNonNull(buffer, "Session input buffer");
+        Objects.requireNonNull(metrics, "Transport metrics");
         this.buffer = buffer;
         this.channel = channel;
         this.metrics = metrics;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractContentEncoder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractContentEncoder.java
@@ -31,12 +31,12 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.impl.BasicHttpTransportMetrics;
 import org.apache.hc.core5.http.nio.ContentEncoder;
 import org.apache.hc.core5.http.nio.SessionOutputBuffer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 
 /**
@@ -66,9 +66,9 @@ public abstract class AbstractContentEncoder implements ContentEncoder {
             final SessionOutputBuffer buffer,
             final BasicHttpTransportMetrics metrics) {
         super();
-        Args.notNull(channel, "Channel");
-        Args.notNull(buffer, "Session input buffer");
-        Args.notNull(metrics, "Transport metrics");
+        Objects.requireNonNull(channel, "Channel");
+        Objects.requireNonNull(buffer, "Session input buffer");
+        Objects.requireNonNull(metrics, "Transport metrics");
         this.buffer = buffer;
         this.channel = channel;
         this.metrics = metrics;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1IOEventHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1IOEventHandler.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.nio;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import javax.net.ssl.SSLSession;
 
@@ -38,7 +39,6 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 class AbstractHttp1IOEventHandler implements HttpConnectionEventHandler {
@@ -46,7 +46,7 @@ class AbstractHttp1IOEventHandler implements HttpConnectionEventHandler {
     final AbstractHttp1StreamDuplexer<?, ?> streamDuplexer;
 
     AbstractHttp1IOEventHandler(final AbstractHttp1StreamDuplexer<?, ?> streamDuplexer) {
-        this.streamDuplexer = Args.notNull(streamDuplexer, "Stream multiplexer");
+        this.streamDuplexer = Objects.requireNonNull(streamDuplexer, "Stream multiplexer");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractHttp1StreamDuplexer.java
@@ -35,6 +35,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLSession;
@@ -74,7 +75,6 @@ import org.apache.hc.core5.reactor.EventMask;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Identifiable;
 import org.apache.hc.core5.util.Timeout;
 
@@ -113,7 +113,7 @@ abstract class AbstractHttp1StreamDuplexer<IncomingMessage extends HttpMessage, 
             final NHttpMessageWriter<OutgoingMessage> outgoingMessageWriter,
             final ContentLengthStrategy incomingContentStrategy,
             final ContentLengthStrategy outgoingContentStrategy) {
-        this.ioSession = Args.notNull(ioSession, "I/O session");
+        this.ioSession = Objects.requireNonNull(ioSession, "I/O session");
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         final int bufferSize = this.http1Config.getBufferSize();
         this.inbuf = new SessionInputBufferImpl(bufferSize, bufferSize < 512 ? bufferSize : 512,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractMessageParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractMessageParser.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.nio;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpMessage;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.message.LazyLineParser;
 import org.apache.hc.core5.http.message.LineParser;
 import org.apache.hc.core5.http.nio.SessionInputBuffer;
 import org.apache.hc.core5.http.nio.NHttpMessageParser;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -144,7 +144,7 @@ public abstract class AbstractMessageParser<T extends HttpMessage> implements NH
     @Override
     public T parse(
             final SessionInputBuffer sessionBuffer, final boolean endOfStream) throws IOException, HttpException {
-        Args.notNull(sessionBuffer, "Session input buffer");
+        Objects.requireNonNull(sessionBuffer, "Session input buffer");
         while (this.state !=State.COMPLETED) {
             if (this.lineBuf == null) {
                 this.lineBuf = new CharArrayBuffer(64);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractMessageWriter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/AbstractMessageWriter.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.nio;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.FormattedHeader;
 import org.apache.hc.core5.http.Header;
@@ -38,7 +39,6 @@ import org.apache.hc.core5.http.message.BasicLineFormatter;
 import org.apache.hc.core5.http.message.LineFormatter;
 import org.apache.hc.core5.http.nio.SessionOutputBuffer;
 import org.apache.hc.core5.http.nio.NHttpMessageWriter;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -83,8 +83,8 @@ public abstract class AbstractMessageWriter<T extends HttpMessage> implements NH
 
     @Override
     public void write(final T message, final SessionOutputBuffer sessionBuffer) throws IOException, HttpException {
-        Args.notNull(message, "HTTP message");
-        Args.notNull(sessionBuffer, "Session output buffer");
+        Objects.requireNonNull(message, "HTTP message");
+        Objects.requireNonNull(sessionBuffer, "Session output buffer");
 
         writeHeadLine(message, this.lineBuf);
         sessionBuffer.writeLine(this.lineBuf);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/BufferedData.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/BufferedData.java
@@ -31,8 +31,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * A buffer that expand its capacity on demand. Internally, this class is backed
@@ -73,7 +72,7 @@ public class BufferedData extends ExpandableBuffer {
     }
 
     public final void put(final ByteBuffer src) {
-        Args.notNull(src, "Data source");
+        Objects.requireNonNull(src, "Data source");
         setInputMode();
         final int requiredCapacity = buffer().position() + src.remaining();
         ensureAdjustedCapacity(requiredCapacity);
@@ -81,7 +80,7 @@ public class BufferedData extends ExpandableBuffer {
     }
 
     public final int readFrom(final ReadableByteChannel channel) throws IOException {
-        Args.notNull(channel, "Channel");
+        Objects.requireNonNull(channel, "Channel");
         setInputMode();
         if (!buffer().hasRemaining()) {
             expand();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ChunkDecoder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ChunkDecoder.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.Header;
@@ -43,7 +44,6 @@ import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.impl.BasicHttpTransportMetrics;
 import org.apache.hc.core5.http.message.BufferedHeader;
 import org.apache.hc.core5.http.nio.SessionInputBuffer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -183,7 +183,7 @@ public class ChunkDecoder extends AbstractContentDecoder {
 
     @Override
     public int read(final ByteBuffer dst) throws IOException {
-        Args.notNull(dst, "Byte buffer");
+        Objects.requireNonNull(dst, "Byte buffer");
         if (this.state == State.COMPLETED) {
             return -1;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1IOEventHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1IOEventHandlerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpHost;
@@ -35,7 +37,6 @@ import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -54,7 +55,7 @@ public class ClientHttp1IOEventHandlerFactory implements IOEventHandlerFactory {
             final ClientHttp1StreamDuplexerFactory streamDuplexerFactory,
             final TlsStrategy tlsStrategy,
             final Timeout handshakeTimeout) {
-        this.streamDuplexerFactory = Args.notNull(streamDuplexerFactory, "Stream duplexer factory");
+        this.streamDuplexerFactory = Objects.requireNonNull(streamDuplexerFactory, "Stream duplexer factory");
         this.tlsStrategy = tlsStrategy;
         this.handshakeTimeout = handshakeTimeout;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -66,7 +67,6 @@ import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.Timeout;
 
@@ -102,7 +102,7 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             final ContentLengthStrategy outgoingContentStrategy,
             final Http1StreamListener streamListener) {
         super(ioSession, http1Config, charCodingConfig, incomingMessageParser, outgoingMessageWriter, incomingContentStrategy, outgoingContentStrategy);
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :
                 DefaultConnectionReuseStrategy.INSTANCE;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -43,7 +45,6 @@ import org.apache.hc.core5.http.nio.NHttpMessageParserFactory;
 import org.apache.hc.core5.http.nio.NHttpMessageWriterFactory;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link ClientHttp1StreamDuplexer} factory.
@@ -74,7 +75,7 @@ public final class ClientHttp1StreamDuplexerFactory {
             final ContentLengthStrategy incomingContentStrategy,
             final ContentLengthStrategy outgoingContentStrategy,
             final Http1StreamListener streamListener) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.charCodingConfig = charCodingConfig !=  null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestParser.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl.nio;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
@@ -38,7 +39,6 @@ import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.message.LineParser;
 import org.apache.hc.core5.http.message.RequestLine;
 import org.apache.hc.core5.http.nio.SessionInputBuffer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -66,7 +66,7 @@ public class DefaultHttpRequestParser<T extends HttpRequest> extends AbstractMes
             final LineParser parser,
             final Http1Config http1Config) {
         super(parser, http1Config);
-        this.requestFactory = Args.notNull(requestFactory, "Request factory");
+        this.requestFactory = Objects.requireNonNull(requestFactory, "Request factory");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpResponse;
@@ -34,7 +36,6 @@ import org.apache.hc.core5.http.HttpResponseFactory;
 import org.apache.hc.core5.http.ReasonPhraseCatalog;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default factory for creating {@link HttpResponse} objects.
@@ -54,7 +55,7 @@ public class DefaultHttpResponseFactory implements HttpResponseFactory<HttpRespo
      * @param catalog   the catalog of reason phrases
      */
     public DefaultHttpResponseFactory(final ReasonPhraseCatalog catalog) {
-        this.reasonCatalog = Args.notNull(catalog, "Reason phrase catalog");
+        this.reasonCatalog = Objects.requireNonNull(catalog, "Reason phrase catalog");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseParser.java
@@ -27,13 +27,14 @@
 
 package org.apache.hc.core5.http.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpResponseFactory;
 import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.message.LineParser;
 import org.apache.hc.core5.http.message.StatusLine;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -61,7 +62,7 @@ public class DefaultHttpResponseParser<T extends HttpResponse> extends AbstractM
             final LineParser parser,
             final Http1Config http1Config) {
         super(parser, http1Config);
-        this.responseFactory = Args.notNull(responseFactory, "Response factory");
+        this.responseFactory = Objects.requireNonNull(responseFactory, "Response factory");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/IdentityDecoder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/IdentityDecoder.java
@@ -31,11 +31,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.impl.BasicHttpTransportMetrics;
 import org.apache.hc.core5.http.nio.FileContentDecoder;
 import org.apache.hc.core5.http.nio.SessionInputBuffer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Content decoder that reads data without any transformation. The end of the
@@ -60,7 +60,7 @@ public class IdentityDecoder extends AbstractContentDecoder implements FileConte
 
     @Override
     public int read(final ByteBuffer dst) throws IOException {
-        Args.notNull(dst, "Byte buffer");
+        Objects.requireNonNull(dst, "Byte buffer");
         if (isCompleted()) {
             return -1;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/LengthDelimitedDecoder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/LengthDelimitedDecoder.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.impl.BasicHttpTransportMetrics;
@@ -69,7 +70,7 @@ public class LengthDelimitedDecoder extends AbstractContentDecoder implements Fi
 
     @Override
     public int read(final ByteBuffer dst) throws IOException {
-        Args.notNull(dst, "Byte buffer");
+        Objects.requireNonNull(dst, "Byte buffer");
         if (isCompleted()) {
             return -1;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1IOEventHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1IOEventHandlerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.URIScheme;
@@ -34,7 +36,6 @@ import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -53,7 +54,7 @@ public class ServerHttp1IOEventHandlerFactory implements IOEventHandlerFactory {
             final ServerHttp1StreamDuplexerFactory streamDuplexerFactory,
             final TlsStrategy tlsStrategy,
             final Timeout handshakeTimeout) {
-        this.streamDuplexerFactory = Args.notNull(streamDuplexerFactory, "Stream duplexer factory");
+        this.streamDuplexerFactory = Objects.requireNonNull(streamDuplexerFactory, "Stream duplexer factory");
         this.tlsStrategy = tlsStrategy;
         this.handshakeTimeout = handshakeTimeout;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -65,7 +66,6 @@ import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.Timeout;
 
@@ -105,8 +105,8 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             final ContentLengthStrategy outgoingContentStrategy,
             final Http1StreamListener streamListener) {
         super(ioSession, http1Config, charCodingConfig, incomingMessageParser, outgoingMessageWriter, incomingContentStrategy, outgoingContentStrategy);
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
+        this.exchangeHandlerFactory = Objects.requireNonNull(exchangeHandlerFactory, "Exchange handler factory");
         this.scheme = scheme;
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexerFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.core5.http.impl.nio;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -45,7 +47,6 @@ import org.apache.hc.core5.http.nio.NHttpMessageParserFactory;
 import org.apache.hc.core5.http.nio.NHttpMessageWriterFactory;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link ServerHttp1StreamDuplexer} factory.
@@ -78,8 +79,8 @@ public final class ServerHttp1StreamDuplexerFactory {
             final ContentLengthStrategy incomingContentStrategy,
             final ContentLengthStrategy outgoingContentStrategy,
             final Http1StreamListener streamListener) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
+        this.httpProcessor = Objects.requireNonNull(httpProcessor, "HTTP processor");
+        this.exchangeHandlerFactory = Objects.requireNonNull(exchangeHandlerFactory, "Exchange handler factory");
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionInputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionInputBufferImpl.java
@@ -35,6 +35,7 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Chars;
 import org.apache.hc.core5.http.MessageConstraintException;
@@ -135,7 +136,7 @@ class SessionInputBufferImpl extends ExpandableBuffer implements SessionInputBuf
 
     @Override
     public int fill(final ReadableByteChannel channel) throws IOException {
-        Args.notNull(channel, "Channel");
+        Objects.requireNonNull(channel, "Channel");
         setInputMode();
         if (!buffer().hasRemaining()) {
             expand();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
@@ -36,6 +36,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Chars;
 import org.apache.hc.core5.http.nio.SessionOutputBuffer;
@@ -114,7 +115,7 @@ class SessionOutputBufferImpl extends ExpandableBuffer implements SessionOutputB
 
     @Override
     public int flush(final WritableByteChannel channel) throws IOException {
-        Args.notNull(channel, "Channel");
+        Objects.requireNonNull(channel, "Channel");
         setOutputMode();
         return channel.write(buffer());
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
@@ -28,8 +28,7 @@ package org.apache.hc.core5.http.io;
 
 import java.io.IOException;
 import java.io.InputStream;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * A stream wrapper that triggers actions on {@link #close close()} and EOF.
@@ -79,7 +78,7 @@ public class EofSensorInputStream extends InputStream {
      */
     public EofSensorInputStream(final InputStream in,
                                 final EofSensorWatcher watcher) {
-        Args.notNull(in, "Wrapped stream");
+        Objects.requireNonNull(in, "Wrapped stream");
         wrappedStream = in;
         selfClosed = false;
         eofWatcher = watcher;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/SocketConfig.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/SocketConfig.java
@@ -28,11 +28,11 @@
 package org.apache.hc.core5.http.io;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -165,7 +165,7 @@ public class SocketConfig {
     }
 
     public static SocketConfig.Builder copy(final SocketConfig config) {
-        Args.notNull(config, "Socket config");
+        Objects.requireNonNull(config, "Socket config");
         return new Builder()
             .setSoTimeout(config.getSoTimeout())
             .setSoReuseAddress(config.isSoReuseAddress())

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/AbstractHttpEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/AbstractHttpEntity.java
@@ -32,13 +32,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract base class for mutable entities. Provides the commonly used attributes for streamed and
@@ -75,8 +75,8 @@ public abstract class AbstractHttpEntity implements HttpEntity {
     }
 
     public static void writeTo(final HttpEntity entity, final OutputStream outStream) throws IOException {
-        Args.notNull(entity, "Entity");
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(entity, "Entity");
+        Objects.requireNonNull(outStream, "Output stream");
         try (final InputStream inStream = entity.getContent()) {
             if (inStream != null) {
                 int count;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/BasicHttpEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/BasicHttpEntity.java
@@ -29,13 +29,13 @@ package org.apache.hc.core5.http.io.entity;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.impl.io.EmptyInputStream;
 import org.apache.hc.core5.io.Closer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A generic streamed, non-repeatable entity that obtains its content from an {@link InputStream}.
@@ -52,7 +52,7 @@ public class BasicHttpEntity extends AbstractHttpEntity {
             final InputStream content, final long length, final ContentType contentType, final String contentEncoding,
             final boolean chunked) {
         super(contentType, contentEncoding, chunked);
-        this.content = Args.notNull(content, "Content stream");
+        this.content = Objects.requireNonNull(content, "Content stream");
         this.length = length;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/BufferedHttpEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/BufferedHttpEntity.java
@@ -32,9 +32,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A wrapping entity that buffers it content if necessary.
@@ -106,7 +106,7 @@ public class BufferedHttpEntity extends HttpEntityWrapper {
 
     @Override
     public void writeTo(final OutputStream outStream) throws IOException {
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(outStream, "Output stream");
         if (this.buffer != null) {
             outStream.write(this.buffer);
         } else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/ByteArrayEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/ByteArrayEntity.java
@@ -31,11 +31,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A self contained, repeatable entity that obtains its content from a byte array.
@@ -55,7 +55,7 @@ public class ByteArrayEntity extends AbstractHttpEntity {
             final byte[] b, final int off, final int len, final ContentType contentType, final String contentEncoding,
             final boolean chunked) {
         super(contentType, contentEncoding, chunked);
-        Args.notNull(b, "Source byte array");
+        Objects.requireNonNull(b, "Source byte array");
         if ((off < 0) || (off > b.length) || (len < 0) ||
                 ((off + len) < 0) || ((off + len) > b.length)) {
             throw new IndexOutOfBoundsException("off: " + off + " len: " + len + " b.length: " + b.length);
@@ -79,7 +79,7 @@ public class ByteArrayEntity extends AbstractHttpEntity {
     public ByteArrayEntity(
             final byte[] b, final ContentType contentType, final String contentEncoding, final boolean chunked) {
         super(contentType, contentEncoding, chunked);
-        Args.notNull(b, "Source byte array");
+        Objects.requireNonNull(b, "Source byte array");
         this.b = b;
         this.off = 0;
         this.len = this.b.length;
@@ -126,7 +126,7 @@ public class ByteArrayEntity extends AbstractHttpEntity {
 
     @Override
     public final void writeTo(final OutputStream outStream) throws IOException {
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(outStream, "Output stream");
         outStream.write(this.b, this.off, this.len);
         outStream.flush();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/ByteBufferEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/ByteBufferEntity.java
@@ -30,9 +30,9 @@ package org.apache.hc.core5.http.io.entity;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * An entity that delivers the contents of a {@link ByteBuffer}.
@@ -44,7 +44,7 @@ public class ByteBufferEntity extends AbstractHttpEntity {
 
     public ByteBufferEntity(final ByteBuffer buffer, final ContentType contentType, final String contentEncoding) {
         super(contentType, contentEncoding);
-        Args.notNull(buffer, "Source byte buffer");
+        Objects.requireNonNull(buffer, "Source byte buffer");
         this.buffer = buffer;
         this.length = buffer.remaining();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityTemplate.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityTemplate.java
@@ -32,12 +32,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.io.IOCallback;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Entity that delegates the process of content generation to a {@link IOCallback}
@@ -56,7 +56,7 @@ public final class EntityTemplate extends AbstractHttpEntity {
             final IOCallback<OutputStream> callback) {
         super(contentType, contentEncoding);
         this.contentLength = contentLength;
-        this.callback = Args.notNull(callback, "I/O callback");
+        this.callback = Objects.requireNonNull(callback, "I/O callback");
     }
 
     @Override
@@ -78,7 +78,7 @@ public final class EntityTemplate extends AbstractHttpEntity {
 
     @Override
     public void writeTo(final OutputStream outStream) throws IOException {
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(outStream, "Output stream");
         this.callback.execute(outStream);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
@@ -119,7 +120,7 @@ public final class EntityUtils {
      * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
      */
     public static byte[] toByteArray(final HttpEntity entity) throws IOException {
-        Args.notNull(entity, "HttpEntity");
+        Objects.requireNonNull(entity, "HttpEntity");
         final int contentLength = toContentLength((int) Args.checkContentLength(entity));
         try (final InputStream inStream = entity.getContent()) {
             if (inStream == null) {
@@ -147,7 +148,7 @@ public final class EntityUtils {
      * @throws IllegalArgumentException if entity is null or if content length &gt; Integer.MAX_VALUE
      */
     public static byte[] toByteArray(final HttpEntity entity, final int maxResultLength) throws IOException {
-        Args.notNull(entity, "HttpEntity");
+        Objects.requireNonNull(entity, "HttpEntity");
         final int contentLength = toContentLength((int) Args.checkContentLength(entity));
         try (final InputStream inStream = entity.getContent()) {
             if (inStream == null) {
@@ -165,7 +166,7 @@ public final class EntityUtils {
 
     private static CharArrayBuffer toCharArrayBuffer(final InputStream inStream, final long contentLength,
             final Charset charset, final int maxResultLength) throws IOException {
-        Args.notNull(inStream, "InputStream");
+        Objects.requireNonNull(inStream, "InputStream");
         Args.positive(maxResultLength, "maxResultLength");
         final Charset actualCharset = charset == null ? DEFAULT_CHARSET : charset;
         final CharArrayBuffer buf = new CharArrayBuffer(
@@ -181,7 +182,7 @@ public final class EntityUtils {
 
     private static String toString(final HttpEntity entity, final ContentType contentType, final int maxResultLength)
             throws IOException {
-        Args.notNull(entity, "HttpEntity");
+        Objects.requireNonNull(entity, "HttpEntity");
         final int contentLength = toContentLength((int) Args.checkContentLength(entity));
         try (final InputStream inStream = entity.getContent()) {
             if (inStream == null) {
@@ -240,7 +241,7 @@ public final class EntityUtils {
      */
     public static String toString(
             final HttpEntity entity, final Charset defaultCharset, final int maxResultLength) throws IOException, ParseException {
-        Args.notNull(entity, "HttpEntity");
+        Objects.requireNonNull(entity, "HttpEntity");
         ContentType contentType = null;
         try {
             contentType = ContentType.parse(entity.getContentType());
@@ -334,7 +335,7 @@ public final class EntityUtils {
      * this instance of the Java virtual machine
      */
     public static String toString(final HttpEntity entity, final int maxResultLength) throws IOException, ParseException {
-        Args.notNull(entity, "HttpEntity");
+        Objects.requireNonNull(entity, "HttpEntity");
         return toString(entity, ContentType.parse(entity.getContentType()), maxResultLength);
     }
 
@@ -371,7 +372,7 @@ public final class EntityUtils {
      *             If there was an exception getting the entity's data.
      */
     public static List<NameValuePair> parse(final HttpEntity entity, final int maxStreamLength) throws IOException {
-        Args.notNull(entity, "HttpEntity");
+        Objects.requireNonNull(entity, "HttpEntity");
         final int contentLength = toContentLength((int) Args.checkContentLength(entity));
         final ContentType contentType = ContentType.parse(entity.getContentType());
         if (!ContentType.APPLICATION_FORM_URLENCODED.isSameMimeType(contentType)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/FileEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/FileEntity.java
@@ -31,11 +31,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A self contained, repeatable entity that obtains its content from a file.
@@ -49,12 +49,12 @@ public class FileEntity extends AbstractHttpEntity {
 
     public FileEntity(final File file, final ContentType contentType, final String contentEncoding) {
         super(contentType, contentEncoding);
-        this.file = Args.notNull(file, "File");
+        this.file = Objects.requireNonNull(file, "File");
     }
 
     public FileEntity(final File file, final ContentType contentType) {
         super(contentType, null);
-        this.file = Args.notNull(file, "File");
+        this.file = Objects.requireNonNull(file, "File");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/HttpEntities.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/HttpEntities.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
@@ -47,7 +48,6 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.io.IOCallback;
 import org.apache.hc.core5.net.URLEncodedUtils;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {HttpEntity} factory methods.
@@ -115,7 +115,7 @@ public final class HttpEntities {
 
             @Override
             public void writeTo(final OutputStream outStream) throws IOException {
-                Args.notNull(outStream, "Output stream");
+                Objects.requireNonNull(outStream, "Output stream");
                 final GZIPOutputStream gzip = new GZIPOutputStream(outStream);
                 super.writeTo(gzip);
                 // Only close output stream if the wrapped entity has been

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/HttpEntityWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/HttpEntityWrapper.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -38,7 +39,6 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Base class for wrapping entities that delegates all calls to the wrapped entity.
@@ -60,7 +60,7 @@ public class HttpEntityWrapper implements HttpEntity {
      */
     public HttpEntityWrapper(final HttpEntity wrappedEntity) {
         super();
-        this.wrappedEntity = Args.notNull(wrappedEntity, "Wrapped entity");
+        this.wrappedEntity = Objects.requireNonNull(wrappedEntity, "Wrapped entity");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/InputStreamEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/InputStreamEntity.java
@@ -30,9 +30,9 @@ package org.apache.hc.core5.http.io.entity;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A streamed, non-repeatable entity that obtains its content from an {@link InputStream}.
@@ -47,7 +47,7 @@ public class InputStreamEntity extends AbstractHttpEntity {
     public InputStreamEntity(
             final InputStream inStream, final long length, final ContentType contentType, final String contentEncoding) {
         super(contentType, contentEncoding);
-        this.content = Args.notNull(inStream, "Source input stream");
+        this.content = Objects.requireNonNull(inStream, "Source input stream");
         this.length = length;
     }
 
@@ -86,7 +86,7 @@ public class InputStreamEntity extends AbstractHttpEntity {
      */
     @Override
     public final void writeTo(final OutputStream outStream) throws IOException {
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(outStream, "Output stream");
         try (final InputStream inStream = this.content) {
             final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
             int readLen;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/PathEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/PathEntity.java
@@ -31,11 +31,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A self contained, repeatable entity that obtains its content from a path.
@@ -47,12 +47,12 @@ public class PathEntity extends AbstractHttpEntity {
 
     public PathEntity(final Path path, final ContentType contentType, final String contentEncoding) {
         super(contentType, contentEncoding);
-        this.path = Args.notNull(path, "Path");
+        this.path = Objects.requireNonNull(path, "Path");
     }
 
     public PathEntity(final Path path, final ContentType contentType) {
         super(contentType, null);
-        this.path = Args.notNull(path, "Path");
+        this.path = Objects.requireNonNull(path, "Path");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/SerializableEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/SerializableEntity.java
@@ -34,11 +34,11 @@ import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A streamed entity that obtains its content from a {@link Serializable}.
@@ -60,7 +60,7 @@ public class SerializableEntity extends AbstractHttpEntity {
     public SerializableEntity(
             final Serializable serializable, final ContentType contentType, final String contentEncoding) {
         super(contentType, contentEncoding);
-        this.serializable = Args.notNull(serializable, "Source object");
+        this.serializable = Objects.requireNonNull(serializable, "Source object");
     }
 
     /**
@@ -97,7 +97,7 @@ public class SerializableEntity extends AbstractHttpEntity {
 
     @Override
     public final void writeTo(final OutputStream outStream) throws IOException {
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(outStream, "Output stream");
         final ObjectOutputStream out = new ObjectOutputStream(outStream);
         out.writeObject(this.serializable);
         out.flush();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/StringEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/StringEntity.java
@@ -33,11 +33,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A self contained, repeatable entity that obtains its content from a {@link String}.
@@ -61,7 +61,7 @@ public class StringEntity extends AbstractHttpEntity {
     public StringEntity(
             final String string, final ContentType contentType, final String contentEncoding, final boolean chunked) {
         super(contentType, contentEncoding, chunked);
-        Args.notNull(string, "Source string");
+        Objects.requireNonNull(string, "Source string");
         Charset charset = contentType != null ? contentType.getCharset() : null;
         if (charset == null) {
             charset = StandardCharsets.ISO_8859_1;
@@ -124,7 +124,7 @@ public class StringEntity extends AbstractHttpEntity {
 
     @Override
     public final void writeTo(final OutputStream outStream) throws IOException {
-        Args.notNull(outStream, "Output stream");
+        Objects.requireNonNull(outStream, "Output stream");
         outStream.write(this.content);
         outStream.flush();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/BasicHttpServerExpectationDecorator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/BasicHttpServerExpectationDecorator.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.io.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.HttpServerRequestHandler;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link HttpServerRequestHandler} implementation that adds support
@@ -53,7 +53,7 @@ public class BasicHttpServerExpectationDecorator implements HttpServerRequestHan
     private final HttpServerRequestHandler requestHandler;
 
     public BasicHttpServerExpectationDecorator(final HttpServerRequestHandler requestHandler) {
-        this.requestHandler = Args.notNull(requestHandler, "Request handler");
+        this.requestHandler = Objects.requireNonNull(requestHandler, "Request handler");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/BasicHttpServerRequestHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/BasicHttpServerRequestHandler.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.io.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.impl.io.DefaultClassicHttpResponseFactory;
 import org.apache.hc.core5.http.io.HttpRequestHandler;
 import org.apache.hc.core5.http.io.HttpServerRequestHandler;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic {@link HttpServerRequestHandler} implementation that makes use of
@@ -56,7 +56,7 @@ public class BasicHttpServerRequestHandler implements HttpServerRequestHandler {
     public BasicHttpServerRequestHandler(
             final HttpRequestMapper<HttpRequestHandler> handlerMapper,
             final HttpResponseFactory<ClassicHttpResponse> responseFactory) {
-        this.handlerMapper = Args.notNull(handlerMapper, "Handler mapper");
+        this.handlerMapper = Objects.requireNonNull(handlerMapper, "Handler mapper");
         this.responseFactory = responseFactory != null ? responseFactory : DefaultClassicHttpResponseFactory.INSTANCE;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
@@ -345,7 +346,7 @@ public class ClassicRequestBuilder {
     }
 
     public ClassicRequestBuilder addParameter(final NameValuePair nvp) {
-        Args.notNull(nvp, "Name value pair");
+        Objects.requireNonNull(nvp, "Name value pair");
         if (parameters == null) {
             parameters = new LinkedList<>();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/HttpServerFilterChainRequestHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/HttpServerFilterChainRequestHandler.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.io.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -35,7 +36,6 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.io.HttpFilterChain;
 import org.apache.hc.core5.http.io.HttpServerRequestHandler;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link HttpServerRequestHandler} implementation that delegates request processing
@@ -48,7 +48,7 @@ public class HttpServerFilterChainRequestHandler implements HttpServerRequestHan
     private final HttpServerFilterChainElement filterChain;
 
     public HttpServerFilterChainRequestHandler(final HttpServerFilterChainElement filterChain) {
-        this.filterChain = Args.notNull(filterChain, "Filter chain");
+        this.filterChain = Objects.requireNonNull(filterChain, "Filter chain");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/TerminalServerFilter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/TerminalServerFilter.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.http.io.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -41,7 +42,6 @@ import org.apache.hc.core5.http.io.HttpFilterChain;
 import org.apache.hc.core5.http.io.HttpFilterHandler;
 import org.apache.hc.core5.http.io.HttpRequestHandler;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link HttpFilterHandler} implementation represents a terminal handler
@@ -59,7 +59,7 @@ public final class TerminalServerFilter implements HttpFilterHandler {
     public TerminalServerFilter(
             final HttpRequestMapper<HttpRequestHandler> handlerMapper,
             final HttpResponseFactory<ClassicHttpResponse> responseFactory) {
-        this.handlerMapper = Args.notNull(handlerMapper, "Handler mapper");
+        this.handlerMapper = Objects.requireNonNull(handlerMapper, "Handler mapper");
         this.responseFactory = responseFactory != null ? responseFactory : DefaultClassicHttpResponseFactory.INSTANCE;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/AbstractHeaderElementIterator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/AbstractHeaderElementIterator.java
@@ -29,10 +29,10 @@ package org.apache.hc.core5.http.message;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.FormattedHeader;
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link java.util.Iterator} of {@link org.apache.hc.core5.http.HeaderElement}s.
@@ -51,7 +51,7 @@ abstract class AbstractHeaderElementIterator<T> implements Iterator<T> {
      * Creates a new instance of BasicHeaderElementIterator
      */
     AbstractHeaderElementIterator(final Iterator<Header> headerIterator) {
-        this.headerIt = Args.notNull(headerIterator, "Header iterator");
+        this.headerIt = Objects.requireNonNull(headerIterator, "Header iterator");
     }
 
     private void bufferHeaderValue() {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/AbstractMessageWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/AbstractMessageWrapper.java
@@ -28,12 +28,12 @@
 package org.apache.hc.core5.http.message;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpMessage;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract {@link HttpMessage} wrapper.
@@ -43,7 +43,7 @@ public abstract class AbstractMessageWrapper implements HttpMessage {
     private final HttpMessage message;
 
     public AbstractMessageWrapper(final HttpMessage message) {
-        this.message = Args.notNull(message, "Message");
+        this.message = Objects.requireNonNull(message, "Message");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeader.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeader.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Immutable {@link Header}.
@@ -70,7 +69,7 @@ public class BasicHeader implements Header, Cloneable, Serializable {
      */
     public BasicHeader(final String name, final Object value, final boolean sensitive) {
         super();
-        this.name = Args.notNull(name, "Name");
+        this.name = Objects.requireNonNull(name, "Name");
         this.value = Objects.toString(value, null);
         this.sensitive = sensitive;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderElement.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderElement.java
@@ -27,9 +27,10 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.NameValuePair;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic implementation of {@link HeaderElement}
@@ -57,7 +58,7 @@ public class BasicHeaderElement implements HeaderElement {
             final String value,
             final NameValuePair[] parameters) {
         super();
-        this.name = Args.notNull(name, "Name");
+        this.name = Objects.requireNonNull(name, "Name");
         this.value = value;
         if (parameters != null) {
             this.parameters = parameters;
@@ -104,7 +105,7 @@ public class BasicHeaderElement implements HeaderElement {
 
     @Override
     public NameValuePair getParameterByName(final String name) {
-        Args.notNull(name, "Name");
+        Objects.requireNonNull(name, "Name");
         NameValuePair found = null;
         for (final NameValuePair current : this.parameters) {
             if (current.getName().equalsIgnoreCase(name)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderElementIterator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderElementIterator.java
@@ -28,10 +28,10 @@
 package org.apache.hc.core5.http.message;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HeaderElement;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link java.util.Iterator} of {@link org.apache.hc.core5.http.HeaderElement}s.
@@ -49,7 +49,7 @@ public class BasicHeaderElementIterator extends AbstractHeaderElementIterator<He
             final Iterator<Header> headerIterator,
             final HeaderValueParser parser) {
         super(headerIterator);
-        this.parser = Args.notNull(parser, "Parser");
+        this.parser = Objects.requireNonNull(parser, "Parser");
     }
 
     public BasicHeaderElementIterator(final Iterator<Header> headerIterator) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderIterator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderIterator.java
@@ -29,9 +29,9 @@ package org.apache.hc.core5.http.message;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link java.util.Iterator} of {@link org.apache.hc.core5.http.Header}s.
@@ -69,7 +69,7 @@ public class BasicHeaderIterator implements Iterator<Header> {
      */
     public BasicHeaderIterator(final Header[] headers, final String name) {
         super();
-        this.allHeaders = Args.notNull(headers, "Header array");
+        this.allHeaders = Objects.requireNonNull(headers, "Header array");
         this.headerName = name;
         this.currentIndex = findNext(-1);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderValueFormatter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderValueFormatter.java
@@ -27,11 +27,12 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.NameValuePair;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -54,8 +55,8 @@ public class BasicHeaderValueFormatter implements HeaderValueFormatter {
     @Override
     public void formatElements(
             final CharArrayBuffer buffer, final HeaderElement[] elems, final boolean quote) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(elems, "Header element array");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(elems, "Header element array");
 
         for (int i = 0; i < elems.length; i++) {
             if (i > 0) {
@@ -68,8 +69,8 @@ public class BasicHeaderValueFormatter implements HeaderValueFormatter {
     @Override
     public void formatHeaderElement(
             final CharArrayBuffer buffer, final HeaderElement elem, final boolean quote) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(elem, "Header element");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(elem, "Header element");
 
         buffer.append(elem.getName());
         final String value = elem.getValue();
@@ -90,8 +91,8 @@ public class BasicHeaderValueFormatter implements HeaderValueFormatter {
     @Override
     public void formatParameters(
             final CharArrayBuffer buffer, final NameValuePair[] nvps, final boolean quote) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(nvps, "Header parameter array");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(nvps, "Header parameter array");
 
         for (int i = 0; i < nvps.length; i++) {
             if (i > 0) {
@@ -104,8 +105,8 @@ public class BasicHeaderValueFormatter implements HeaderValueFormatter {
     @Override
     public void formatNameValuePair(
             final CharArrayBuffer buffer, final NameValuePair nvp, final boolean quote) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(nvp, "Name / value pair");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(nvp, "Name / value pair");
 
         buffer.append(nvp.getName());
         final String value = nvp.getValue();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderValueParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderValueParser.java
@@ -30,12 +30,12 @@ package org.apache.hc.core5.http.message;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.NameValuePair;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default {@link org.apache.hc.core5.http.message.HeaderValueParser} implementation.
@@ -63,8 +63,8 @@ public class BasicHeaderValueParser implements HeaderValueParser {
 
     @Override
     public HeaderElement[] parseElements(final CharSequence buffer, final ParserCursor cursor) {
-        Args.notNull(buffer, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buffer, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
         final List<HeaderElement> elements = new ArrayList<>();
         while (!cursor.atEnd()) {
             final HeaderElement element = parseHeaderElement(buffer, cursor);
@@ -77,8 +77,8 @@ public class BasicHeaderValueParser implements HeaderValueParser {
 
     @Override
     public HeaderElement parseHeaderElement(final CharSequence buffer, final ParserCursor cursor) {
-        Args.notNull(buffer, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buffer, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
         final NameValuePair nvp = parseNameValuePair(buffer, cursor);
         NameValuePair[] params = null;
         if (!cursor.atEnd()) {
@@ -92,8 +92,8 @@ public class BasicHeaderValueParser implements HeaderValueParser {
 
     @Override
     public NameValuePair[] parseParameters(final CharSequence buffer, final ParserCursor cursor) {
-        Args.notNull(buffer, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buffer, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
         tokenParser.skipWhiteSpace(buffer, cursor);
         final List<NameValuePair> params = new ArrayList<>();
         while (!cursor.atEnd()) {
@@ -109,8 +109,8 @@ public class BasicHeaderValueParser implements HeaderValueParser {
 
     @Override
     public NameValuePair parseNameValuePair(final CharSequence buffer, final ParserCursor cursor) {
-        Args.notNull(buffer, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buffer, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
 
         final String name = tokenParser.parseToken(buffer, cursor, TOKEN_DELIMS);
         if (cursor.atEnd()) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.message;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.net.URIAuthority;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TextUtils;
 
 /**
@@ -84,7 +84,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
      */
     public BasicHttpRequest(final String method, final HttpHost host, final String path) {
         super();
-        this.method = Args.notNull(method, "Method name");
+        this.method = Objects.requireNonNull(method, "Method name");
         this.scheme = host != null ? host.getSchemeName() : null;
         this.authority = host != null ? new URIAuthority(host) : null;
         this.path = path;
@@ -100,8 +100,8 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
      */
     public BasicHttpRequest(final String method, final URI requestUri) {
         super();
-        this.method = Args.notNull(method, "Method name");
-        setUri(Args.notNull(requestUri, "Request URI"));
+        this.method = Objects.requireNonNull(method, "Method name");
+        setUri(Objects.requireNonNull(requestUri, "Request URI"));
     }
 
     /**
@@ -114,7 +114,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
      */
     public BasicHttpRequest(final Method method, final String path) {
         super();
-        this.method = Args.notNull(method, "Method").name();
+        this.method = Objects.requireNonNull(method, "Method").name();
         if (path != null) {
             try {
                 setUri(new URI(path));
@@ -135,7 +135,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
      */
     public BasicHttpRequest(final Method method, final HttpHost host, final String path) {
         super();
-        this.method = Args.notNull(method, "Method").name();
+        this.method = Objects.requireNonNull(method, "Method").name();
         this.scheme = host != null ? host.getSchemeName() : null;
         this.authority = host != null ? new URIAuthority(host) : null;
         this.path = path;
@@ -151,19 +151,19 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
      */
     public BasicHttpRequest(final Method method, final URI requestUri) {
         super();
-        this.method = Args.notNull(method, "Method").name();
-        setUri(Args.notNull(requestUri, "Request URI"));
+        this.method = Objects.requireNonNull(method, "Method").name();
+        setUri(Objects.requireNonNull(requestUri, "Request URI"));
     }
 
     @Override
     public void addHeader(final String name, final Object value) {
-        Args.notNull(name, "Header name");
+        Objects.requireNonNull(name, "Header name");
         addHeader(new BasicHeader(name, value));
     }
 
     @Override
     public void setHeader(final String name, final Object value) {
-        Args.notNull(name, "Header name");
+        Objects.requireNonNull(name, "Header name");
         setHeader(new BasicHeader(name, value));
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpResponse.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpResponse.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.message;
 
 import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.ProtocolVersion;
@@ -97,13 +98,13 @@ public class BasicHttpResponse extends HeaderGroup implements HttpResponse {
 
     @Override
     public void addHeader(final String name, final Object value) {
-        Args.notNull(name, "Header name");
+        Objects.requireNonNull(name, "Header name");
         addHeader(new BasicHeader(name, value));
     }
 
     @Override
     public void setHeader(final String name, final Object value) {
-        Args.notNull(name, "Header name");
+        Objects.requireNonNull(name, "Header name");
         setHeader(new BasicHeader(name, value));
     }
 
@@ -146,7 +147,7 @@ public class BasicHttpResponse extends HeaderGroup implements HttpResponse {
 
     @Override
     public void setLocale(final Locale locale) {
-        this.locale = Args.notNull(locale, "Locale");
+        this.locale = Objects.requireNonNull(locale, "Locale");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicLineFormatter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicLineFormatter.java
@@ -27,11 +27,12 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -54,8 +55,8 @@ public class BasicLineFormatter implements LineFormatter {
 
     @Override
     public void formatRequestLine(final CharArrayBuffer buffer, final RequestLine reqline) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(reqline, "Request line");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(reqline, "Request line");
         buffer.append(reqline.getMethod());
         buffer.append(' ');
         buffer.append(reqline.getUri());
@@ -65,8 +66,8 @@ public class BasicLineFormatter implements LineFormatter {
 
     @Override
     public void formatStatusLine(final CharArrayBuffer buffer, final StatusLine statusLine) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(statusLine, "Status line");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(statusLine, "Status line");
 
         formatProtocolVersion(buffer, statusLine.getProtocolVersion());
         buffer.append(' ');
@@ -80,8 +81,8 @@ public class BasicLineFormatter implements LineFormatter {
 
     @Override
     public void formatHeader(final CharArrayBuffer buffer, final Header header) {
-        Args.notNull(buffer, "Char array buffer");
-        Args.notNull(header, "Header");
+        Objects.requireNonNull(buffer, "Char array buffer");
+        Objects.requireNonNull(header, "Header");
 
         buffer.append(header.getName());
         buffer.append(": ");

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicLineParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicLineParser.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.message;
 
 import java.util.BitSet;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -35,7 +36,6 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 import org.apache.hc.core5.util.TextUtils;
 
@@ -147,7 +147,7 @@ public class BasicLineParser implements LineParser {
      */
     @Override
     public RequestLine parseRequestLine(final CharArrayBuffer buffer) throws ParseException {
-        Args.notNull(buffer, "Char array buffer");
+        Objects.requireNonNull(buffer, "Char array buffer");
 
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         this.tokenParser.skipWhiteSpace(buffer, cursor);
@@ -173,7 +173,7 @@ public class BasicLineParser implements LineParser {
 
     @Override
     public StatusLine parseStatusLine(final CharArrayBuffer buffer) throws ParseException {
-        Args.notNull(buffer, "Char array buffer");
+        Objects.requireNonNull(buffer, "Char array buffer");
 
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         this.tokenParser.skipWhiteSpace(buffer, cursor);
@@ -199,7 +199,7 @@ public class BasicLineParser implements LineParser {
 
     @Override
     public Header parseHeader(final CharArrayBuffer buffer) throws ParseException {
-        Args.notNull(buffer, "Char array buffer");
+        Objects.requireNonNull(buffer, "Char array buffer");
 
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         this.tokenParser.skipWhiteSpace(buffer, cursor);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicListHeaderIterator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicListHeaderIterator.java
@@ -30,9 +30,9 @@ package org.apache.hc.core5.http.message;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 
 /**
@@ -75,7 +75,7 @@ class BasicListHeaderIterator implements Iterator<Header> {
      */
     public BasicListHeaderIterator(final List<Header> headers, final String name) {
         super();
-        this.allHeaders = Args.notNull(headers, "Header list");
+        this.allHeaders = Objects.requireNonNull(headers, "Header list");
         this.headerName = name;
         this.currentIndex = findNext(-1);
         this.lastIndex = -1;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicNameValuePair.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicNameValuePair.java
@@ -29,11 +29,11 @@ package org.apache.hc.core5.http.message;
 
 import java.io.Serializable;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.NameValuePair;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.LangUtils;
 
 /**
@@ -57,7 +57,7 @@ public class BasicNameValuePair implements NameValuePair, Serializable {
      */
     public BasicNameValuePair(final String name, final String value) {
         super();
-        this.name = Args.notNull(name, "Name");
+        this.name = Objects.requireNonNull(name, "Name");
         this.value = value;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BufferedHeader.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BufferedHeader.java
@@ -28,10 +28,10 @@
 package org.apache.hc.core5.http.message;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.FormattedHeader;
 import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -85,7 +85,7 @@ public class BufferedHeader implements FormattedHeader, Serializable {
 
     BufferedHeader(final CharArrayBuffer buffer, final boolean strict) throws ParseException {
         super();
-        Args.notNull(buffer, "Char array buffer");
+        Objects.requireNonNull(buffer, "Char array buffer");
         final int colon = buffer.indexOf(':');
         if (colon <= 0) {
             throw new ParseException("Invalid header", buffer, 0, buffer.length());

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/LazyLaxLineParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/LazyLaxLineParser.java
@@ -27,9 +27,10 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -52,7 +53,7 @@ public class LazyLaxLineParser extends BasicLineParser {
 
     @Override
     public Header parseHeader(final CharArrayBuffer buffer) throws ParseException {
-        Args.notNull(buffer, "Char array buffer");
+        Objects.requireNonNull(buffer, "Char array buffer");
 
         return new BufferedHeader(buffer, false);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/LazyLineParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/LazyLineParser.java
@@ -27,11 +27,12 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
 /**
@@ -50,7 +51,7 @@ public class LazyLineParser extends BasicLineParser {
 
     @Override
     public Header parseHeader(final CharArrayBuffer buffer) throws ParseException {
-        Args.notNull(buffer, "Char array buffer");
+        Objects.requireNonNull(buffer, "Char array buffer");
 
         return new BufferedHeader(buffer, true);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/MessageSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/MessageSupport.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.message;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.http.EntityDetails;
@@ -58,7 +59,7 @@ public class MessageSupport {
     }
 
     public static void formatTokens(final CharArrayBuffer dst, final String... tokens) {
-        Args.notNull(dst, "Destination");
+        Objects.requireNonNull(dst, "Destination");
         for (int i = 0; i < tokens.length; i++) {
             final String element = tokens[i];
             if (i > 0) {
@@ -69,7 +70,7 @@ public class MessageSupport {
     }
 
     public static void formatTokens(final CharArrayBuffer dst, final Set<String> tokens) {
-        Args.notNull(dst, "Destination");
+        Objects.requireNonNull(dst, "Destination");
         if (tokens == null || tokens.isEmpty()) {
             return;
         }
@@ -103,8 +104,8 @@ public class MessageSupport {
     private static final BitSet COMMA = TokenParser.INIT_BITSET(',');
 
     public static Set<String> parseTokens(final CharSequence src, final ParserCursor cursor) {
-        Args.notNull(src, "Source");
-        Args.notNull(cursor, "Cursor");
+        Objects.requireNonNull(src, "Source");
+        Objects.requireNonNull(cursor, "Cursor");
         final Set<String> tokens = new LinkedHashSet<>();
         while (!cursor.atEnd()) {
             final int pos = cursor.getPos();
@@ -120,7 +121,7 @@ public class MessageSupport {
     }
 
     public static Set<String> parseTokens(final Header header) {
-        Args.notNull(header, "Header");
+        Objects.requireNonNull(header, "Header");
         if (header instanceof FormattedHeader) {
             final CharArrayBuffer buf = ((FormattedHeader) header).getBuffer();
             final ParserCursor cursor = new ParserCursor(0, buf.length());
@@ -154,13 +155,13 @@ public class MessageSupport {
     }
 
     public static Iterator<HeaderElement> iterate(final MessageHeaders headers, final String name) {
-        Args.notNull(headers, "Message headers");
+        Objects.requireNonNull(headers, "Message headers");
         Args.notBlank(name, "Header name");
         return new BasicHeaderElementIterator(headers.headerIterator(name));
     }
 
     public static HeaderElement[] parse(final Header header) {
-        Args.notNull(header, "Headers");
+        Objects.requireNonNull(header, "Headers");
         final String value = header.getValue();
         if (value == null) {
             return new HeaderElement[] {};

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/RequestLine.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/RequestLine.java
@@ -28,13 +28,13 @@
 package org.apache.hc.core5.http.message;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/1.1 request line.
@@ -52,7 +52,7 @@ public final class RequestLine implements Serializable {
 
     public RequestLine(final HttpRequest request) {
         super();
-        Args.notNull(request, "Request");
+        Objects.requireNonNull(request, "Request");
         this.method = request.getMethod();
         this.uri = request.getRequestUri();
         this.protoversion = request.getVersion() != null ? request.getVersion() : HttpVersion.HTTP_1_1;
@@ -62,8 +62,8 @@ public final class RequestLine implements Serializable {
                        final String uri,
                        final ProtocolVersion version) {
         super();
-        this.method = Args.notNull(method, "Method");
-        this.uri = Args.notNull(uri, "URI");
+        this.method = Objects.requireNonNull(method, "Method");
+        this.uri = Objects.requireNonNull(uri, "URI");
         this.protoversion = version != null ? version : HttpVersion.HTTP_1_1;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/StatusLine.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/StatusLine.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.message;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -68,7 +69,7 @@ public final class StatusLine implements Serializable {
 
     public StatusLine(final HttpResponse response) {
         super();
-        Args.notNull(response, "Response");
+        Objects.requireNonNull(response, "Response");
         this.protoVersion = response.getVersion() != null ? response.getVersion() : HttpVersion.HTTP_1_1;
         this.statusCode = response.getCode();
         this.statusClass = StatusClass.from(this.statusCode);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/TokenParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/TokenParser.java
@@ -28,11 +28,11 @@
 package org.apache.hc.core5.http.message;
 
 import java.util.BitSet;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.Chars;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Low level parser for header field elements. The parsing routines of this class are designed
@@ -75,8 +75,8 @@ public class TokenParser {
      *  is not delimited by any character.
      */
     public String parseToken(final CharSequence buf, final ParserCursor cursor, final BitSet delimiters) {
-        Args.notNull(buf, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buf, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
         final StringBuilder dst = new StringBuilder();
         boolean whitespace = false;
         while (!cursor.atEnd()) {
@@ -108,8 +108,8 @@ public class TokenParser {
      *  is not delimited by any character.
      */
     public String parseValue(final CharSequence buf, final ParserCursor cursor, final BitSet delimiters) {
-        Args.notNull(buf, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buf, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
         final StringBuilder dst = new StringBuilder();
         boolean whitespace = false;
         while (!cursor.atEnd()) {
@@ -144,8 +144,8 @@ public class TokenParser {
      * @param cursor defines the bounds and current position of the buffer
      */
     public void skipWhiteSpace(final CharSequence buf, final ParserCursor cursor) {
-        Args.notNull(buf, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
+        Objects.requireNonNull(buf, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
         int pos = cursor.getPos();
         final int indexFrom = cursor.getPos();
         final int indexTo = cursor.getUpperBound();
@@ -171,9 +171,9 @@ public class TokenParser {
      */
     public void copyContent(final CharSequence buf, final ParserCursor cursor, final BitSet delimiters,
             final StringBuilder dst) {
-        Args.notNull(buf, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
-        Args.notNull(dst, "String builder");
+        Objects.requireNonNull(buf, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
+        Objects.requireNonNull(dst, "String builder");
         int pos = cursor.getPos();
         final int indexFrom = cursor.getPos();
         final int indexTo = cursor.getUpperBound();
@@ -200,9 +200,9 @@ public class TokenParser {
      */
     public void copyUnquotedContent(final CharSequence buf, final ParserCursor cursor,
             final BitSet delimiters, final StringBuilder dst) {
-        Args.notNull(buf, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
-        Args.notNull(dst, "String builder");
+        Objects.requireNonNull(buf, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
+        Objects.requireNonNull(dst, "String builder");
         int pos = cursor.getPos();
         final int indexFrom = cursor.getPos();
         final int indexTo = cursor.getUpperBound();
@@ -227,9 +227,9 @@ public class TokenParser {
      */
     public void copyQuotedContent(final CharSequence buf, final ParserCursor cursor,
             final StringBuilder dst) {
-        Args.notNull(buf, "Char sequence");
-        Args.notNull(cursor, "Parser cursor");
-        Args.notNull(dst, "String builder");
+        Objects.requireNonNull(buf, "Char sequence");
+        Objects.requireNonNull(cursor, "Parser cursor");
+        Objects.requireNonNull(dst, "String builder");
         if (cursor.atEnd()) {
             return;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/CommandSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/CommandSupport.java
@@ -27,12 +27,13 @@
 
 package org.apache.hc.core5.http.nio.command;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.nio.AsyncClientExchangeHandler;
 import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.IOSession;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link Command} utility methods.
@@ -46,7 +47,7 @@ public final class CommandSupport {
      * Fails all pending session {@link Command}s.
      */
     static public void failCommands(final IOSession ioSession, final Exception ex) {
-        Args.notNull(ioSession, "I/O session");
+        Objects.requireNonNull(ioSession, "I/O session");
         Command command;
         while ((command = ioSession.poll()) != null) {
             if (command instanceof RequestExecutionCommand) {
@@ -66,7 +67,7 @@ public final class CommandSupport {
      * Cancels all pending session {@link Command}s.
      */
     static public void cancelCommands(final IOSession ioSession) {
-        Args.notNull(ioSession, "I/O session");
+        Objects.requireNonNull(ioSession, "I/O session");
         Command command;
         while ((command = ioSession.poll()) != null) {
             if (command instanceof RequestExecutionCommand) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/RequestExecutionCommand.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/RequestExecutionCommand.java
@@ -27,13 +27,14 @@
 
 package org.apache.hc.core5.http.nio.command;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.concurrent.CancellableDependency;
 import org.apache.hc.core5.http.nio.AsyncClientExchangeHandler;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Request execution command.
@@ -53,7 +54,7 @@ public final class RequestExecutionCommand extends ExecutableCommand {
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
             final CancellableDependency cancellableDependency,
             final HttpContext context) {
-        this.exchangeHandler = Args.notNull(exchangeHandler, "Handler");
+        this.exchangeHandler = Objects.requireNonNull(exchangeHandler, "Handler");
         this.pushHandlerFactory = pushHandlerFactory;
         this.cancellableDependency = cancellableDependency;
         this.context = context;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityConsumer.java
@@ -29,13 +29,13 @@ package org.apache.hc.core5.http.nio.entity;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Objects;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract binary entity content consumer.
@@ -67,7 +67,7 @@ public abstract class AbstractBinAsyncEntityConsumer<T> extends AbstractBinDataC
     public final void streamStart(
             final EntityDetails entityDetails,
             final FutureCallback<T> resultCallback) throws IOException, HttpException {
-        Args.notNull(resultCallback, "Result callback");
+        Objects.requireNonNull(resultCallback, "Result callback");
         this.resultCallback = resultCallback;
         try {
             final ContentType contentType = entityDetails != null ? ContentType.parse(entityDetails.getContentType()) : null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityProducer.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http.nio.entity;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.StreamChannel;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract binary entity content producer.
@@ -177,7 +177,7 @@ public abstract class AbstractBinAsyncEntityProducer implements AsyncEntityProdu
 
                     @Override
                     public int write(final ByteBuffer src) throws IOException {
-                        Args.notNull(src, "Buffer");
+                        Objects.requireNonNull(src, "Buffer");
                         synchronized (bytebuf) {
                             return writeData(channel, src);
                         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityConsumer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.entity;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Objects;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ContentType;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract text entity content consumer.
@@ -75,7 +75,7 @@ public abstract class AbstractCharAsyncEntityConsumer<T> extends AbstractCharDat
     public final void streamStart(
             final EntityDetails entityDetails,
             final FutureCallback<T> resultCallback) throws IOException, HttpException {
-        Args.notNull(resultCallback, "Result callback");
+        Objects.requireNonNull(resultCallback, "Result callback");
         this.resultCallback = resultCallback;
         try {
             final ContentType contentType = entityDetails != null ? ContentType.parse(entityDetails.getContentType()) : null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityProducer.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -195,7 +196,7 @@ public abstract class AbstractCharAsyncEntityProducer implements AsyncEntityProd
 
                     @Override
                     public int write(final CharBuffer src) throws IOException {
-                        Args.notNull(src, "Buffer");
+                        Objects.requireNonNull(src, "Buffer");
                         synchronized (bytebuf) {
                             return writeData(channel, src);
                         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AsyncEntityProducerWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AsyncEntityProducerWrapper.java
@@ -28,13 +28,13 @@
 package org.apache.hc.core5.http.nio.entity;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Base class for wrapping entity producers that delegates all calls to the wrapped producer.
@@ -50,7 +50,7 @@ public class AsyncEntityProducerWrapper implements AsyncEntityProducer {
 
     public AsyncEntityProducerWrapper(final AsyncEntityProducer wrappedEntityProducer) {
         super();
-        this.wrappedEntityProducer = Args.notNull(wrappedEntityProducer, "Wrapped entity producer");
+        this.wrappedEntityProducer = Objects.requireNonNull(wrappedEntityProducer, "Wrapped entity producer");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
@@ -31,13 +31,13 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic {@link AsyncEntityProducer} implementation that generates data stream
@@ -54,7 +54,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     private final AtomicReference<Exception> exception;
 
     public BasicAsyncEntityProducer(final byte[] content, final ContentType contentType, final boolean chunked) {
-        Args.notNull(content, "Content");
+        Objects.requireNonNull(content, "Content");
         this.bytebuf = ByteBuffer.wrap(content);
         this.length = this.bytebuf.remaining();
         this.contentType = contentType;
@@ -71,7 +71,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     }
 
     public BasicAsyncEntityProducer(final CharSequence content, final ContentType contentType, final boolean chunked) {
-        Args.notNull(content, "Content");
+        Objects.requireNonNull(content, "Content");
         this.contentType = contentType;
         Charset charset = contentType != null ? contentType.getCharset() : null;
         if (charset == null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityConsumer.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.EntityDetails;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link AsyncEntityConsumer} decorator that calculates a digest hash from
@@ -59,7 +59,7 @@ public class DigestingEntityConsumer<T> implements AsyncEntityConsumer<T> {
     public DigestingEntityConsumer(
             final String algo,
             final AsyncEntityConsumer<T> wrapped) throws NoSuchAlgorithmException {
-        this.wrapped = Args.notNull(wrapped, "Entity consumer");
+        this.wrapped = Objects.requireNonNull(wrapped, "Entity consumer");
         this.trailers = new ArrayList<>();
         this.digester = MessageDigest.getInstance(algo);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityProducer.java
@@ -33,13 +33,13 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TextUtils;
 
 /**
@@ -58,7 +58,7 @@ public class DigestingEntityProducer implements AsyncEntityProducer {
     public DigestingEntityProducer(
             final String algo,
             final AsyncEntityProducer wrapped) {
-        this.wrapped = Args.notNull(wrapped, "Entity consumer");
+        this.wrapped = Objects.requireNonNull(wrapped, "Entity consumer");
         try {
             this.digester = MessageDigest.getInstance(algo);
         } catch (final NoSuchAlgorithmException ex) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/FileEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/FileEntityProducer.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.io.Closer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 
 /**
@@ -58,7 +58,7 @@ public final class FileEntityProducer implements AsyncEntityProducer {
     private boolean eof;
 
     public FileEntityProducer(final File file, final int bufferSize, final ContentType contentType, final boolean chunked) {
-        this.file = Args.notNull(file, "File");
+        this.file = Objects.requireNonNull(file, "File");
         this.length = file.length();
         this.byteBuffer = ByteBuffer.allocate(bufferSize);
         this.contentType = contentType;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityConsumer.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http.nio.entity;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpException;
@@ -75,7 +76,7 @@ public class StringAsyncEntityConsumer extends AbstractCharAsyncEntityConsumer<S
 
     @Override
     protected final void data(final CharBuffer src, final boolean endOfStream) {
-        Args.notNull(src, "CharBuffer");
+        Objects.requireNonNull(src, "CharBuffer");
         final int chunk = src.remaining();
         content.ensureCapacity(chunk);
         src.get(content.array(), content.length(), chunk);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
@@ -28,11 +28,11 @@ package org.apache.hc.core5.http.nio.entity;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.nio.StreamChannel;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 
 /**
@@ -52,7 +52,7 @@ public class StringAsyncEntityProducer extends AbstractCharAsyncEntityProducer {
             final int fragmentSizeHint,
             final ContentType contentType) {
         super(bufferSize, fragmentSizeHint, contentType);
-        Args.notNull(content, "Content");
+        Objects.requireNonNull(content, "Content");
         this.content = CharBuffer.wrap(content);
         this.exception = new AtomicReference<>(null);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicClientTlsStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicClientTlsStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.nio.ssl;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -38,7 +39,6 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -59,7 +59,7 @@ public class BasicClientTlsStrategy implements TlsStrategy {
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
             final SSLSessionVerifier verifier) {
-        this.sslContext = Args.notNull(sslContext, "SSL context");
+        this.sslContext = Objects.requireNonNull(sslContext, "SSL context");
         this.sslBufferMode = sslBufferMode;
         this.initializer = initializer;
         this.verifier = verifier;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicServerTlsStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/BasicServerTlsStrategy.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.nio.ssl;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -37,7 +38,6 @@ import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
 import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.ssl.SSLContexts;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -60,7 +60,7 @@ public class BasicServerTlsStrategy implements TlsStrategy {
             final SSLBufferMode sslBufferMode,
             final SSLSessionInitializer initializer,
             final SSLSessionVerifier verifier) {
-        this.sslContext = Args.notNull(sslContext, "SSL context");
+        this.sslContext = Objects.requireNonNull(sslContext, "SSL context");
         this.securePortStrategy = securePortStrategy;
         this.sslBufferMode = sslBufferMode;
         this.initializer = initializer;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/FixedPortStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ssl/FixedPortStrategy.java
@@ -29,8 +29,7 @@ package org.apache.hc.core5.http.nio.ssl;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * Basic implementation of {@link SecurePortStrategy} with a fixed list of secure ports.
@@ -42,7 +41,7 @@ public final class FixedPortStrategy implements SecurePortStrategy {
     private final int[] securePorts;
 
     public FixedPortStrategy(final int... securePorts) {
-        this.securePorts = Args.notNull(securePorts, "Secure ports");
+        this.securePorts = Objects.requireNonNull(securePorts, "Secure ports");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncPushHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncPushHandler.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.EntityDetails;
@@ -40,7 +41,6 @@ import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract push response handler.
@@ -54,7 +54,7 @@ public abstract class AbstractAsyncPushHandler<T> implements AsyncPushConsumer {
     private final AsyncResponseConsumer<T> responseConsumer;
 
     public AbstractAsyncPushHandler(final AsyncResponseConsumer<T> responseConsumer) {
-        this.responseConsumer = Args.notNull(responseConsumer, "Response consumer");
+        this.responseConsumer = Objects.requireNonNull(responseConsumer, "Response consumer");
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncRequesterConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncRequesterConsumer.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -43,7 +44,6 @@ import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.AsyncRequestConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract asynchronous request consumer that makes use of {@link AsyncEntityConsumer}
@@ -60,7 +60,7 @@ public abstract class AbstractAsyncRequesterConsumer<T, E> implements AsyncReque
     private final AtomicReference<AsyncEntityConsumer<E>> dataConsumerRef;
 
     public AbstractAsyncRequesterConsumer(final Supplier<AsyncEntityConsumer<E>> dataConsumerSupplier) {
-        this.dataConsumerSupplier = Args.notNull(dataConsumerSupplier, "Data consumer supplier");
+        this.dataConsumerSupplier = Objects.requireNonNull(dataConsumerSupplier, "Data consumer supplier");
         this.dataConsumerRef = new AtomicReference<>(null);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncResponseConsumer.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -43,7 +44,6 @@ import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract asynchronous response consumer that makes use of {@link AsyncEntityConsumer}
@@ -60,7 +60,7 @@ public abstract class AbstractAsyncResponseConsumer<T, E> implements AsyncRespon
     private final AtomicReference<AsyncEntityConsumer<E>> dataConsumerRef;
 
     public AbstractAsyncResponseConsumer(final Supplier<AsyncEntityConsumer<E>> dataConsumerSupplier) {
-        this.dataConsumerSupplier = Args.notNull(dataConsumerSupplier, "Data consumer supplier");
+        this.dataConsumerSupplier = Objects.requireNonNull(dataConsumerSupplier, "Data consumer supplier");
         this.dataConsumerRef = new AtomicReference<>(null);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
@@ -320,7 +321,7 @@ public class AsyncRequestBuilder {
     }
 
     public AsyncRequestBuilder addParameter(final NameValuePair nvp) {
-        Args.notNull(nvp, "Name value pair");
+        Objects.requireNonNull(nvp, "Name value pair");
         if (parameters == null) {
             parameters = new LinkedList<>();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncServerFilterChainExchangeHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncServerFilterChainExchangeHandlerFactory.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.http.EntityDetails;
@@ -48,7 +49,6 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.nio.ResponseChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 
 /**
@@ -62,7 +62,7 @@ public final class AsyncServerFilterChainExchangeHandlerFactory implements Handl
     private final AsyncServerFilterChainElement filterChain;
 
     public AsyncServerFilterChainExchangeHandlerFactory(final AsyncServerFilterChainElement filterChain) {
-        this.filterChain = Args.notNull(filterChain, "Filter chain");
+        this.filterChain = Objects.requireNonNull(filterChain, "Filter chain");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicAsyncServerExpectationDecorator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicAsyncServerExpectationDecorator.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.http.EntityDetails;
@@ -45,7 +46,6 @@ import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.ResponseChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link AsyncServerExchangeHandler} implementation that adds support
@@ -60,7 +60,7 @@ public class BasicAsyncServerExpectationDecorator implements AsyncServerExchange
     private final AtomicReference<AsyncResponseProducer> responseProducerRef;
 
     public BasicAsyncServerExpectationDecorator(final AsyncServerExchangeHandler handler) {
-        this.handler = Args.notNull(handler, "Handler");
+        this.handler = Objects.requireNonNull(handler, "Handler");
         this.responseProducerRef = new AtomicReference<>(null);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicClientExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicClientExchangeHandler.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -44,7 +45,6 @@ import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.RequestChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic {@link AsyncClientExchangeHandler} implementation that makes use
@@ -65,8 +65,8 @@ public final class BasicClientExchangeHandler<T> implements AsyncClientExchangeH
             final AsyncRequestProducer requestProducer,
             final AsyncResponseConsumer<T> responseConsumer,
             final FutureCallback<T> resultCallback) {
-        this.requestProducer = Args.notNull(requestProducer, "Request producer");
-        this.responseConsumer = Args.notNull(responseConsumer, "Response consumer");
+        this.requestProducer = Objects.requireNonNull(requestProducer, "Request producer");
+        this.responseConsumer = Objects.requireNonNull(responseConsumer, "Response consumer");
         this.completed = new AtomicBoolean(false);
         this.resultCallback = resultCallback;
         this.outputTerminated = new AtomicBoolean(false);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicPushProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicPushProducer.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.http.nio.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpResponse;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.nio.AsyncPushProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.ResponseChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic implementation of {@link AsyncPushProducer} that produces one fixed response
@@ -51,8 +51,8 @@ public class BasicPushProducer implements AsyncPushProducer {
     private final AsyncEntityProducer dataProducer;
 
     public BasicPushProducer(final HttpResponse response, final AsyncEntityProducer dataProducer) {
-        this.response = Args.notNull(response, "Response");
-        this.dataProducer = Args.notNull(dataProducer, "Entity producer");
+        this.response = Objects.requireNonNull(response, "Response");
+        this.dataProducer = Objects.requireNonNull(dataProducer, "Entity producer");
     }
 
     public BasicPushProducer(final int code, final AsyncEntityProducer dataProducer) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicRequestConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicRequestConsumer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -42,7 +43,6 @@ import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.AsyncRequestConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic implementation of {@link AsyncRequestConsumer} that represents the request message as
@@ -56,7 +56,7 @@ public class BasicRequestConsumer<T> implements AsyncRequestConsumer<Message<Htt
     private final AtomicReference<AsyncEntityConsumer<T>> dataConsumerRef;
 
     public BasicRequestConsumer(final Supplier<AsyncEntityConsumer<T>> dataConsumerSupplier) {
-        this.dataConsumerSupplier = Args.notNull(dataConsumerSupplier, "Data consumer supplier");
+        this.dataConsumerSupplier = Objects.requireNonNull(dataConsumerSupplier, "Data consumer supplier");
         this.dataConsumerRef = new AtomicReference<>(null);
     }
 
@@ -77,7 +77,7 @@ public class BasicRequestConsumer<T> implements AsyncRequestConsumer<Message<Htt
             final EntityDetails entityDetails,
             final HttpContext httpContext,
             final FutureCallback<Message<HttpRequest, T>> resultCallback) throws HttpException, IOException {
-        Args.notNull(request, "Request");
+        Objects.requireNonNull(request, "Request");
         if (entityDetails != null) {
             final AsyncEntityConsumer<T> dataConsumer = dataConsumerSupplier.get();
             if (dataConsumer == null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseConsumer.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -42,7 +43,6 @@ import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic implementation of {@link AsyncResponseConsumer} that represents response message as
@@ -57,7 +57,7 @@ public class BasicResponseConsumer<T> implements AsyncResponseConsumer<Message<H
     private final AtomicReference<AsyncEntityConsumer<T>> dataConsumerRef;
 
     public BasicResponseConsumer(final Supplier<AsyncEntityConsumer<T>> dataConsumerSupplier) {
-        this.dataConsumerSupplier = Args.notNull(dataConsumerSupplier, "Data consumer supplier");
+        this.dataConsumerSupplier = Objects.requireNonNull(dataConsumerSupplier, "Data consumer supplier");
         this.dataConsumerRef = new AtomicReference<>(null);
     }
 
@@ -77,7 +77,7 @@ public class BasicResponseConsumer<T> implements AsyncResponseConsumer<Message<H
             final HttpResponse response,
             final EntityDetails entityDetails,
             final HttpContext httpContext, final FutureCallback<Message<HttpResponse, T>> resultCallback) throws HttpException, IOException {
-        Args.notNull(response, "Response");
+        Objects.requireNonNull(response, "Response");
 
         if (entityDetails != null) {
             final AsyncEntityConsumer<T> dataConsumer = dataConsumerSupplier.get();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseProducer.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.http.nio.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpException;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.ResponseChannel;
 import org.apache.hc.core5.http.nio.entity.AsyncEntityProducers;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic implementation of {@link AsyncResponseProducer} that produces one fixed response
@@ -53,12 +53,12 @@ public class BasicResponseProducer implements AsyncResponseProducer {
     private final AsyncEntityProducer dataProducer;
 
     public BasicResponseProducer(final HttpResponse response, final AsyncEntityProducer dataProducer) {
-        this.response = Args.notNull(response, "Response");
+        this.response = Objects.requireNonNull(response, "Response");
         this.dataProducer = dataProducer;
     }
 
     public BasicResponseProducer(final HttpResponse response) {
-        this.response = Args.notNull(response, "Response");
+        this.response = Objects.requireNonNull(response, "Response");
         this.dataProducer = null;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicServerExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicServerExchangeHandler.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.http.nio.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
@@ -34,7 +35,6 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.nio.AsyncRequestConsumer;
 import org.apache.hc.core5.http.nio.AsyncServerRequestHandler;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Basic {@link AbstractServerExchangeHandler} implementation that delegates
@@ -48,7 +48,7 @@ public class BasicServerExchangeHandler<T> extends AbstractServerExchangeHandler
 
     public BasicServerExchangeHandler(final AsyncServerRequestHandler<T> requestHandler) {
         super();
-        this.requestHandler = Args.notNull(requestHandler, "Response handler");
+        this.requestHandler = Objects.requireNonNull(requestHandler, "Response handler");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/DefaultAsyncResponseExchangeHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/DefaultAsyncResponseExchangeHandlerFactory.java
@@ -26,6 +26,8 @@
  */
 package org.apache.hc.core5.http.nio.support;
 
+import java.util.Objects;
+
 import org.apache.hc.core5.function.Decorator;
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.HttpException;
@@ -36,7 +38,6 @@ import org.apache.hc.core5.http.MisdirectedRequestException;
 import org.apache.hc.core5.http.nio.AsyncServerExchangeHandler;
 import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Factory for {@link AsyncServerExchangeHandler} instances that make use
@@ -53,7 +54,7 @@ public final class DefaultAsyncResponseExchangeHandlerFactory implements Handler
     public DefaultAsyncResponseExchangeHandlerFactory(
             final HttpRequestMapper<Supplier<AsyncServerExchangeHandler>> mapper,
             final Decorator<AsyncServerExchangeHandler> decorator) {
-        this.mapper = Args.notNull(mapper, "Request handler mapper");
+        this.mapper = Objects.requireNonNull(mapper, "Request handler mapper");
         this.decorator = decorator;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/ImmediateResponseExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/ImmediateResponseExchangeHandler.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.nio.support;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
@@ -43,7 +44,6 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.ResponseChannel;
 import org.apache.hc.core5.http.nio.entity.AsyncEntityProducers;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link AsyncServerExchangeHandler} implementation that immediately responds
@@ -57,7 +57,7 @@ public final class ImmediateResponseExchangeHandler implements AsyncServerExchan
     private final AsyncResponseProducer responseProducer;
 
     public ImmediateResponseExchangeHandler(final AsyncResponseProducer responseProducer) {
-        this.responseProducer = Args.notNull(responseProducer, "Response producer");
+        this.responseProducer = Objects.requireNonNull(responseProducer, "Response producer");
     }
 
     public ImmediateResponseExchangeHandler(final HttpResponse response, final String message) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/TerminalAsyncServerFilter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/TerminalAsyncServerFilter.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.http.nio.support;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -48,7 +49,6 @@ import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.nio.ResponseChannel;
 import org.apache.hc.core5.http.nio.entity.AsyncEntityProducers;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link AsyncFilterHandler} implementation represents a terminal handler
@@ -63,7 +63,7 @@ public final class TerminalAsyncServerFilter implements AsyncFilterHandler {
     final private HandlerFactory<AsyncServerExchangeHandler> handlerFactory;
 
     public TerminalAsyncServerFilter(final HandlerFactory<AsyncServerExchangeHandler> handlerFactory) {
-        this.handlerFactory = Args.notNull(handlerFactory, "Handler factory");
+        this.handlerFactory = Objects.requireNonNull(handlerFactory, "Handler factory");
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityConsumer.java
@@ -32,6 +32,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -42,7 +43,6 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link AsyncEntityConsumer} implementation that acts as a compatibility
@@ -64,7 +64,7 @@ public abstract class AbstractClassicEntityConsumer<T> implements AsyncEntityCon
     private final AtomicReference<Exception> exceptionRef;
 
     public AbstractClassicEntityConsumer(final int initialBufferSize, final Executor executor) {
-        this.executor = Args.notNull(executor, "Executor");
+        this.executor = Objects.requireNonNull(executor, "Executor");
         this.buffer = new SharedInputBuffer(initialBufferSize);
         this.state = new AtomicReference<>(State.IDLE);
         this.resultRef = new AtomicReference<>(null);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityProducer.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http.nio.support.classic;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,7 +36,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.nio.AsyncEntityProducer;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
-import org.apache.hc.core5.util.Args;
 
 /**
  * {@link AsyncEntityProducer} implementation that acts as a compatibility
@@ -57,7 +57,7 @@ public abstract class AbstractClassicEntityProducer implements AsyncEntityProduc
     public AbstractClassicEntityProducer(final int initialBufferSize, final ContentType contentType, final Executor executor) {
         this.buffer = new SharedOutputBuffer(initialBufferSize);
         this.contentType = contentType;
-        this.executor = Args.notNull(executor, "Executor");
+        this.executor = Objects.requireNonNull(executor, "Executor");
         this.state = new AtomicReference<>(State.IDLE);
         this.exception = new AtomicReference<>(null);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicServerExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicServerExchangeHandler.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -77,7 +78,7 @@ public abstract class AbstractClassicServerExchangeHandler implements AsyncServe
 
     public AbstractClassicServerExchangeHandler(final int initialBufferSize, final Executor executor) {
         this.initialBufferSize = Args.positive(initialBufferSize, "Initial buffer size");
-        this.executor = Args.notNull(executor, "Executor");
+        this.executor = Objects.requireNonNull(executor, "Executor");
         this.exception = new AtomicReference<>(null);
         this.state = new AtomicReference<>(State.IDLE);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractSharedBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractSharedBuffer.java
@@ -26,13 +26,13 @@
  */
 package org.apache.hc.core5.http.nio.support.classic;
 
+import java.util.Objects;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.impl.nio.ExpandableBuffer;
-import org.apache.hc.core5.util.Args;
 
 /**
  * @since 5.0
@@ -48,7 +48,7 @@ abstract class AbstractSharedBuffer extends ExpandableBuffer {
 
     public AbstractSharedBuffer(final ReentrantLock lock, final int initialBufferSize) {
         super(initialBufferSize);
-        this.lock = Args.notNull(lock, "Lock");
+        this.lock = Objects.requireNonNull(lock, "Lock");
         this.condition = lock.newCondition();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/ContentInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/ContentInputStream.java
@@ -29,8 +29,7 @@ package org.apache.hc.core5.http.nio.support.classic;
 
 import java.io.IOException;
 import java.io.InputStream;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * {@link InputStream} adaptor for {@link ContentInputBuffer}.
@@ -43,7 +42,7 @@ public class ContentInputStream extends InputStream {
 
     public ContentInputStream(final ContentInputBuffer buffer) {
         super();
-        Args.notNull(buffer, "Input buffer");
+        Objects.requireNonNull(buffer, "Input buffer");
         this.buffer = buffer;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/ContentOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/ContentOutputStream.java
@@ -29,8 +29,7 @@ package org.apache.hc.core5.http.nio.support.classic;
 
 import java.io.IOException;
 import java.io.OutputStream;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * {@link OutputStream} adaptor for {@link ContentOutputBuffer}.
@@ -43,7 +42,7 @@ public class ContentOutputStream extends OutputStream {
 
     public ContentOutputStream(final ContentOutputBuffer buffer) {
         super();
-        Args.notNull(buffer, "Output buffer");
+        Objects.requireNonNull(buffer, "Output buffer");
         this.buffer = buffer;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/BasicHttpContext.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/BasicHttpContext.java
@@ -28,13 +28,13 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Default implementation of {@link HttpContext}.
@@ -64,7 +64,7 @@ public class BasicHttpContext implements HttpContext {
 
     @Override
     public Object getAttribute(final String id) {
-        Args.notNull(id, "Id");
+        Objects.requireNonNull(id, "Id");
         Object obj = this.map.get(id);
         if (obj == null && this.parentContext != null) {
             obj = this.parentContext.getAttribute(id);
@@ -74,7 +74,7 @@ public class BasicHttpContext implements HttpContext {
 
     @Override
     public Object setAttribute(final String id, final Object obj) {
-        Args.notNull(id, "Id");
+        Objects.requireNonNull(id, "Id");
         if (obj != null) {
             return this.map.put(id, obj);
         }
@@ -83,7 +83,7 @@ public class BasicHttpContext implements HttpContext {
 
     @Override
     public Object removeAttribute(final String id) {
-        Args.notNull(id, "Id");
+        Objects.requireNonNull(id, "Id");
         return this.map.remove(id);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/HttpCoreContext.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/HttpCoreContext.java
@@ -27,13 +27,14 @@
 
 package org.apache.hc.core5.http.protocol;
 
+import java.util.Objects;
+
 import javax.net.ssl.SSLSession;
 
 import org.apache.hc.core5.http.EndpointDetails;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Implementation of {@link HttpContext} that provides convenience
@@ -125,7 +126,7 @@ public class HttpCoreContext implements HttpContext {
     }
 
     public <T> T getAttribute(final String attribname, final Class<T> clazz) {
-        Args.notNull(clazz, "Attribute class");
+        Objects.requireNonNull(clazz, "Attribute class");
         final Object obj = getAttribute(attribname);
         if (obj == null) {
             return null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConnControl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConnControl.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -38,7 +39,6 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.Method;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestConnControl is responsible for adding {@code Connection} header
@@ -58,7 +58,7 @@ public class RequestConnControl implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
 
         final String method = request.getMethod();
         if (Method.CONNECT.isSame(method)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -42,7 +43,6 @@ import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestContent is the most important interceptor for outgoing requests.
@@ -87,7 +87,7 @@ public class RequestContent implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         final String method = request.getMethod();
         if (Method.TRACE.isSame(method) && entity != null) {
             throw new ProtocolException("TRACE request may not enclose an entity");

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestDate.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestDate.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestDate interceptor is responsible for adding {@code Date} header
@@ -55,7 +55,7 @@ public class RequestDate implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         if (entity != null && !request.containsHeader(HttpHeaders.DATE)) {
             request.setHeader(HttpHeaders.DATE, HttpDateGenerator.INSTANCE.getCurrentDate());
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestExpectContinue.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestExpectContinue.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestExpectContinue is responsible for enabling the 'expect-continue'
@@ -58,7 +58,7 @@ public class RequestExpectContinue implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
 
         if (!request.containsHeader(HttpHeaders.EXPECT)) {
             if (entity != null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestHandlerRegistry.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestHandlerRegistry.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -58,7 +59,7 @@ public class RequestHandlerRegistry<T> implements HttpRequestMapper<T> {
     private final ConcurrentMap<String, LookupRegistry<T>> virtualMap;
 
     public RequestHandlerRegistry(final String canonicalHostName, final Supplier<LookupRegistry<T>> registrySupplier) {
-        this.canonicalHostName = Args.notNull(canonicalHostName, "Canonical hostname").toLowerCase(Locale.ROOT);
+        this.canonicalHostName = Objects.requireNonNull(canonicalHostName, "Canonical hostname").toLowerCase(Locale.ROOT);
         this.registrySupplier = registrySupplier != null ? registrySupplier : new Supplier<LookupRegistry<T>>() {
 
             @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestTargetHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestTargetHost.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -41,7 +42,6 @@ import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.net.URIAuthority;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestHostOutgoing is responsible for adding {@code Host} header to the outgoing message.
@@ -59,8 +59,8 @@ public class RequestTargetHost implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(request, "HTTP request");
+        Objects.requireNonNull(context, "HTTP context");
 
         final ProtocolVersion ver = context.getProtocolVersion();
         final String method = request.getMethod();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestUserAgent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestUserAgent.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestUserAgent is responsible for adding {@code User-Agent} header.
@@ -61,7 +61,7 @@ public class RequestUserAgent implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
         throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
         if (!request.containsHeader(HttpHeaders.USER_AGENT) && this.userAgent != null) {
             request.addHeader(HttpHeaders.USER_AGENT, this.userAgent);
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestValidateHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestValidateHost.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -42,7 +43,6 @@ import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.net.URIAuthority;
-import org.apache.hc.core5.util.Args;
 
 /**
  * RequestTargetHost is responsible for copying {@code Host} header value to
@@ -61,7 +61,7 @@ public class RequestValidateHost implements HttpRequestInterceptor {
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(request, "HTTP request");
+        Objects.requireNonNull(request, "HTTP request");
 
         final Header header = request.getHeader(HttpHeaders.HOST);
         if (header != null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -44,7 +45,6 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
-import org.apache.hc.core5.util.Args;
 
 /**
  * ResponseConnControl is responsible for adding {@code Connection} header
@@ -64,8 +64,8 @@ public class ResponseConnControl implements HttpResponseInterceptor {
     @Override
     public void process(final HttpResponse response, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
-        Args.notNull(context, "HTTP context");
+        Objects.requireNonNull(response, "HTTP response");
+        Objects.requireNonNull(context, "HTTP context");
 
         // Always drop connection after certain type of responses
         final int status = response.getCode();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseContent.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -42,7 +43,6 @@ import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
-import org.apache.hc.core5.util.Args;
 
 /**
  * ResponseContent is the most important interceptor for outgoing responses.
@@ -94,7 +94,7 @@ public class ResponseContent implements HttpResponseInterceptor {
     @Override
     public void process(final HttpResponse response, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
         if (this.overwrite) {
             response.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
             response.removeHeaders(HttpHeaders.CONTENT_LENGTH);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseDate.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseDate.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpResponseInterceptor;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.hc.core5.util.Args;
 
 /**
  * ResponseDate is responsible for adding {@code Date} header to the
@@ -56,7 +56,7 @@ public class ResponseDate implements HttpResponseInterceptor {
     @Override
     public void process(final HttpResponse response, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
         final int status = response.getCode();
         if ((status >= HttpStatus.SC_OK) &&
             !response.containsHeader(HttpHeaders.DATE)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseServer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseServer.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.protocol;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -36,7 +37,6 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpResponseInterceptor;
-import org.apache.hc.core5.util.Args;
 
 /**
  * ResponseServer is responsible for adding {@code Server} header. This
@@ -64,7 +64,7 @@ public class ResponseServer implements HttpResponseInterceptor {
     @Override
     public void process(final HttpResponse response, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {
-        Args.notNull(response, "HTTP response");
+        Objects.requireNonNull(response, "HTTP response");
         if (!response.containsHeader(HttpHeaders.SERVER) && this.originServer != null) {
             response.addHeader(HttpHeaders.SERVER, this.originServer);
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/UriPatternMatcher.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/UriPatternMatcher.java
@@ -31,11 +31,11 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Maintains a map of objects keyed by a request URI pattern.
@@ -87,7 +87,7 @@ public class UriPatternMatcher<T> implements LookupRegistry<T> {
      */
     @Override
     public synchronized void register(final String pattern, final T obj) {
-        Args.notNull(pattern, "URI request pattern");
+        Objects.requireNonNull(pattern, "URI request pattern");
         this.map.put(pattern, obj);
     }
 
@@ -114,7 +114,7 @@ public class UriPatternMatcher<T> implements LookupRegistry<T> {
      */
     @Override
     public synchronized T lookup(final String path) {
-        Args.notNull(path, "Request path");
+        Objects.requireNonNull(path, "Request path");
         // direct match?
         T obj = this.map.get(path);
         if (obj == null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/UriPatternOrderedMatcher.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/UriPatternOrderedMatcher.java
@@ -31,11 +31,11 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Maintains a map of objects keyed by a request URI pattern.
@@ -85,7 +85,7 @@ public class UriPatternOrderedMatcher<T> implements LookupRegistry<T> {
      */
     @Override
     public synchronized void register(final String pattern, final T obj) {
-        Args.notNull(pattern, "URI request pattern");
+        Objects.requireNonNull(pattern, "URI request pattern");
         this.map.put(pattern, obj);
     }
 
@@ -110,7 +110,7 @@ public class UriPatternOrderedMatcher<T> implements LookupRegistry<T> {
      */
     @Override
     public synchronized T lookup(final String path) {
-        Args.notNull(path, "Request path");
+        Objects.requireNonNull(path, "Request path");
         for (final Entry<String, T> entry : this.map.entrySet()) {
             final String pattern = entry.getKey();
             if (path.equals(pattern)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/UriRegexMatcher.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/UriRegexMatcher.java
@@ -30,11 +30,11 @@ package org.apache.hc.core5.http.protocol;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
-import org.apache.hc.core5.util.Args;
 
 /**
  * Maintains a map of objects keyed by a request URI regular expression.
@@ -69,7 +69,7 @@ public class UriRegexMatcher<T> implements LookupRegistry<T> {
      */
     @Override
     public synchronized void register(final String regex, final T obj) {
-        Args.notNull(regex, "URI request regex");
+        Objects.requireNonNull(regex, "URI request regex");
         this.objectMap.put(regex, obj);
         this.patternMap.put(regex, Pattern.compile(regex));
     }
@@ -98,7 +98,7 @@ public class UriRegexMatcher<T> implements LookupRegistry<T> {
      */
     @Override
     public synchronized T lookup(final String path) {
-        Args.notNull(path, "Request path");
+        Objects.requireNonNull(path, "Request path");
         // direct match?
         final T obj = this.objectMap.get(path);
         if (obj == null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
@@ -31,9 +31,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.util.Objects;
 import java.util.regex.Pattern;
-
-import org.apache.hc.core5.util.Args;
 
 /**
  * A collection of utilities relating to InetAddresses.
@@ -132,7 +131,7 @@ public class InetAddressUtils {
     public static void formatAddress(
             final StringBuilder buffer,
             final SocketAddress socketAddress) {
-        Args.notNull(buffer, "buffer");
+        Objects.requireNonNull(buffer, "buffer");
         if (socketAddress instanceof InetSocketAddress) {
             final InetSocketAddress socketaddr = (InetSocketAddress) socketAddress;
             final InetAddress inetaddr = socketaddr.getAddress();

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URLEncodedUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URLEncodedUtils.java
@@ -37,12 +37,12 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.http.message.ParserCursor;
 import org.apache.hc.core5.http.message.TokenParser;
-import org.apache.hc.core5.util.Args;
 
 /**
  * A collection of utilities for encoding URLs.
@@ -72,7 +72,7 @@ public class URLEncodedUtils {
      * @since 4.5
      */
     public static List<NameValuePair> parse(final URI uri, final Charset charset) {
-        Args.notNull(uri, "URI");
+        Objects.requireNonNull(uri, "URI");
         final String query = uri.getRawQuery();
         if (query != null && !query.isEmpty()) {
             return parse(query, charset);
@@ -109,7 +109,7 @@ public class URLEncodedUtils {
      */
     public static List<NameValuePair> parse(
             final CharSequence s, final Charset charset, final char... separators) {
-        Args.notNull(s, "Char sequence");
+        Objects.requireNonNull(s, "Char sequence");
         final TokenParser tokenParser = TokenParser.INSTANCE;
         final BitSet delimSet = new BitSet();
         for (final char separator: separators) {
@@ -183,7 +183,7 @@ public class URLEncodedUtils {
      * @since 4.5
      */
     public static List<String> parsePathSegments(final CharSequence s, final Charset charset) {
-        Args.notNull(s, "Char sequence");
+        Objects.requireNonNull(s, "Char sequence");
         final List<String> list = splitPathSegments(s);
         for (int i = 0; i < list.size(); i++) {
             list.set(i, urlDecode(list.get(i), charset != null ? charset : StandardCharsets.UTF_8, false));
@@ -220,7 +220,7 @@ public class URLEncodedUtils {
      * @since 4.5
      */
     public static String formatSegments(final Iterable<String> segments, final Charset charset) {
-        Args.notNull(segments, "Segments");
+        Objects.requireNonNull(segments, "Segments");
         final StringBuilder buf = new StringBuilder();
         formatSegments(buf, segments, charset);
         return buf.toString();
@@ -279,7 +279,7 @@ public class URLEncodedUtils {
             final Iterable<? extends NameValuePair> parameters,
             final char parameterSeparator,
             final Charset charset) {
-        Args.notNull(parameters, "Parameters");
+        Objects.requireNonNull(parameters, "Parameters");
         final StringBuilder buf = new StringBuilder();
         formatNameValuePairs(buf, parameters, parameterSeparator, charset);
         return buf.toString();

--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/LaxConnPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/LaxConnPool.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.pool;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -156,7 +157,7 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
             final T route, final Object state,
             final Timeout requestTimeout,
             final FutureCallback<PoolEntry<T, C>> callback) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         Asserts.check(!isShutDown.get(), "Connection pool shut down");
         final PerRoutePool<T, C> routePool = getPool(route);
         return routePool.lease(state, requestTimeout, callback);
@@ -206,14 +207,14 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
 
     @Override
     public void setMaxPerRoute(final T route, final int max) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         final PerRoutePool<T, C> routePool = getPool(route);
         routePool.setMax(max > -1 ? max : defaultMaxPerRoute);
     }
 
     @Override
     public int getMaxPerRoute(final T route) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         final PerRoutePool<T, C> routePool = getPool(route);
         return routePool.getMax();
     }
@@ -235,7 +236,7 @@ public class LaxConnPool<T, C extends ModalCloseable> implements ManagedConnPool
 
     @Override
     public PoolStats getStats(final T route) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         final PerRoutePool<T, C> routePool = getPool(route);
         return new PoolStats(
                 routePool.getLeasedCount(),

--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/PoolEntry.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/PoolEntry.java
@@ -26,12 +26,12 @@
  */
 package org.apache.hc.core5.pool;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.ModalCloseable;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Deadline;
 import org.apache.hc.core5.util.TimeValue;
 
@@ -64,7 +64,7 @@ public final class PoolEntry<T, C extends ModalCloseable> {
     PoolEntry(final T route, final TimeValue timeToLive, final DisposalCallback<C> disposalCallback,
               final Supplier<Long> currentTimeSupplier) {
         super();
-        this.route = Args.notNull(route, "Route");
+        this.route = Objects.requireNonNull(route, "Route");
         this.timeToLive = TimeValue.defaultsToNegativeOneMillisecond(timeToLive);
         this.connRef = new AtomicReference<>(null);
         this.disposalCallback = disposalCallback;
@@ -144,7 +144,7 @@ public final class PoolEntry<T, C extends ModalCloseable> {
      * @since 5.0
      */
     public void assignConnection(final C conn) {
-        Args.notNull(conn, "connection");
+        Objects.requireNonNull(conn, "connection");
         if (this.connRef.compareAndSet(null, conn)) {
             this.created = getCurrentTime();
             this.updated = this.created;
@@ -179,7 +179,7 @@ public final class PoolEntry<T, C extends ModalCloseable> {
      * @since 5.0
      */
     public void updateExpiry(final TimeValue expiryTime) {
-        Args.notNull(expiryTime, "Expiry time");
+        Objects.requireNonNull(expiryTime, "Expiry time");
         final long currentTime = getCurrentTime();
         final Deadline newExpiry = Deadline.calculate(currentTime, expiryTime);
         this.expiryDeadline = newExpiry.min(this.validityDeadline);

--- a/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/pool/StrictConnPool.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
@@ -168,8 +169,8 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
             final T route, final Object state,
             final Timeout requestTimeout,
             final FutureCallback<PoolEntry<T, C>> callback) {
-        Args.notNull(route, "Route");
-        Args.notNull(requestTimeout, "Request timeout");
+        Objects.requireNonNull(route, "Route");
+        Objects.requireNonNull(requestTimeout, "Request timeout");
         Asserts.check(!this.isShutDown.get(), "Connection pool shut down");
         final Deadline deadline = Deadline.calculate(requestTimeout);
         final BasicFuture<PoolEntry<T, C>> future = new BasicFuture<>(callback);
@@ -471,7 +472,7 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
 
     @Override
     public void setMaxPerRoute(final T route, final int max) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         this.lock.lock();
         try {
             if (max > -1) {
@@ -486,7 +487,7 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
 
     @Override
     public int getMaxPerRoute(final T route) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         this.lock.lock();
         try {
             return getMax(route);
@@ -511,7 +512,7 @@ public class StrictConnPool<T, C extends ModalCloseable> implements ManagedConnP
 
     @Override
     public PoolStats getStats(final T route) {
-        Args.notNull(route, "Route");
+        Objects.requireNonNull(route, "Route");
         this.lock.lock();
         try {
             final PerRoutePool<T, C> pool = getPool(route);

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOReactorBase.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOReactorBase.java
@@ -28,11 +28,11 @@
 package org.apache.hc.core5.reactor;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.net.NamedEndpoint;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 abstract class AbstractIOReactorBase implements ConnectionInitiator, IOReactorService {
@@ -45,7 +45,7 @@ abstract class AbstractIOReactorBase implements ConnectionInitiator, IOReactorSe
             final Timeout timeout,
             final Object attachment,
             final FutureCallback<IOSession> callback) throws IOReactorShutdownException {
-        Args.notNull(remoteEndpoint, "Remote endpoint");
+        Objects.requireNonNull(remoteEndpoint, "Remote endpoint");
         if (getStatus().compareTo(IOReactorStatus.ACTIVE) > 0) {
             throw new IOReactorShutdownException("I/O reactor has been shut down");
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOSessionPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOSessionPool.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.reactor;
 
 import java.util.ArrayDeque;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,7 +44,6 @@ import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.ModalCloseable;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -124,7 +124,7 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
             final T endpoint,
             final Timeout connectTimeout,
             final FutureCallback<IOSession> callback) {
-        Args.notNull(endpoint, "Endpoint");
+        Objects.requireNonNull(endpoint, "Endpoint");
         Asserts.check(!closed.get(), "Connection pool shut down");
         final ComplexFuture<IOSession> future = new ComplexFuture<>(callback);
         final PoolEntry poolEntry = getPoolEntry(endpoint);

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractSingleCoreIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractSingleCoreIOReactor.java
@@ -32,13 +32,13 @@ import java.io.IOException;
 import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.Closer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 
 abstract class AbstractSingleCoreIOReactor implements IOReactor {
@@ -115,7 +115,7 @@ abstract class AbstractSingleCoreIOReactor implements IOReactor {
 
     @Override
     public final void awaitShutdown(final TimeValue waitTime) throws InterruptedException {
-        Args.notNull(waitTime, "Wait time");
+        Objects.requireNonNull(waitTime, "Wait time");
         final long deadline = System.currentTimeMillis() + waitTime.toMilliseconds();
         long remaining = waitTime.toMilliseconds();
         synchronized (this.shutdownMutex) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/DefaultConnectingIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/DefaultConnectingIOReactor.java
@@ -28,13 +28,13 @@
 package org.apache.hc.core5.reactor;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 
 import org.apache.hc.core5.concurrent.DefaultThreadFactory;
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Decorator;
 import org.apache.hc.core5.io.CloseMode;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 
 /**
@@ -63,7 +63,7 @@ public class DefaultConnectingIOReactor extends AbstractIOReactorBase {
             final Callback<Exception> exceptionCallback,
             final IOSessionListener sessionListener,
             final Callback<IOSession> sessionShutdownCallback) {
-        Args.notNull(eventHandlerFactory, "Event handler factory");
+        Objects.requireNonNull(eventHandlerFactory, "Event handler factory");
         this.workerCount = ioReactorConfig != null ? ioReactorConfig.getIoThreadCount() : IOReactorConfig.DEFAULT.getIoThreadCount();
         this.workers = new SingleCoreIOReactor[workerCount];
         final Thread[] threads = new Thread[workerCount];

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/DefaultListeningIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/DefaultListeningIOReactor.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.reactor;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
@@ -39,7 +40,6 @@ import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Decorator;
 import org.apache.hc.core5.io.CloseMode;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 
 /**
@@ -81,7 +81,7 @@ public class DefaultListeningIOReactor extends AbstractIOReactorBase implements 
             final Callback<Exception> exceptionCallback,
             final IOSessionListener sessionListener,
             final Callback<IOSession> sessionShutdownCallback) {
-        Args.notNull(eventHandlerFactory, "Event handler factory");
+        Objects.requireNonNull(eventHandlerFactory, "Event handler factory");
         this.workerCount = ioReactorConfig != null ? ioReactorConfig.getIoThreadCount() : IOReactorConfig.DEFAULT.getIoThreadCount();
         this.workers = new SingleCoreIOReactor[workerCount];
         final Thread[] threads = new Thread[workerCount + 1];

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOReactorConfig.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOReactorConfig.java
@@ -28,11 +28,11 @@
 package org.apache.hc.core5.reactor;
 
 import java.net.SocketAddress;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -186,7 +186,7 @@ public final class IOReactorConfig {
     }
 
     public static Builder copy(final IOReactorConfig config) {
-        Args.notNull(config, "I/O reactor config");
+        Objects.requireNonNull(config, "I/O reactor config");
         return new Builder()
             .setSelectInterval(config.getSelectInterval())
             .setIoThreadCount(config.getIoThreadCount())

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
@@ -35,6 +35,7 @@ import java.nio.channels.ByteChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Deque;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -43,7 +44,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.Closer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
 class IOSessionImpl implements IOSession {
@@ -66,8 +66,8 @@ class IOSessionImpl implements IOSession {
 
     public IOSessionImpl(final String type, final SelectionKey key, final SocketChannel socketChannel) {
         super();
-        this.key = Args.notNull(key, "Selection key");
-        this.channel = Args.notNull(socketChannel, "Socket channel");
+        this.key = Objects.requireNonNull(key, "Selection key");
+        this.channel = Objects.requireNonNull(socketChannel, "Socket channel");
         this.commandQueue = new ConcurrentLinkedDeque<>();
         this.lock = new ReentrantLock();
         this.socketTimeout = Timeout.DISABLED;

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/MultiCoreIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/MultiCoreIOReactor.java
@@ -27,12 +27,12 @@
 
 package org.apache.hc.core5.reactor;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.Closer;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
 
 class MultiCoreIOReactor implements IOReactor {
@@ -80,7 +80,7 @@ class MultiCoreIOReactor implements IOReactor {
 
     @Override
     public final void awaitShutdown(final TimeValue waitTime) throws InterruptedException {
-        Args.notNull(waitTime, "Wait time");
+        Objects.requireNonNull(waitTime, "Wait time");
         final long deadline = System.currentTimeMillis() + waitTime.toMilliseconds();
         long remaining = waitTime.toMilliseconds();
         for (int i = 0; i < this.ioReactors.length; i++) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/SingleCoreIOReactor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/SingleCoreIOReactor.java
@@ -39,6 +39,7 @@ import java.nio.channels.SocketChannel;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -51,7 +52,6 @@ import org.apache.hc.core5.function.Decorator;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.Closer;
 import org.apache.hc.core5.net.NamedEndpoint;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.Timeout;
 
@@ -79,8 +79,8 @@ class SingleCoreIOReactor extends AbstractSingleCoreIOReactor implements Connect
             final IOSessionListener sessionListener,
             final Callback<IOSession> sessionShutdownCallback) {
         super(exceptionCallback);
-        this.eventHandlerFactory = Args.notNull(eventHandlerFactory, "Event handler factory");
-        this.reactorConfig = Args.notNull(reactorConfig, "I/O reactor config");
+        this.eventHandlerFactory = Objects.requireNonNull(eventHandlerFactory, "Event handler factory");
+        this.reactorConfig = Objects.requireNonNull(reactorConfig, "I/O reactor config");
         this.ioSessionDecorator = ioSessionDecorator;
         this.sessionListener = sessionListener;
         this.sessionShutdownCallback = sessionShutdownCallback;
@@ -92,7 +92,7 @@ class SingleCoreIOReactor extends AbstractSingleCoreIOReactor implements Connect
     }
 
     void enqueueChannel(final SocketChannel socketChannel) throws IOReactorShutdownException {
-        Args.notNull(socketChannel, "SocketChannel");
+        Objects.requireNonNull(socketChannel, "SocketChannel");
         if (getStatus().compareTo(IOReactorStatus.ACTIVE) > 0) {
             throw new IOReactorShutdownException("I/O reactor has been shut down");
         }
@@ -248,7 +248,7 @@ class SingleCoreIOReactor extends AbstractSingleCoreIOReactor implements Connect
             final Timeout timeout,
             final Object attachment,
             final FutureCallback<IOSession> callback) throws IOReactorShutdownException {
-        Args.notNull(remoteEndpoint, "Remote endpoint");
+        Objects.requireNonNull(remoteEndpoint, "Remote endpoint");
         final IOSessionRequest sessionRequest = new IOSessionRequest(
                 remoteEndpoint,
                 remoteAddress != null ? remoteAddress : new InetSocketAddress(remoteEndpoint.getHostName(), remoteEndpoint.getPort()),

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -34,6 +34,7 @@ import java.nio.channels.ByteChannel;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 
@@ -54,7 +55,6 @@ import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.EventMask;
 import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOSession;
-import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
 import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.Timeout;
@@ -119,8 +119,8 @@ public class SSLIOSession implements IOSession {
             final Callback<SSLIOSession> disconnectedCallback,
             final Timeout connectTimeout) {
         super();
-        Args.notNull(session, "IO session");
-        Args.notNull(sslContext, "SSL context");
+        Objects.requireNonNull(session, "IO session");
+        Objects.requireNonNull(sslContext, "SSL context");
         this.targetEndpoint = targetEndpoint;
         this.session = session;
         this.sslMode = sslMode;
@@ -575,7 +575,7 @@ public class SSLIOSession implements IOSession {
 
     @Override
     public int write(final ByteBuffer src) throws IOException {
-        Args.notNull(src, "Byte buffer");
+        Objects.requireNonNull(src, "Byte buffer");
         this.session.getLock().lock();
         try {
             if (this.status != Status.ACTIVE) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/PrivateKeyDetails.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/PrivateKeyDetails.java
@@ -28,8 +28,7 @@ package org.apache.hc.core5.ssl;
 
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
-
-import org.apache.hc.core5.util.Args;
+import java.util.Objects;
 
 /**
  * Private key details.
@@ -43,7 +42,7 @@ public final class PrivateKeyDetails {
 
     public PrivateKeyDetails(final String type, final X509Certificate[] certChain) {
         super();
-        this.type = Args.notNull(type, "Private key type");
+        this.type = Objects.requireNonNull(type, "Private key type");
         this.certChain = certChain;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContextBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContextBuilder.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.net.ssl.KeyManager;
@@ -60,8 +61,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509TrustManager;
-
-import org.apache.hc.core5.util.Args;
 
 /**
  * Builder for {@link javax.net.ssl.SSLContext} instances.
@@ -226,7 +225,7 @@ public class SSLContextBuilder {
             final File file,
             final char[] storePassword,
             final TrustStrategy trustStrategy) throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
-        Args.notNull(file, "Truststore file");
+        Objects.requireNonNull(file, "Truststore file");
         final KeyStore trustStore = KeyStore.getInstance(keyStoreType);
         try (final FileInputStream inStream = new FileInputStream(file)) {
             trustStore.load(inStream, storePassword);
@@ -249,7 +248,7 @@ public class SSLContextBuilder {
             final URL url,
             final char[] storePassword,
             final TrustStrategy trustStrategy) throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
-        Args.notNull(url, "Truststore URL");
+        Objects.requireNonNull(url, "Truststore URL");
         final KeyStore trustStore = KeyStore.getInstance(keyStoreType);
         try (final InputStream inStream = url.openStream()) {
             trustStore.load(inStream, storePassword);
@@ -300,7 +299,7 @@ public class SSLContextBuilder {
             final char[] storePassword,
             final char[] keyPassword,
             final PrivateKeyStrategy aliasStrategy) throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException, CertificateException, IOException {
-        Args.notNull(file, "Keystore file");
+        Objects.requireNonNull(file, "Keystore file");
         final KeyStore identityStore = KeyStore.getInstance(keyStoreType);
         try (final FileInputStream inStream = new FileInputStream(file)) {
             identityStore.load(inStream, storePassword);
@@ -320,7 +319,7 @@ public class SSLContextBuilder {
             final char[] storePassword,
             final char[] keyPassword,
             final PrivateKeyStrategy aliasStrategy) throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException, CertificateException, IOException {
-        Args.notNull(url, "Keystore URL");
+        Objects.requireNonNull(url, "Keystore URL");
         final KeyStore identityStore = KeyStore.getInstance(keyStoreType);
         try (final InputStream inStream = url.openStream()) {
             identityStore.load(inStream, storePassword);

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Args.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Args.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.util;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.EntityDetails;
 
@@ -78,9 +79,7 @@ public class Args {
     }
 
     public static <T extends CharSequence> T containsNoBlanks(final T argument, final String name) {
-        if (argument == null) {
-            throw NullPointerException(name);
-        }
+        Objects.requireNonNull(argument, name);
         if (argument.length() == 0) {
             throw illegalArgumentExceptionNotEmpty(name);
         }
@@ -98,14 +97,8 @@ public class Args {
         return new IllegalArgumentException(name + " must not be empty");
     }
 
-    private static NullPointerException NullPointerException(final String name) {
-        return new NullPointerException(name + " must not be null");
-    }
-
     public static <T extends CharSequence> T notBlank(final T argument, final String name) {
-        if (argument == null) {
-            throw NullPointerException(name);
-        }
+        Objects.requireNonNull(argument, name);
         if (TextUtils.isBlank(argument)) {
             throw new IllegalArgumentException(name + " must not be blank");
         }
@@ -113,9 +106,7 @@ public class Args {
     }
 
     public static <T extends CharSequence> T notEmpty(final T argument, final String name) {
-        if (argument == null) {
-            throw NullPointerException(name);
-        }
+        Objects.requireNonNull(argument, name);
         if (TextUtils.isEmpty(argument)) {
             throw illegalArgumentExceptionNotEmpty(name);
         }
@@ -123,9 +114,7 @@ public class Args {
     }
 
     public static <E, T extends Collection<E>> T notEmpty(final T argument, final String name) {
-        if (argument == null) {
-            throw NullPointerException(name);
-        }
+        Objects.requireNonNull(argument, name);
         if (argument.isEmpty()) {
             throw illegalArgumentExceptionNotEmpty(name);
         }
@@ -146,11 +135,12 @@ public class Args {
         return n;
     }
 
+    /**
+     * @deprecated Use {@link Objects#requireNonNull(Object, String)}.
+     */
+    @Deprecated
     public static <T> T notNull(final T argument, final String name) {
-        if (argument == null) {
-            throw NullPointerException(name);
-        }
-        return argument;
+        return Objects.requireNonNull(argument, name);
     }
 
     public static int positive(final int n, final String name) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TimeValue.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TimeValue.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.util;
 
 import java.text.ParseException;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -212,11 +213,11 @@ public class TimeValue implements Comparable<TimeValue> {
     TimeValue(final long duration, final TimeUnit timeUnit) {
         super();
         this.duration = duration;
-        this.timeUnit = Args.notNull(timeUnit, "timeUnit");
+        this.timeUnit = Objects.requireNonNull(timeUnit, "timeUnit");
     }
 
     public long convert(final TimeUnit targetTimeUnit) {
-        Args.notNull(targetTimeUnit, "timeUnit");
+        Objects.requireNonNull(targetTimeUnit, "timeUnit");
         return targetTimeUnit.convert(duration, timeUnit);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Timeout.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Timeout.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.util;
 
 import java.text.ParseException;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -154,7 +155,7 @@ public class Timeout extends TimeValue {
     }
 
     Timeout(final long duration, final TimeUnit timeUnit) {
-        super(Args.notNegative(duration, "duration"), Args.notNull(timeUnit, "timeUnit"));
+        super(Args.notNegative(duration, "duration"), Objects.requireNonNull(timeUnit, "timeUnit"));
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/VersionInfo.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/VersionInfo.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -88,7 +89,7 @@ public class VersionInfo {
      */
     protected VersionInfo(final String pckg, final String module,
                           final String release, final String time, final String clsldr) {
-        Args.notNull(pckg, "Package identifier");
+        Objects.requireNonNull(pckg, "Package identifier");
         infoPackage     = pckg;
         infoModule      = (module  != null) ? module  : UNAVAILABLE;
         infoRelease     = (release != null) ? release : UNAVAILABLE;
@@ -196,7 +197,7 @@ public class VersionInfo {
      */
     public static VersionInfo[] loadVersionInfo(final String[] pckgs,
                                                       final ClassLoader clsldr) {
-        Args.notNull(pckgs, "Package identifier array");
+        Objects.requireNonNull(pckgs, "Package identifier array");
         final List<VersionInfo> vil = new ArrayList<>(pckgs.length);
         for (final String pckg : pckgs) {
             final VersionInfo vi = loadVersionInfo(pckg, clsldr);
@@ -222,7 +223,7 @@ public class VersionInfo {
      *          {@code null} if not available
      */
     public static VersionInfo loadVersionInfo(final String pckg, final ClassLoader clsldr) {
-        Args.notNull(pckg, "Package identifier");
+        Objects.requireNonNull(pckg, "Package identifier");
         final ClassLoader cl = clsldr != null ? clsldr : Thread.currentThread().getContextClassLoader();
 
         Properties vip = null; // version info properties, if available
@@ -260,7 +261,7 @@ public class VersionInfo {
      */
     protected static VersionInfo fromMap(final String pckg, final Map<?, ?> info,
                                                final ClassLoader clsldr) {
-        Args.notNull(pckg, "Package identifier");
+        Objects.requireNonNull(pckg, "Package identifier");
         String module = null;
         String release = null;
         String timestamp = null;

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestArgs.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestArgs.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.util;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,12 +53,12 @@ public class TestArgs {
     @Test
     public void testArgNotNullPass() {
         final String stuff = "stuff";
-        Assert.assertSame(stuff, Args.notNull(stuff, "Stuff"));
+        Assert.assertSame(stuff, Objects.requireNonNull(stuff, "Stuff"));
     }
 
     @Test(expected=NullPointerException.class)
     public void testArgNotNullFail() {
-        Args.notNull(null, "Stuff");
+        Objects.requireNonNull(null, "Stuff");
     }
 
     @Test


### PR DESCRIPTION
java.util.Objects.requireNonNull(T, String).