### PR TITLE
HTTPCORE-634: fix possible race condition

### DIFF
--- a/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
+++ b/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
@@ -318,13 +318,13 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
         }
         this.lock.lock();
         try {
-            final RouteSpecificPool<T, C, E> pool = getPool(route);
             E entry;
             for (;;) {
                 Asserts.check(!this.isShutDown, "Connection pool shut down");
                 if (future.isCancelled()) {
                     throw new ExecutionException(operationAborted());
                 }
+                final RouteSpecificPool<T, C, E> pool = getPool(route);
                 for (;;) {
                     entry = pool.getFree(state);
                     if (entry == null) {


### PR DESCRIPTION
pool cached in getPoolEntryBlocking could be removed from routeToPool map by another thread while the thread executing getPoolEntryBlocking was waiting on condition.
After this change we check routeToPool after every wait.