### PR TITLE
Use decimal numbers for endpoint/execution IDs

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
@@ -71,7 +71,7 @@ class IOSessionImpl implements IOSession {
         this.commandQueue = new ConcurrentLinkedDeque<>();
         this.lock = new ReentrantLock();
         this.socketTimeout = Timeout.DISABLED;
-        this.id = String.format(type + "-%08X", COUNT.getAndIncrement());
+        this.id = String.format(type + "-%010d", COUNT.getAndIncrement());
         this.handlerRef = new AtomicReference<>();
         this.status = new AtomicReference<>(Status.ACTIVE);
         final long currentTimeMillis = System.currentTimeMillis();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
@@ -251,7 +251,7 @@ public class AsyncReverseProxyExample {
         AsyncClientEndpoint clientEndpoint;
 
         ProxyExchangeState() {
-            this.id = String.format("%08X", COUNT.getAndIncrement());
+            this.id = String.format("%010d", COUNT.getAndIncrement());
         }
 
     }


### PR DESCRIPTION
As discussed some time ago on the dev mailing list.