### PR TITLE
HTTPCORE-645: Increase blocking default chunk size to 8 KiB and reuse chunk buffers

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/BHttpConnectionBase.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/BHttpConnectionBase.java
@@ -158,7 +158,7 @@ class BHttpConnectionBase implements BHttpConnection {
     private byte[] getChunkedRequestBuffer() {
         if (chunkedRequestBuffer == null) {
             final int chunkSizeHint = this.http1Config.getChunkSizeHint();
-            chunkedRequestBuffer = new byte[chunkSizeHint > 0 ? chunkSizeHint : 2048];
+            chunkedRequestBuffer = new byte[chunkSizeHint > 0 ? chunkSizeHint : 8192];
         }
         return chunkedRequestBuffer;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
@@ -69,6 +69,29 @@ public class ChunkedOutputStream extends OutputStream {
      *
      * @param buffer Session output buffer
      * @param outputStream Output stream
+     * @param chunkCache Buffer used to aggregate smaller writes into chunks.
+     * @param trailerSupplier Trailer supplier. May be {@code null}
+     *
+     * @since 5.1
+     */
+    public ChunkedOutputStream(
+            final SessionOutputBuffer buffer,
+            final OutputStream outputStream,
+            final byte[] chunkCache,
+            final Supplier<List<? extends Header>> trailerSupplier) {
+        super();
+        this.buffer = Args.notNull(buffer, "Session output buffer");
+        this.outputStream = Args.notNull(outputStream, "Output stream");
+        this.cache = Args.notNull(chunkCache, "Chunk cache");
+        this.lineBuffer = new CharArrayBuffer(32);
+        this.trailerSupplier = trailerSupplier;
+    }
+
+    /**
+     * Constructor taking an integer chunk size hint.
+     *
+     * @param buffer Session output buffer
+     * @param outputStream Output stream
      * @param chunkSizeHint minimal chunk size hint
      * @param trailerSupplier Trailer supplier. May be {@code null}
      *
@@ -79,12 +102,7 @@ public class ChunkedOutputStream extends OutputStream {
             final OutputStream outputStream,
             final int chunkSizeHint,
             final Supplier<List<? extends Header>> trailerSupplier) {
-        super();
-        this.buffer = Args.notNull(buffer, "Session output buffer");
-        this.outputStream = Args.notNull(outputStream, "Output stream");
-        this.cache = new byte[chunkSizeHint > 0 ? chunkSizeHint : 2048];
-        this.lineBuffer = new CharArrayBuffer(32);
-        this.trailerSupplier = trailerSupplier;
+        this(buffer, outputStream, new byte[chunkSizeHint > 0 ? chunkSizeHint : 2048], trailerSupplier);
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
@@ -102,7 +102,7 @@ public class ChunkedOutputStream extends OutputStream {
             final OutputStream outputStream,
             final int chunkSizeHint,
             final Supplier<List<? extends Header>> trailerSupplier) {
-        this(buffer, outputStream, new byte[chunkSizeHint > 0 ? chunkSizeHint : 2048], trailerSupplier);
+        this(buffer, outputStream, new byte[chunkSizeHint > 0 ? chunkSizeHint : 8192], trailerSupplier);
     }
 
     /**


### PR DESCRIPTION
This PR includes two commits, because this fix is implemented in two parts:
1. Reuse chunk buffers between requests using a persistent connection in order to eliminate the performance cost of allocating buffers
2. Increase the default value from 2 KiB to 8 KiB matching the default buffer size.