### PR TITLE
Add workaround of java nio bug 

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
@@ -77,7 +77,7 @@ public abstract class AbstractIOReactor implements IOReactor {
      * @param selectTimeout the select timeout.
      * @throws IOReactorException in case if a non-recoverable I/O error.
      */
-    public AbstractIOReactor(final long selectTimeout, boolean epollBugWorkaround) throws IOReactorException {
+    public AbstractIOReactor(final long selectTimeout, final boolean epollBugWorkaround) throws IOReactorException {
         this(selectTimeout, false, false);
     }
 
@@ -337,32 +337,32 @@ public abstract class AbstractIOReactor implements IOReactor {
 
         try {
             newSelector = Selector.open();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             return;
         }
 
         // Register all channels to the new Selector.
         for (;;) {
             try {
-                for (SelectionKey key : oldSelector.keys()) {
+                for (final SelectionKey key : oldSelector.keys()) {
                     try {
                         if (key.channel().keyFor(newSelector) != null) {
                             continue;
                         }
 
-                        int interestOps = key.interestOps();
+                        final int interestOps = key.interestOps();
                         key.channel().register(newSelector, interestOps, key.attachment());
                         key.cancel();
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         try {
                             newSelector.close();
-                        } catch (IOException ex) {
+                        } catch (final IOException ex) {
                             //ignore
                         }
                         return;
                     }
                 }
-            } catch (ConcurrentModificationException e) {
+            } catch (final ConcurrentModificationException e) {
                 continue;
             }
             break;
@@ -373,7 +373,7 @@ public abstract class AbstractIOReactor implements IOReactor {
         try {
             // time to close the old selector as everything else is registered to the new one
             oldSelector.close();
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             //ignore
         }
     }

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
@@ -35,8 +35,12 @@ import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.ConcurrentModificationException;
 
 import org.apache.http.nio.reactor.IOReactor;
 import org.apache.http.nio.reactor.IOReactorException;

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
@@ -329,6 +329,7 @@ public abstract class AbstractIOReactor implements IOReactor {
 
         final Selector oldSelector = selector;
         final Selector newSelector;
+        nioBugTimes = 0;
 
         if (oldSelector == null) {
             return;

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
@@ -271,6 +271,7 @@ public abstract class AbstractIOReactor implements IOReactor {
                     throw new IOReactorException("Unexpected selector failure", ex);
                 }
                 if (epollBugWorkaround && System.currentTimeMillis() - t0 < 100 && readyCount == 0) {
+                    nioBugTimes++;
                     if (nioBugTimes == nioBugTimesThreshold) {
                         rebuildSelector();
                     }

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractMultiworkerIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractMultiworkerIOReactor.java
@@ -122,6 +122,8 @@ public abstract class AbstractMultiworkerIOReactor implements IOReactor {
 
     private int currentWorker = 0;
 
+    private boolean epollBugWorkaround;
+
     /**
      * Creates an instance of AbstractMultiworkerIOReactor with the given configuration.
      *
@@ -145,6 +147,7 @@ public abstract class AbstractMultiworkerIOReactor implements IOReactor {
         }
         this.selectTimeout = this.config.getSelectInterval();
         this.interestOpsQueueing = this.config.isInterestOpQueued();
+        this.epollBugWorkaround = this.config.isEpollBugWorkaround();
         this.statusLock = new Object();
         if (threadFactory != null) {
             this.threadFactory = threadFactory;
@@ -318,7 +321,7 @@ public abstract class AbstractMultiworkerIOReactor implements IOReactor {
             this.status = IOReactorStatus.ACTIVE;
             // Start I/O dispatchers
             for (int i = 0; i < this.dispatchers.length; i++) {
-                final BaseIOReactor dispatcher = new BaseIOReactor(this.selectTimeout, this.interestOpsQueueing);
+                final BaseIOReactor dispatcher = new BaseIOReactor(this.selectTimeout, this.interestOpsQueueing, epollBugWorkaround);
                 dispatcher.setExceptionHandler(exceptionHandler);
                 this.dispatchers[i] = dispatcher;
             }

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/BaseIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/BaseIOReactor.java
@@ -67,7 +67,7 @@ public class BaseIOReactor extends AbstractIOReactor {
      * @throws IOReactorException in case if a non-recoverable I/O error.
      */
     public BaseIOReactor(final long selectTimeout) throws IOReactorException {
-        this(selectTimeout, false);
+        this(selectTimeout, false, false);
     }
 
     /**
@@ -81,8 +81,8 @@ public class BaseIOReactor extends AbstractIOReactor {
      * @since 4.1
      */
     public BaseIOReactor(
-            final long selectTimeout, final boolean interestOpsQueueing) throws IOReactorException {
-        super(selectTimeout, interestOpsQueueing);
+            final long selectTimeout, final boolean interestOpsQueueing, final boolean epollBugWorkaround) throws IOReactorException {
+        super(selectTimeout, interestOpsQueueing, epollBugWorkaround);
         this.bufferingSessions = new HashSet<IOSession>();
         this.timeoutCheckInterval = selectTimeout;
         this.lastTimeoutCheck = System.currentTimeMillis();

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/IOReactorConfig.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/IOReactorConfig.java
@@ -519,7 +519,7 @@ public final class IOReactorConfig implements Cloneable {
             return this;
         }
 
-        public Builder setEpollBugWorkaround(boolean epollBugWorkaround) {
+        public Builder setEpollBugWorkaround(final boolean epollBugWorkaround) {
             this.epollBugWorkaround = epollBugWorkaround;
             return this;
         }

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/IOReactorConfig.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/IOReactorConfig.java
@@ -52,6 +52,8 @@ public final class IOReactorConfig implements Cloneable {
     private int sndBufSize;
     private int rcvBufSize;
     private final int backlogSize;
+    //the param use to workaround nio bug in windows
+    private boolean epollBugWorkaround;
 
     /**
      * @deprecated Use {@link Builder}.
@@ -72,6 +74,7 @@ public final class IOReactorConfig implements Cloneable {
         this.sndBufSize = 0;
         this.rcvBufSize = 0;
         this.backlogSize = 0;
+        this.epollBugWorkaround = false;
     }
 
     IOReactorConfig(
@@ -87,7 +90,8 @@ public final class IOReactorConfig implements Cloneable {
             final int connectTimeout,
             final int sndBufSize,
             final int rcvBufSize,
-            final int backlogSize) {
+            final int backlogSize,
+            final boolean epollBugWorkaround) {
         super();
         this.selectInterval = selectInterval;
         this.shutdownGracePeriod = shutdownGracePeriod;
@@ -102,6 +106,7 @@ public final class IOReactorConfig implements Cloneable {
         this.sndBufSize = sndBufSize;
         this.rcvBufSize = rcvBufSize;
         this.backlogSize = backlogSize;
+        this.epollBugWorkaround = epollBugWorkaround;
     }
 
     /**
@@ -350,6 +355,17 @@ public final class IOReactorConfig implements Cloneable {
         return backlogSize;
     }
 
+    /**
+     * to fix nio bug in windows
+     * <p>
+     * Default: {@code false}
+     *
+     * @since 4.4
+     */
+    public boolean isEpollBugWorkaround() {
+        return epollBugWorkaround;
+    }
+
     @Override
     protected IOReactorConfig clone() throws CloneNotSupportedException {
         return (IOReactorConfig) super.clone();
@@ -362,19 +378,20 @@ public final class IOReactorConfig implements Cloneable {
     public static Builder copy(final IOReactorConfig config) {
         Args.notNull(config, "I/O reactor config");
         return new Builder()
-            .setSelectInterval(config.getSelectInterval())
-            .setShutdownGracePeriod(config.getShutdownGracePeriod())
-            .setInterestOpQueued(config.isInterestOpQueued())
-            .setIoThreadCount(config.getIoThreadCount())
-            .setSoTimeout(config.getSoTimeout())
-            .setSoReuseAddress(config.isSoReuseAddress())
-            .setSoLinger(config.getSoLinger())
-            .setSoKeepAlive(config.isSoKeepalive())
-            .setTcpNoDelay(config.isTcpNoDelay())
-            .setConnectTimeout(config.getConnectTimeout())
-            .setSndBufSize(config.getSndBufSize())
-            .setRcvBufSize(config.getRcvBufSize())
-            .setBacklogSize(config.getBacklogSize());
+                .setSelectInterval(config.getSelectInterval())
+                .setShutdownGracePeriod(config.getShutdownGracePeriod())
+                .setInterestOpQueued(config.isInterestOpQueued())
+                .setIoThreadCount(config.getIoThreadCount())
+                .setSoTimeout(config.getSoTimeout())
+                .setSoReuseAddress(config.isSoReuseAddress())
+                .setSoLinger(config.getSoLinger())
+                .setSoKeepAlive(config.isSoKeepalive())
+                .setTcpNoDelay(config.isTcpNoDelay())
+                .setConnectTimeout(config.getConnectTimeout())
+                .setSndBufSize(config.getSndBufSize())
+                .setRcvBufSize(config.getRcvBufSize())
+                .setBacklogSize(config.getBacklogSize())
+                .setEpollBugWorkaround(config.isEpollBugWorkaround());
     }
 
     public static class Builder {
@@ -398,8 +415,7 @@ public final class IOReactorConfig implements Cloneable {
          * cause {@link #getDefaultMaxIoThreadCount()} to return
          * {@link Runtime#availableProcessors()}.
          *
-         * @param defaultMaxIoThreadCount
-         *            the default value for ioThreadCount.
+         * @param defaultMaxIoThreadCount the default value for ioThreadCount.
          * @since 4.4.10
          */
         public static void setDefaultMaxIoThreadCount(final int defaultMaxIoThreadCount) {
@@ -419,6 +435,7 @@ public final class IOReactorConfig implements Cloneable {
         private int sndBufSize;
         private int rcvBufSize;
         private int backlogSize;
+        private boolean epollBugWorkaround;
 
         Builder() {
             this.selectInterval = 1000;
@@ -434,6 +451,7 @@ public final class IOReactorConfig implements Cloneable {
             this.sndBufSize = 0;
             this.rcvBufSize = 0;
             this.backlogSize = 0;
+            this.epollBugWorkaround = false;
         }
 
         public Builder setSelectInterval(final long selectInterval) {
@@ -501,11 +519,16 @@ public final class IOReactorConfig implements Cloneable {
             return this;
         }
 
+        public Builder setEpollBugWorkaround(boolean epollBugWorkaround) {
+            this.epollBugWorkaround = epollBugWorkaround;
+            return this;
+        }
+
         public IOReactorConfig build() {
             return new IOReactorConfig(
                     selectInterval, shutdownGracePeriod, interestOpQueued, ioThreadCount,
                     soTimeout, soReuseAddress, soLinger, soKeepAlive, tcpNoDelay,
-                    connectTimeout, sndBufSize, rcvBufSize, backlogSize);
+                    connectTimeout, sndBufSize, rcvBufSize, backlogSize, epollBugWorkaround);
         }
 
     }
@@ -526,6 +549,7 @@ public final class IOReactorConfig implements Cloneable {
                 .append(", sndBufSize=").append(this.sndBufSize)
                 .append(", rcvBufSize=").append(this.rcvBufSize)
                 .append(", backlogSize=").append(this.backlogSize)
+                .append(", epollBugWorkaround=").append(this.epollBugWorkaround)
                 .append("]");
         return builder.toString();
     }


### PR DESCRIPTION
Recently, I found my web programer cpu spike. finnly I found it should be java nio bug. refer eclipse/jetty.project#2205. I notice in my project, the logic in `org.apache.http.impl.nio.reactor.AbstractIOReactor#execute`,  exist `                        readyCount = this.selector.select(selectTimeout);`. This is the reason of cpu spike. So I want add a way to workaround it.
 I am not good at nio code, this is my clumsy code, I hope it will solve the cpu spike problem. If it can't work normally, can community create a pr to fix it? Thanks very much.

