### PR TITLE
HTTPCORE-636: Logging statements use slf4j interpolation over concatenation

### DIFF
--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2GreetingServer.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2GreetingServer.java
@@ -155,7 +155,7 @@ public class H2GreetingServer {
 
             // recording the request
             System.out.println(String.format("[%s] %s %s %s", new Date(),
-                    endpoint.getRemoteAddress().toString(),
+                    endpoint.getRemoteAddress(),
                     req.getMethod(),
                     req.getPath()));
 

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/examples/ReactiveFullDuplexClientExample.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/examples/ReactiveFullDuplexClientExample.java
@@ -128,7 +128,7 @@ public class ReactiveFullDuplexClientExample {
 
         System.out.println(streamingResponse.getHead());
         for (final Header header : streamingResponse.getHead().getHeaders()) {
-            System.out.println(header.toString());
+            System.out.println(header);
         }
         System.out.println();
 
@@ -145,7 +145,7 @@ public class ReactiveFullDuplexClientExample {
             .forEach(new Consumer<Notification<String>>() {
                 @Override
                 public void accept(final Notification<String> byteBufferNotification) {
-                    System.out.println(byteBufferNotification.toString());
+                    System.out.println(byteBufferNotification);
                 }
             });
 

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/HttpBenchmark.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/HttpBenchmark.java
@@ -334,7 +334,7 @@ public class HttpBenchmark {
                             System.out.println(">> " + request.getMethod() + " " + request.getRequestUri());
                             final Header[] headers = request.getHeaders();
                             for (final Header header : headers) {
-                                System.out.println(">> " + header.toString());
+                                System.out.println(">> " + header);
                             }
                             System.out.println();
                         }
@@ -346,7 +346,7 @@ public class HttpBenchmark {
                             System.out.println("<< " + response.getCode() + " " + response.getReasonPhrase());
                             final Header[] headers = response.getHeaders();
                             for (final Header header : headers) {
-                                System.out.println("<< " + header.toString());
+                                System.out.println("<< " + header);
                             }
                             System.out.println();
                         }
@@ -371,7 +371,7 @@ public class HttpBenchmark {
                             final List<? extends Header> headers) {
                         if (config.getVerbosity() >= 3) {
                             for (final Header header : headers) {
-                                System.out.println(">> " + header.toString());
+                                System.out.println(">> " + header);
                             }
                             System.out.println();
                         }
@@ -384,7 +384,7 @@ public class HttpBenchmark {
                             final List<? extends Header> headers) {
                         if (config.getVerbosity() >= 3) {
                             for (final Header header : headers) {
-                                System.out.println("<< " + header.toString());
+                                System.out.println("<< " + header);
                             }
                             System.out.println();
                         }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingBHttpClientConnection.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingBHttpClientConnection.java
@@ -87,7 +87,7 @@ public class LoggingBHttpClientConnection extends DefaultBHttpClientConnection i
     @Override
     public void close() throws IOException {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + ": Close connection");
+            this.log.debug("{}: Close connection", this.id);
         }
         super.close();
     }
@@ -95,7 +95,7 @@ public class LoggingBHttpClientConnection extends DefaultBHttpClientConnection i
     @Override
     public void close(final CloseMode closeMode) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + ": Shutdown connection");
+            this.log.debug("{}: Shutdown connection", this.id);
         }
         super.close(closeMode);
     }
@@ -108,10 +108,10 @@ public class LoggingBHttpClientConnection extends DefaultBHttpClientConnection i
     @Override
     protected void onResponseReceived(final ClassicHttpResponse response) {
         if (response != null && this.headerLog.isDebugEnabled()) {
-            this.headerLog.debug(this.id + " << " + new StatusLine(response));
+            this.headerLog.debug("{} << {}", this.id, new StatusLine(response));
             final Header[] headers = response.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug(this.id + " << " + header.toString());
+                this.headerLog.debug("{} << {}", this.id, header);
             }
         }
     }
@@ -119,10 +119,10 @@ public class LoggingBHttpClientConnection extends DefaultBHttpClientConnection i
     @Override
     protected void onRequestSubmitted(final ClassicHttpRequest request) {
         if (request != null && this.headerLog.isDebugEnabled()) {
-            this.headerLog.debug(id + " >> " + new RequestLine(request));
+            this.headerLog.debug("{} >> {}", id, new RequestLine(request));
             final Header[] headers = request.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug(this.id + " >> " + header.toString());
+                this.headerLog.debug("{} >> {}", this.id, header);
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingBHttpServerConnection.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingBHttpServerConnection.java
@@ -87,7 +87,7 @@ public class LoggingBHttpServerConnection extends DefaultBHttpServerConnection i
     @Override
     public void close() throws IOException {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + ": Close connection");
+            this.log.debug("{}: Close connection", this.id);
         }
         super.close();
     }
@@ -95,7 +95,7 @@ public class LoggingBHttpServerConnection extends DefaultBHttpServerConnection i
     @Override
     public void close(final CloseMode closeMode) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + ": Shutdown connection");
+            this.log.debug("{}: Shutdown connection", this.id);
         }
         super.close(closeMode);
     }
@@ -108,10 +108,10 @@ public class LoggingBHttpServerConnection extends DefaultBHttpServerConnection i
     @Override
     protected void onRequestReceived(final ClassicHttpRequest request) {
         if (request != null && this.headerLog.isDebugEnabled()) {
-            this.headerLog.debug(id + " >> " + new RequestLine(request));
+            this.headerLog.debug("{} >> {}", id, new RequestLine(request));
             final Header[] headers = request.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug(this.id + " >> " + header.toString());
+                this.headerLog.debug("{} >> {}", this.id, header);
             }
         }
     }
@@ -119,10 +119,10 @@ public class LoggingBHttpServerConnection extends DefaultBHttpServerConnection i
     @Override
     protected void onResponseSubmitted(final ClassicHttpResponse response) {
         if (response != null && this.headerLog.isDebugEnabled()) {
-            this.headerLog.debug(this.id + " << " + new StatusLine(response));
+            this.headerLog.debug("{} << {}", this.id, new StatusLine(response));
             final Header[] headers = response.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug(this.id + " << " + header.toString());
+                this.headerLog.debug("{} << {}", this.id, header);
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingHttp1StreamListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingHttp1StreamListener.java
@@ -52,9 +52,9 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     public void onExchangeComplete(final HttpConnection connection, final boolean keepAlive) {
         if (connLog.isDebugEnabled()) {
             if (keepAlive) {
-                connLog.debug("{} Connection is kept alive", LoggingSupport.getId(connection));
+                connLog.debug("{} connection is kept alive", LoggingSupport.getId(connection));
             } else {
-                connLog.debug("{} Connection is not kept alive", LoggingSupport.getId(connection));
+                connLog.debug("{} connection is not kept alive", LoggingSupport.getId(connection));
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingHttp1StreamListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/LoggingHttp1StreamListener.java
@@ -52,9 +52,9 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     public void onExchangeComplete(final HttpConnection connection, final boolean keepAlive) {
         if (connLog.isDebugEnabled()) {
             if (keepAlive) {
-                connLog.debug(LoggingSupport.getId(connection) + " Connection is kept alive");
+                connLog.debug("{} Connection is kept alive", LoggingSupport.getId(connection));
             } else {
-                connLog.debug(LoggingSupport.getId(connection) + " Connection is not kept alive");
+                connLog.debug("{} Connection is not kept alive", LoggingSupport.getId(connection));
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/Wire.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/Wire.java
@@ -53,7 +53,7 @@ public class Wire {
                 buffer.append("[\\n]\"");
                 buffer.insert(0, "\"");
                 buffer.insert(0, header);
-                this.log.debug(this.id + " " + buffer.toString());
+                this.log.debug("{} {}", this.id, buffer);
                 buffer.setLength(0);
             } else if ((ch < Chars.SP) || (ch >= Chars.DEL)) {
                 buffer.append("[0x");
@@ -67,7 +67,7 @@ public class Wire {
             buffer.append('\"');
             buffer.insert(0, '\"');
             buffer.insert(0, header);
-            this.log.debug(this.id + " " + buffer.toString());
+            this.log.debug("{} {}", this.id, buffer);
         }
     }
 

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LogAppendable.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LogAppendable.java
@@ -60,7 +60,7 @@ class LogAppendable implements Appendable {
     @Override
     public Appendable append(final char ch) throws IOException {
         if (ch == '\n') {
-            log.debug(prefix + " " + buffer.toString());
+            log.debug("{} {}", prefix, buffer);
             buffer.setLength(0);
         } else if (ch != '\r') {
             buffer.append(ch);
@@ -70,7 +70,7 @@ class LogAppendable implements Appendable {
 
     public void flush() {
         if (buffer.length() > 0) {
-            log.debug(prefix + " " + buffer.toString());
+            log.debug("{} {}", prefix, buffer);
             buffer.setLength(0);
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingH2StreamListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingH2StreamListener.java
@@ -78,19 +78,15 @@ public class LoggingH2StreamListener implements H2StreamListener {
     }
 
     private void logFlowControl(final String prefix, final int streamId, final int delta, final int actualSize) {
-        final StringBuilder buffer = new StringBuilder();
-        buffer.append(prefix).append(" stream ").append(streamId).append(" flow control " )
-                .append(delta).append(" -> ")
-                .append(actualSize);
-        flowCtrlLog.debug(buffer.toString());
+        flowCtrlLog.debug("{} stream {} flow control {} -> {}", prefix, streamId, delta, actualSize);
     }
 
     @Override
     public void onHeaderInput(final HttpConnection connection, final int streamId, final List<? extends Header> headers) {
         if (headerLog.isDebugEnabled()) {
-            final String prefix = LoggingSupport.getId(connection) + " << ";
+            final String prefix = LoggingSupport.getId(connection);
             for (int i = 0; i < headers.size(); i++) {
-                headerLog.debug("{}{}", prefix, headers.get(i));
+                headerLog.debug("{} << {}", prefix, headers.get(i));
             }
         }
     }
@@ -98,9 +94,9 @@ public class LoggingH2StreamListener implements H2StreamListener {
     @Override
     public void onHeaderOutput(final HttpConnection connection, final int streamId, final List<? extends Header> headers) {
         if (headerLog.isDebugEnabled()) {
-            final String prefix = LoggingSupport.getId(connection) + " >> ";
+            final String prefix = LoggingSupport.getId(connection);
             for (int i = 0; i < headers.size(); i++) {
-                headerLog.debug("{}{}", prefix, headers.get(i));
+                headerLog.debug("{} >> {}", prefix, headers.get(i));
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingH2StreamListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingH2StreamListener.java
@@ -90,7 +90,7 @@ public class LoggingH2StreamListener implements H2StreamListener {
         if (headerLog.isDebugEnabled()) {
             final String prefix = LoggingSupport.getId(connection) + " << ";
             for (int i = 0; i < headers.size(); i++) {
-                headerLog.debug(prefix + headers.get(i));
+                headerLog.debug("{}{}", prefix, headers.get(i));
             }
         }
     }
@@ -100,7 +100,7 @@ public class LoggingH2StreamListener implements H2StreamListener {
         if (headerLog.isDebugEnabled()) {
             final String prefix = LoggingSupport.getId(connection) + " >> ";
             for (int i = 0; i < headers.size(); i++) {
-                headerLog.debug(prefix + headers.get(i));
+                headerLog.debug("{}{}", prefix, headers.get(i));
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingHttp1StreamListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingHttp1StreamListener.java
@@ -71,10 +71,10 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     @Override
     public void onResponseHead(final HttpConnection connection, final HttpResponse response) {
         if (headerLog.isDebugEnabled()) {
-            final String idResponseDirection = LoggingSupport.getId(connection) + responseDirection;
-            headerLog.debug("{}{}", idResponseDirection, new StatusLine(response));
+            final String id = LoggingSupport.getId(connection);
+            headerLog.debug("{}{}{}", id, responseDirection, new StatusLine(response));
             for (final Iterator<Header> it = response.headerIterator(); it.hasNext(); ) {
-                headerLog.debug("{}{}", idResponseDirection, it.next());
+                headerLog.debug("{}{}{}", id, responseDirection, it.next());
             }
         }
     }
@@ -83,9 +83,9 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     public void onExchangeComplete(final HttpConnection connection, final boolean keepAlive) {
         if (connLog.isDebugEnabled()) {
             if (keepAlive) {
-                connLog.debug("{} Connection is kept alive", LoggingSupport.getId(connection));
+                connLog.debug("{} connection is kept alive", LoggingSupport.getId(connection));
             } else {
-                connLog.debug("{} Connection is not kept alive", LoggingSupport.getId(connection));
+                connLog.debug("{} connection is not kept alive", LoggingSupport.getId(connection));
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingHttp1StreamListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingHttp1StreamListener.java
@@ -61,9 +61,9 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     public void onRequestHead(final HttpConnection connection, final HttpRequest request) {
         if (headerLog.isDebugEnabled()) {
             final String idRequestDirection = LoggingSupport.getId(connection) + requestDirection;
-            headerLog.debug(idRequestDirection + new RequestLine(request));
+            headerLog.debug("{}{}", idRequestDirection, new RequestLine(request));
             for (final Iterator<Header> it = request.headerIterator(); it.hasNext(); ) {
-                headerLog.debug(idRequestDirection + it.next());
+                headerLog.debug("{}{}", idRequestDirection, it.next());
             }
         }
     }
@@ -72,9 +72,9 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     public void onResponseHead(final HttpConnection connection, final HttpResponse response) {
         if (headerLog.isDebugEnabled()) {
             final String idResponseDirection = LoggingSupport.getId(connection) + responseDirection;
-            headerLog.debug(idResponseDirection + new StatusLine(response));
+            headerLog.debug("{}{}", idResponseDirection, new StatusLine(response));
             for (final Iterator<Header> it = response.headerIterator(); it.hasNext(); ) {
-                headerLog.debug(idResponseDirection + it.next());
+                headerLog.debug("{}{}", idResponseDirection, it.next());
             }
         }
     }
@@ -83,9 +83,9 @@ public class LoggingHttp1StreamListener implements Http1StreamListener {
     public void onExchangeComplete(final HttpConnection connection, final boolean keepAlive) {
         if (connLog.isDebugEnabled()) {
             if (keepAlive) {
-                connLog.debug(LoggingSupport.getId(connection) + " Connection is kept alive");
+                connLog.debug("{} Connection is kept alive", LoggingSupport.getId(connection));
             } else {
-                connLog.debug(LoggingSupport.getId(connection) + " Connection is not kept alive");
+                connLog.debug("{} Connection is not kept alive", LoggingSupport.getId(connection));
             }
         }
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingIOSession.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingIOSession.java
@@ -76,7 +76,7 @@ public class LoggingIOSession implements IOSession {
     public void enqueue(final Command command, final Command.Priority priority) {
         this.session.enqueue(command, priority);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Enqueued " + command.getClass().getSimpleName() + " with priority " + priority);
+            this.log.debug("{} Enqueued {} with priority {}", this.session, command.getClass().getSimpleName(), priority);
         }
     }
 
@@ -133,7 +133,7 @@ public class LoggingIOSession implements IOSession {
     public void setEventMask(final int ops) {
         this.session.setEventMask(ops);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Event mask set " + formatOps(ops));
+            this.log.debug("{} Event mask set {}", this.session, formatOps(ops));
         }
     }
 
@@ -141,7 +141,7 @@ public class LoggingIOSession implements IOSession {
     public void setEvent(final int op) {
         this.session.setEvent(op);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Event set " + formatOps(op));
+            this.log.debug("{} Event set {}", this.session, formatOps(op));
         }
     }
 
@@ -149,14 +149,14 @@ public class LoggingIOSession implements IOSession {
     public void clearEvent(final int op) {
         this.session.clearEvent(op);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Event cleared " + formatOps(op));
+            this.log.debug("{} Event cleared {}", this.session, formatOps(op));
         }
     }
 
     @Override
     public void close() {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Close");
+            this.log.debug("{} Close", this.session);
         }
         this.session.close();
     }
@@ -174,7 +174,7 @@ public class LoggingIOSession implements IOSession {
     @Override
     public void close(final CloseMode closeMode) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Shutdown " + closeMode);
+            this.log.debug("{} Shutdown {}", this.session, closeMode);
         }
         this.session.close(closeMode);
     }
@@ -187,7 +187,7 @@ public class LoggingIOSession implements IOSession {
     @Override
     public void setSocketTimeout(final Timeout timeout) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Set timeout " + timeout);
+            this.log.debug("{} Set timeout {}", this.session, timeout);
         }
         this.session.setSocketTimeout(timeout);
     }
@@ -196,7 +196,7 @@ public class LoggingIOSession implements IOSession {
     public int read(final ByteBuffer dst) throws IOException {
         final int bytesRead = session.read(dst);
         if (log.isDebugEnabled()) {
-            log.debug(session + " " + bytesRead + " bytes read");
+            log.debug("{} {} bytes read", session, bytesRead);
         }
         if (bytesRead > 0 && wireLog.isEnabled()) {
             final ByteBuffer b = dst.duplicate();
@@ -212,7 +212,7 @@ public class LoggingIOSession implements IOSession {
     public int write(final ByteBuffer src) throws IOException {
         final int byteWritten = session.write(src);
         if (log.isDebugEnabled()) {
-            log.debug(session + " " + byteWritten + " bytes written");
+            log.debug("{} {} bytes written", session, byteWritten);
         }
         if (byteWritten > 0 && wireLog.isEnabled()) {
             final ByteBuffer b = src.duplicate();
@@ -257,7 +257,7 @@ public class LoggingIOSession implements IOSession {
     @Override
     public void upgrade(final IOEventHandler handler) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Protocol upgrade: " + (handler != null ? handler.getClass() : null));
+            this.log.debug("{} Protocol upgrade: {}", this.session, handler != null ? handler.getClass() : null);
         }
         this.session.upgrade(handler);
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingIOSession.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingIOSession.java
@@ -76,7 +76,7 @@ public class LoggingIOSession implements IOSession {
     public void enqueue(final Command command, final Command.Priority priority) {
         this.session.enqueue(command, priority);
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Enqueued {} with priority {}", this.session, command.getClass().getSimpleName(), priority);
+            this.log.debug("{} enqueued {} with priority {}", this.session, command.getClass().getSimpleName(), priority);
         }
     }
 
@@ -133,7 +133,7 @@ public class LoggingIOSession implements IOSession {
     public void setEventMask(final int ops) {
         this.session.setEventMask(ops);
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Event mask set {}", this.session, formatOps(ops));
+            this.log.debug("{} event mask set {}", this.session, formatOps(ops));
         }
     }
 
@@ -141,7 +141,7 @@ public class LoggingIOSession implements IOSession {
     public void setEvent(final int op) {
         this.session.setEvent(op);
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Event set {}", this.session, formatOps(op));
+            this.log.debug("{} event set {}", this.session, formatOps(op));
         }
     }
 
@@ -149,14 +149,14 @@ public class LoggingIOSession implements IOSession {
     public void clearEvent(final int op) {
         this.session.clearEvent(op);
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Event cleared {}", this.session, formatOps(op));
+            this.log.debug("{} event cleared {}", this.session, formatOps(op));
         }
     }
 
     @Override
     public void close() {
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Close", this.session);
+            this.log.debug("{} close", this.session);
         }
         this.session.close();
     }
@@ -174,7 +174,7 @@ public class LoggingIOSession implements IOSession {
     @Override
     public void close(final CloseMode closeMode) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Shutdown {}", this.session, closeMode);
+            this.log.debug("{} shutdown {}", this.session, closeMode);
         }
         this.session.close(closeMode);
     }
@@ -187,7 +187,7 @@ public class LoggingIOSession implements IOSession {
     @Override
     public void setSocketTimeout(final Timeout timeout) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Set timeout {}", this.session, timeout);
+            this.log.debug("{} set timeout {}", this.session, timeout);
         }
         this.session.setSocketTimeout(timeout);
     }
@@ -257,7 +257,7 @@ public class LoggingIOSession implements IOSession {
     @Override
     public void upgrade(final IOEventHandler handler) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug("{} Protocol upgrade: {}", this.session, handler != null ? handler.getClass() : null);
+            this.log.debug("{} protocol upgrade: {}", this.session, handler != null ? handler.getClass() : null);
         }
         this.session.upgrade(handler);
     }

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingIOSessionListener.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/LoggingIOSessionListener.java
@@ -45,35 +45,35 @@ public class LoggingIOSessionListener implements IOSessionListener {
     @Override
     public void connected(final IOSession session) {
         if (connLog.isDebugEnabled()) {
-            connLog.debug(session + " connected");
+            connLog.debug("{} connected", session);
         }
     }
 
     @Override
     public void startTls(final IOSession session) {
         if (connLog.isDebugEnabled()) {
-            connLog.debug(session + " TLS started");
+            connLog.debug("{} TLS started", session);
         }
     }
 
     @Override
     public void inputReady(final IOSession session) {
         if (connLog.isDebugEnabled()) {
-            connLog.debug(session + " input ready");
+            connLog.debug("{} input ready", session);
         }
     }
 
     @Override
     public void outputReady(final IOSession session) {
         if (connLog.isDebugEnabled()) {
-            connLog.debug(session + " output ready");
+            connLog.debug("{} output ready", session);
         }
     }
 
     @Override
     public void timeout(final IOSession session) {
         if (connLog.isDebugEnabled()) {
-            connLog.debug(session + " timeout");
+            connLog.debug("{} timeout", session);
         }
     }
 
@@ -82,13 +82,13 @@ public class LoggingIOSessionListener implements IOSessionListener {
         if (ex instanceof ConnectionClosedException) {
             return;
         }
-        connLog.error(session + " " + ex.getMessage(), ex);
+        connLog.error("{} {}", session, ex.getMessage(), ex);
     }
 
     @Override
     public void disconnected(final IOSession session) {
         if (connLog.isDebugEnabled()) {
-            connLog.debug(session + " disconnected");
+            connLog.debug("{} disconnected", session);
         }
     }
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/H2CompatibilityTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/H2CompatibilityTest.java
@@ -448,7 +448,7 @@ public class H2CompatibilityTest {
         if (message != null && !TextUtils.isBlank(message)) {
             buf.append(" -> ").append(message);
         }
-        System.out.println(buf.toString());
+        System.out.println(buf);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
@@ -179,7 +179,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
 
             @Override
             public String toString() {
-                return "Http1StreamChannel[" + ServerHttp1StreamDuplexer.this.toString() + "]";
+                return "Http1StreamChannel[" + ServerHttp1StreamDuplexer.this + "]";
             }
 
         };

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
@@ -137,7 +137,7 @@ class ServerHttp1StreamHandler implements ResourceHolder {
 
             @Override
             public String toString() {
-                return super.toString() + " " + ServerHttp1StreamHandler.this.toString();
+                return super.toString() + " " + ServerHttp1StreamHandler.this;
             }
 
         };

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicReverseProxyExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicReverseProxyExample.java
@@ -109,7 +109,7 @@ public class ClassicReverseProxyExample {
                     public void onLease(final HttpHost route, final ConnPoolStats<HttpHost> connPoolStats) {
                         final StringBuilder buf = new StringBuilder();
                         buf.append("[proxy->origin] " + Thread.currentThread()  + " connection leased ").append(route);
-                        System.out.println(buf.toString());
+                        System.out.println(buf);
                     }
 
                     @Override
@@ -120,7 +120,7 @@ public class ClassicReverseProxyExample {
                         buf.append("; total kept alive: ").append(totals.getAvailable()).append("; ");
                         buf.append("total allocated: ").append(totals.getLeased() + totals.getAvailable());
                         buf.append(" of ").append(totals.getMax());
-                        System.out.println(buf.toString());
+                        System.out.println(buf);
                     }
 
                 })


### PR DESCRIPTION
Methodology:
I used the intellij idea ultimate edition inspection "non-constant
string concatenation as argument to logging call" to find and
auto-fix occurrences of this pattern.
Followed up with intellij idea fixes for "Unnecessary call to 'toString'"