### PR TITLE
Fix CharArrayBuffer.subSequence(beganIndex,endIndex) to return right result.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/util/CharArrayBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/CharArrayBuffer.java
@@ -485,7 +485,7 @@ public final class CharArrayBuffer implements CharSequence, Serializable {
         if (beginIndex > endIndex) {
             throw new IndexOutOfBoundsException("beginIndex: " + beginIndex + " > endIndex: " + endIndex);
         }
-        return CharBuffer.wrap(this.array, beginIndex, endIndex);
+        return CharBuffer.wrap(this.array, beginIndex, endIndex - beginIndex);
     }
 
     @Override

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestCharArrayBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestCharArrayBuffer.java
@@ -400,6 +400,16 @@ public class TestCharArrayBuffer {
     }
 
     @Test
+    public void testSubSequence() {
+        final CharArrayBuffer buffer = new CharArrayBuffer(16);
+        buffer.append(" name:  value    ");
+        Assert.assertEquals(5, buffer.indexOf(':'));
+        Assert.assertEquals(" name", buffer.subSequence(0, 5).toString());
+        Assert.assertEquals("  value    ",
+            buffer.subSequence(6, buffer.length()).toString());
+    }
+
+    @Test
     public void testSubSequenceIndexOfOutBound() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append("stuff");


### PR DESCRIPTION
**CharArrayBuffer** implemented the **CharSequence** interface, 
and **CharSequence** define method:   
 `public CharSequence subSequence(final int beginIndex, final int endIndex)`
   
Threre are two problem in original implementation of `CharArrayBuffer.subSequence`

1. It call `CharBuffer.wrap(buffer.array, beginIndex, endIndex)` directly，but the 3rd parameter of the `CharBuffer.wrap` method is length, it means how many chars need to copy, not endIndex. It makes some problem such as pass CharArrayBuffer as a CharSequence in to Regex's matcher method like following:   
```CharArrayBuffer charSequence = new CharArrayBuffer(8);   
        charSequence.append("aabb123c");   
        Pattern p = Pattern.compile("\\D*(\\d+)\\D*");   
        Matcher m = p.matcher(charSequence);   
        Assert.assertEquals("123", m.find()?m.group(1):""); 
```

2. **CharArrayBuffer's** sub-sequence should return the result as same class of **CharArrayBuffer**. But' the old implementation use `CharBuffer.wrap` to make a result which instance of **HeapCharBuffer**. 

This problem exists in both 4.x and 5.x. I'd like see this problem to be fixed.