### PR TITLE
Build and test on both AMD64 and ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ sudo: false
 services:
   - docker
 
+arch:
+  - amd64
+  - arm64-graviton2
+
 script: mvn verify -B -P docker
 
 jdk:


### PR DESCRIPTION
More and more software development is being done on ARM64 CPU architecture.
It would be good if HttpComponents Core is being regularly tested on ARM64.