### PR TITLE
Make ReactiveDataConsumer.failed a no-op if it has already been marked as complete

### DIFF
--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
@@ -67,8 +67,10 @@ final class ReactiveDataConsumer implements AsyncDataConsumer, Publisher<ByteBuf
     private volatile Subscriber<? super ByteBuffer> subscriber;
 
     public void failed(final Exception cause) {
-        exception = cause;
-        flushToSubscriber();
+        if (!completed) {
+            exception = cause;
+            flushToSubscriber();
+        }
     }
 
     @Override

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
@@ -206,4 +206,24 @@ public class TestReactiveDataConsumer {
             .blockingGet();
         Assert.assertSame(ex, result.getError());
     }
+
+    @Test
+    public void testFailAfterCompletion() {
+        // Calling consumer.failed() after consumer.streamEnd() must be a no-op.
+        // The exception must be discarded, and the subscriber must see that
+        // the stream was successfully completed.
+        final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
+
+        consumer.streamEnd(null);
+
+        final RuntimeException ex = new RuntimeException();
+        consumer.failed(ex);
+
+        final Notification<ByteBuffer> result = Flowable.fromPublisher(consumer)
+                .materialize()
+                .singleOrError()
+                .blockingGet();
+        Assert.assertFalse(result.isOnError());
+        Assert.assertTrue(result.isOnComplete());
+    }
 }


### PR DESCRIPTION
This change addresses a race condition I’ve observed when executing HTTP calls using a `ReactiveEntityProducer` and a `ReactiveResponseConsumer`. If not all dependencies have been set on the future owned by `InternalAbstractHttpAsyncClient` by the time `ReactiveResponseConsumer.streamEnd` is called, calling `ComplexFuture.setDependency` will throw an `InterruptedIOException` because the future has already been successfully completed. Eventually, `ReactiveDataConsumer.failed` will be called. As long as `ReactiveDataConsumer.flushToSubscriber` was not called between setting `completed = true` in `streamEnd` and setting `exception = cause` in `failed`, the next invocation of `flushToSubscriber` will throw an exception to the subscriber because error messages are published first. I’ve attached a thread dump to help explain: 
[threads_report.txt](https://github.com/apache/httpcomponents-core/files/5442119/threads_report.txt)

My proposed change causes `ReactiveDataConsumer.failed` to do nothing if the consumer has already been set as `complete` (i.e. by `ReactiveResponseConsumer.streamEnd`.) This change is consistent with Java’s CompletableFuture class, as well as the ComplexFuture and BasicFuture classes in the apache-httpcomponents library--in these classes, calling `failed` after the object has been marked `complete` is a no-op. It guards against the race condition I described by guaranteeing that calling `ReactiveDataConsumer.failed` after calling `ReactiveResponseConsumer.streamEnd` on the same object does nothing.

Is this the best change to make? I considered some other possible changes, such as not calling `dependency.cancel` in `ComplexFuture.setDependency` if the future has already completed successfully, but this one seemed to be the most straightforward.

Thanks! I can explain more if needed.
