### PR TITLE
HTTPCORE-638: SharedOutputBuffer must only call dataStreamChannel.endStream() once

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/SharedOutputBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/SharedOutputBuffer.java
@@ -43,10 +43,12 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
 
     private volatile DataStreamChannel dataStreamChannel;
     private volatile boolean hasCapacity;
+    private volatile boolean endStreamPropagated;
 
     public SharedOutputBuffer(final ReentrantLock lock, final int initialBufferSize) {
         super(lock, initialBufferSize);
         this.hasCapacity = false;
+        this.endStreamPropagated = false;
     }
 
     public SharedOutputBuffer(final int bufferSize) {
@@ -63,7 +65,7 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
                 dataStreamChannel.write(buffer());
             }
             if (!buffer().hasRemaining() && endStream) {
-                dataStreamChannel.endStream();
+                propagateEndStreamOnce();
             }
             condition.signalAll();
         } finally {
@@ -135,7 +137,7 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
                     if (buffer().hasRemaining()) {
                         dataStreamChannel.requestOutput();
                     } else {
-                        dataStreamChannel.endStream();
+                        propagateEndStreamOnce();
                     }
                 }
             }
@@ -160,6 +162,13 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
             ensureNotAborted();
         }
         setInputMode();
+    }
+
+    private void propagateEndStreamOnce() throws IOException {
+        if (!endStreamPropagated) {
+            dataStreamChannel.endStream();
+            endStreamPropagated = true;
+        }
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/SharedOutputBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/SharedOutputBuffer.java
@@ -65,7 +65,7 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
                 dataStreamChannel.write(buffer());
             }
             if (!buffer().hasRemaining() && endStream) {
-                propagateEndStreamOnce();
+                propagateEndStream();
             }
             condition.signalAll();
         } finally {
@@ -137,7 +137,7 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
                     if (buffer().hasRemaining()) {
                         dataStreamChannel.requestOutput();
                     } else {
-                        propagateEndStreamOnce();
+                        propagateEndStream();
                     }
                 }
             }
@@ -164,7 +164,7 @@ public final class SharedOutputBuffer extends AbstractSharedBuffer implements Co
         setInputMode();
     }
 
-    private void propagateEndStreamOnce() throws IOException {
+    private void propagateEndStream() throws IOException {
         if (!endStreamPropagated) {
             dataStreamChannel.endStream();
             endStreamPropagated = true;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/support/classic/TestSharedOutputBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/support/classic/TestSharedOutputBuffer.java
@@ -229,5 +229,19 @@ public class TestSharedOutputBuffer {
         }
     }
 
+    @Test
+    public void testEndStreamOnlyCalledOnce() throws IOException {
+
+        final DataStreamChannel channel = Mockito.mock(DataStreamChannel.class);
+        final SharedOutputBuffer outputBuffer = new SharedOutputBuffer(20);
+
+        outputBuffer.flush(channel);
+
+        outputBuffer.writeCompleted();
+        outputBuffer.flush(channel);
+
+        Mockito.verify(channel, Mockito.times(1)).endStream();
+    }
+
 }
 


### PR DESCRIPTION
It is possible for `flush` to be called after `markCompleted` and both would call `dataStreamChannel.endStream` which is incorrect, `endStream` must only be called once.