### PR TITLE
HTTPCORE-627: URIBuilder::Adding query parameters result in removing …

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -276,26 +276,26 @@ public class URIBuilder {
     }
 
     /**
-     * Sets the URI scheme specific part and append a list of parameters to this part.
+     * Sets the URI scheme specific part and append a variable arguments list of NameValuePair instance(s) to this part.
      *
      * @param schemeSpecificPart
-     * @param nvps Optional, can be null. List of NameValuePair query parameters to be reused by the specific scheme part
+     * @param nvps Optional, can be null. Variable arguments list of NameValuePair query parameters to be reused by the specific scheme part
      * @return this.
      * @since 5.1
      */
-    public URIBuilder setSchemeSpecificPartWithParameter(final String schemeSpecificPart, final NameValuePair... nvps) {
-        return setSchemeSpecificPartWithParameters(schemeSpecificPart, nvps != null ? Arrays.asList(nvps) : null);
+    public URIBuilder setSchemeSpecificPart(final String schemeSpecificPart, final NameValuePair... nvps) {
+        return setSchemeSpecificPart(schemeSpecificPart, nvps != null ? Arrays.asList(nvps) : null);
     }
 
     /**
-     * Sets the URI scheme specific part and append a list of parameters to this part.
+     * Sets the URI scheme specific part and append a list of NameValuePair to this part.
      *
      * @param schemeSpecificPart
      * @param nvps Optional, can be null. List of query parameters to be reused by the specific scheme part
      * @return this.
      * @since 5.1
      */
-    public URIBuilder setSchemeSpecificPartWithParameters(final String schemeSpecificPart, final List <NameValuePair> nvps) {
+    public URIBuilder setSchemeSpecificPart(final String schemeSpecificPart, final List <NameValuePair> nvps) {
         this.encodedSchemeSpecificPart = null;
         if (!TextUtils.isBlank(schemeSpecificPart)) {
             final StringBuilder sb = new StringBuilder(schemeSpecificPart);

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -264,6 +264,25 @@ public class URIBuilder {
     }
 
     /**
+     *Sets the URI scheme specific part.
+     *
+     * @param schemeSpecificPart
+     * @param nvps Optional, can be null. List of query parameters to be reused by the specific scheme
+     * @return this.
+     */
+    public URIBuilder setSchemeSpecificPart(final String schemeSpecificPart, final List <NameValuePair> nvps) {
+        if (!TextUtils.isBlank(schemeSpecificPart)) {
+            final StringBuilder sb = new StringBuilder(schemeSpecificPart);
+            if (nvps != null && !nvps.isEmpty()) {
+                sb.append("?");
+                encodeUrlForm(sb, nvps);
+            }
+            this.encodedSchemeSpecificPart = sb.toString();
+        }
+        return this;
+    }
+
+    /**
      * Sets URI user info. The value is expected to be unescaped and may contain non ASCII
      * characters.
      *
@@ -553,6 +572,10 @@ public class URIBuilder {
 
     public String getScheme() {
         return this.scheme;
+    }
+
+    public String getSchemeSpecificPart() {
+        return this.encodedSchemeSpecificPart;
     }
 
     public String getUserInfo() {

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -264,13 +264,39 @@ public class URIBuilder {
     }
 
     /**
-     *Sets the URI scheme specific part.
+     * Sets the URI scheme specific part.
      *
      * @param schemeSpecificPart
-     * @param nvps Optional, can be null. List of query parameters to be reused by the specific scheme
      * @return this.
+     * @since 5.1
      */
-    public URIBuilder setSchemeSpecificPart(final String schemeSpecificPart, final List <NameValuePair> nvps) {
+    public URIBuilder setSchemeSpecificPart(final String schemeSpecificPart) {
+        this.encodedSchemeSpecificPart = schemeSpecificPart;
+        return this;
+    }
+
+    /**
+     * Sets the URI scheme specific part and append a list of parameters to this part.
+     *
+     * @param schemeSpecificPart
+     * @param nvps Optional, can be null. List of NameValuePair query parameters to be reused by the specific scheme part
+     * @return this.
+     * @since 5.1
+     */
+    public URIBuilder setSchemeSpecificPartWithParameter(final String schemeSpecificPart, final NameValuePair... nvps) {
+        return setSchemeSpecificPartWithParameters(schemeSpecificPart, nvps != null ? Arrays.asList(nvps) : null);
+    }
+
+    /**
+     * Sets the URI scheme specific part and append a list of parameters to this part.
+     *
+     * @param schemeSpecificPart
+     * @param nvps Optional, can be null. List of query parameters to be reused by the specific scheme part
+     * @return this.
+     * @since 5.1
+     */
+    public URIBuilder setSchemeSpecificPartWithParameters(final String schemeSpecificPart, final List <NameValuePair> nvps) {
+        this.encodedSchemeSpecificPart = null;
         if (!TextUtils.isBlank(schemeSpecificPart)) {
             final StringBuilder sb = new StringBuilder(schemeSpecificPart);
             if (nvps != null && !nvps.isEmpty()) {
@@ -574,6 +600,12 @@ public class URIBuilder {
         return this.scheme;
     }
 
+    /**
+     * Gets the scheme specific part
+     *
+     * @return String
+     * @since 5.1
+     */
     public String getSchemeSpecificPart() {
         return this.encodedSchemeSpecificPart;
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -467,14 +467,24 @@ public class TestURIBuilder {
     @Test
     public void testSchemeSpecificPartParametersNull() throws Exception {
        final URIBuilder uribuilder = new URIBuilder("http://host.com").setParameter("par", "parvalue")
-               .setSchemeSpecificPart("", null);
+               .setSchemeSpecificPartWithParameters("", null);
        Assert.assertEquals(new URI("http://host.com?par=parvalue"), uribuilder.build());
     }
 
     @Test
     public void testSchemeSpecificPartSetGet() throws Exception {
-       final URIBuilder uribuilder = new URIBuilder().setSchemeSpecificPart("specificpart", null);
+       final URIBuilder uribuilder = new URIBuilder().setSchemeSpecificPart("specificpart");
        Assert.assertEquals("specificpart", uribuilder.getSchemeSpecificPart());
+    }
+
+    /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
+    @Test
+    public void testSchemeSpecificPartParameterByRFC6068Sample() throws Exception {
+       final URIBuilder uribuilder = new URIBuilder().setScheme("mailto")
+               .setSchemeSpecificPartWithParameter("my@email.server", new BasicNameValuePair("subject", "mail subject"));
+       final String result = uribuilder.build().toString();
+       Assert.assertTrue("mail address as scheme specific part expected", result.contains("my@email.server"));
+       Assert.assertTrue("correct parameter encoding expected for that scheme", result.contains("mail%20subject"));
     }
 
     /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
@@ -483,7 +493,7 @@ public class TestURIBuilder {
         final List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("subject", "mail subject"));
 
-       final URIBuilder uribuilder = new URIBuilder().setScheme("mailto").setSchemeSpecificPart("my@email.server", parameters);
+       final URIBuilder uribuilder = new URIBuilder().setScheme("mailto").setSchemeSpecificPartWithParameters("my@email.server", parameters);
        final String result = uribuilder.build().toString();
        Assert.assertTrue("mail address as scheme specific part expected", result.contains("my@email.server"));
        Assert.assertTrue("correct parameter encoding expected for that scheme", result.contains("mail%20subject"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -464,4 +464,28 @@ public class TestURIBuilder {
         Assert.assertEquals(uri, result);
     }
 
+    @Test
+    public void testSchemeSpecificPartParametersNull() throws Exception {
+       final URIBuilder uribuilder = new URIBuilder("http://host.com").setParameter("par", "parvalue")
+               .setSchemeSpecificPart("", null);
+       Assert.assertEquals(new URI("http://host.com?par=parvalue"), uribuilder.build());
+    }
+
+    @Test
+    public void testSchemeSpecificPartSetGet() throws Exception {
+       final URIBuilder uribuilder = new URIBuilder().setSchemeSpecificPart("specificpart", null);
+       Assert.assertEquals("specificpart", uribuilder.getSchemeSpecificPart());
+    }
+
+    /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
+    @Test
+    public void testSchemeSpecificPartParametersByRFC6068Sample() throws Exception {
+        final List<NameValuePair> parameters = new ArrayList<>();
+        parameters.add(new BasicNameValuePair("subject", "mail subject"));
+
+       final URIBuilder uribuilder = new URIBuilder().setScheme("mailto").setSchemeSpecificPart("my@email.server", parameters);
+       final String result = uribuilder.build().toString();
+       Assert.assertTrue("mail address as scheme specific part expected", result.contains("my@email.server"));
+       Assert.assertTrue("correct parameter encoding expected for that scheme", result.contains("mail%20subject"));
+    }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -467,7 +467,7 @@ public class TestURIBuilder {
     @Test
     public void testSchemeSpecificPartParametersNull() throws Exception {
        final URIBuilder uribuilder = new URIBuilder("http://host.com").setParameter("par", "parvalue")
-               .setSchemeSpecificPartWithParameters("", null);
+               .setSchemeSpecificPart("", (NameValuePair)null);
        Assert.assertEquals(new URI("http://host.com?par=parvalue"), uribuilder.build());
     }
 
@@ -479,9 +479,9 @@ public class TestURIBuilder {
 
     /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
     @Test
-    public void testSchemeSpecificPartParameterByRFC6068Sample() throws Exception {
+    public void testSchemeSpecificPartNameValuePairByRFC6068Sample() throws Exception {
        final URIBuilder uribuilder = new URIBuilder().setScheme("mailto")
-               .setSchemeSpecificPartWithParameter("my@email.server", new BasicNameValuePair("subject", "mail subject"));
+               .setSchemeSpecificPart("my@email.server", new BasicNameValuePair("subject", "mail subject"));
        final String result = uribuilder.build().toString();
        Assert.assertTrue("mail address as scheme specific part expected", result.contains("my@email.server"));
        Assert.assertTrue("correct parameter encoding expected for that scheme", result.contains("mail%20subject"));
@@ -489,11 +489,11 @@ public class TestURIBuilder {
 
     /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
     @Test
-    public void testSchemeSpecificPartParametersByRFC6068Sample() throws Exception {
+    public void testSchemeSpecificPartNameValuePairListByRFC6068Sample() throws Exception {
         final List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("subject", "mail subject"));
 
-       final URIBuilder uribuilder = new URIBuilder().setScheme("mailto").setSchemeSpecificPartWithParameters("my@email.server", parameters);
+       final URIBuilder uribuilder = new URIBuilder().setScheme("mailto").setSchemeSpecificPart("my@email.server", parameters);
        final String result = uribuilder.build().toString();
        Assert.assertTrue("mail address as scheme specific part expected", result.contains("my@email.server"));
        Assert.assertTrue("correct parameter encoding expected for that scheme", result.contains("mail%20subject"));


### PR DESCRIPTION
…the scheme specific part of an URI

Changed: URIBuilder to support new getter/setter to allow access to previously existing but private schemeSpecificPart variable. Idea was to open the class for more use cases, like RFC 6068. Issue discussion at [HTTPCORE-627](https://issues.apache.org/jira/browse/HTTPCORE-627)
