### PR TITLE
Switched to TLSv1.2 as default protocol if none provided

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContextBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContextBuilder.java
@@ -77,7 +77,7 @@ import org.apache.hc.core5.util.Args;
  */
 public class SSLContextBuilder {
 
-    static final String TLS   = "TLS";
+    static final String DEFAULT_PROTOCOL = "TLSv1.2";
 
     private String protocol;
     private final Set<KeyManager> keyManagers;
@@ -348,7 +348,7 @@ public class SSLContextBuilder {
 
     public SSLContext build() throws NoSuchAlgorithmException, KeyManagementException {
         final SSLContext sslContext;
-        final String protocolStr = this.protocol != null ? this.protocol : TLS;
+        final String protocolStr = this.protocol != null ? this.protocol : DEFAULT_PROTOCOL;
         if (this.provider != null) {
             sslContext = SSLContext.getInstance(protocolStr, this.provider);
         } else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContexts.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContexts.java
@@ -63,7 +63,7 @@ public final class SSLContexts {
      */
     public static SSLContext createDefault() throws SSLInitializationException {
         try {
-            final SSLContext sslContext = SSLContext.getInstance(SSLContextBuilder.TLS);
+            final SSLContext sslContext = SSLContext.getInstance(SSLContextBuilder.DEFAULT_PROTOCOL);
             sslContext.init(null, null, null);
             return sslContext;
         } catch (final NoSuchAlgorithmException | KeyManagementException ex) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
@@ -138,7 +138,7 @@ public class TestSSLContextBuilder {
                 .loadKeyMaterial((KeyStore) null, null, null)
                 .build();
         Assert.assertNotNull(sslContext);
-        Assert.assertEquals("TLS", sslContext.getProtocol());
+        Assert.assertEquals("TLSv1.2", sslContext.getProtocol());
         Assert.assertEquals(PROVIDER_SUN_JSSE,  sslContext.getProvider().getName());
     }
 
@@ -151,7 +151,7 @@ public class TestSSLContextBuilder {
                 .loadKeyMaterial((KeyStore) null, null, null)
                 .build();
         Assert.assertNotNull(sslContext);
-        Assert.assertEquals("TLS", sslContext.getProtocol());
+        Assert.assertEquals("TLSv1.2", sslContext.getProtocol());
     }
 
     @Test


### PR DESCRIPTION
TLSv1.0 and TLSv1.1 are deprecated from the year 2020 onwards. It would be better for the SSLContextBuilder to use a newer (not deprecated) encryption protocol by default if the user does not provide any.

This change will not prevent the user to still use an older version when providing the old one.