### PR TITLE
Bug fix: Fixed ignoring maxResultLength in toString method of EntityUtils

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
@@ -165,19 +165,20 @@ public final class EntityUtils {
         }
     }
 
-    private static CharArrayBuffer toCharArrayBuffer(final InputStream inStream, final long contentLength,
+    private static CharArrayBuffer toCharArrayBuffer(final InputStream inStream, final int contentLength,
             final Charset charset, final int maxResultLength) throws IOException {
         Args.notNull(inStream, "InputStream");
         Args.positive(maxResultLength, "maxResultLength");
         final Charset actualCharset = charset == null ? DEFAULT_CHARSET : charset;
         final CharArrayBuffer buf = new CharArrayBuffer(
-                Math.min(maxResultLength, contentLength > 0 ? (int) contentLength : DEFAULT_CHAR_BUFFER_SIZE));
+                Math.min(maxResultLength, contentLength > 0 ? contentLength : DEFAULT_CHAR_BUFFER_SIZE));
         final Reader reader = new InputStreamReader(inStream, actualCharset);
         final char[] tmp = new char[DEFAULT_CHAR_BUFFER_SIZE];
         int chReadCount;
-        while ((chReadCount = reader.read(tmp)) != -1) {
+        while ((chReadCount = reader.read(tmp)) != -1 && buf.length() < maxResultLength) {
             buf.append(tmp, 0, chReadCount);
         }
+        buf.setLength(Math.min(buf.length(), maxResultLength));
         return buf;
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.net.URLEncodedUtils;
 import org.junit.Assert;
@@ -259,6 +260,24 @@ public class TestEntityUtils {
             for (int i = 0; i < expectedBytes.length; i++) {
                 Assert.assertEquals(expectedBytes[i], bytes[i]);
             }
+        }
+    }
+
+    @Test
+    public void testStringMaxResultLength() throws IOException, ParseException {
+        final String allMessage = "Message content";
+        final byte[] allBytes = allMessage.getBytes(StandardCharsets.ISO_8859_1);
+        final Map<Integer, String> testCases = new HashMap<>();
+        testCases.put(7, allMessage.substring(0, 7));
+        testCases.put(allMessage.length(), allMessage);
+        testCases.put(Integer.MAX_VALUE, allMessage);
+
+        for (final Map.Entry<Integer, String> tc : testCases.entrySet()) {
+            final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(allBytes), allBytes.length, null);
+            final String string = EntityUtils.toString(entity, StandardCharsets.ISO_8859_1, tc.getKey());
+            final String expectedString = tc.getValue();
+            Assert.assertNotNull(string);
+            Assert.assertEquals(expectedString, string);
         }
     }
 


### PR DESCRIPTION
Currently, the EntityUtils.toString method ignores the maxRequestLength parameter.