### PR TITLE
Build on arm64 (second attempt)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,32 @@ sudo: false
 services:
   - docker
 
-arch:
-  - amd64
-  - arm64-graviton2
-
-script: mvn verify -B -P docker
-
 jdk:
   - oraclejdk8
   - openjdk11
   - oraclejdk11
   - openjdk-ea
 
-matrix:
-  allow_failures:
-    - jdk: openjdk-ea
+addons:
+  apt:
+    packages:
+      - maven
+
+install: skip
+script: mvn verify -B -P docker
 
 jobs:
   include:
-    - jdk: openjdk7
+    - name: amd64-jdk7
+      arch: amd64
+      jdk: openjdk7
       script: mvn verify -B
+    - name: arm64
+      arch: arm64
+      script: mvn verify -B
+  allow_failures:
+    - jdk: openjdk-ea
+          
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ sudo: false
 services:
   - docker
 
+arch:
+  - amd64
+  - arm64-graviton2
+
 script: mvn verify -B -P docker
 
 jdk:

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/frame/StreamIdGenerator.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/frame/StreamIdGenerator.java
@@ -28,7 +28,7 @@
 package org.apache.hc.core5.http2.frame;
 
 /**
- * HTTP/2 steam ID generator.
+ * HTTP/2 stream ID generator.
  *
  * @since 5.0
  */


### PR DESCRIPTION
Unfortunately https://github.com/apache/httpcomponents-core/pull/228 did not work.
`arm64-graviton2` is available only for travis-ci.com, while Apache uses travis-ci.org.

With this PR I'm changing it to use the old `arm64` instead of `arm64-graviton2`.

But there is a small problem - https://hub.docker.com/r/kennethreitz/httpbin/tags is amd64 only and HttpBinIT fails:
```
[ERROR] Errors: 

[ERROR]   HttpBinIT.executeHttpBin:51 » Execution java.net.ConnectException: Connection ...
```
So, the `arm64` job should be executed without `-P docker` profile.

I've also merged `jobs` and `matrix` elements - they are aliases.