### PR TITLE
Enable IT for H2 Protocol Negotiation

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
@@ -233,7 +233,7 @@ public class H2ProtocolNegotiationTest {
         final HttpResponse response1 = message1.getHead();
         Assert.assertThat(response1.getCode(), CoreMatchers.equalTo(HttpStatus.SC_OK));
 
-        if (javaVersion >= 9) {
+        if (javaVersion >= 8) {
             Assert.assertThat(response1.getVersion(), CoreMatchers.<ProtocolVersion>equalTo(HttpVersion.HTTP_2));
         } else {
             Assert.assertThat(response1.getVersion(), CoreMatchers.<ProtocolVersion>equalTo(HttpVersion.HTTP_1_1));


### PR DESCRIPTION
Since TLS 1.3 and/or APLN is now available in Java 8 we can enable this and avoid the failure on Java 8.