### PR TITLE
4.4.x use better map apis and more

### DIFF
--- a/httpcore-ab/src/test/java/org/apache/http/benchmark/HttpServer.java
+++ b/httpcore-ab/src/test/java/org/apache/http/benchmark/HttpServer.java
@@ -35,7 +35,6 @@ import java.net.Socket;
 
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpException;
-import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.HttpServerConnection;
 import org.apache.http.impl.DefaultBHttpServerConnection;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
@@ -65,12 +64,10 @@ public class HttpServer {
     public HttpServer() throws IOException {
         super();
         this.httpproc = new ImmutableHttpProcessor(
-                new HttpResponseInterceptor[] {
-                        new ResponseDate(),
-                        new ResponseServer("TEST-SERVER/1.1"),
-                        new ResponseContent(),
-                        new ResponseConnControl()
-                });
+                new ResponseDate(),
+                new ResponseServer("TEST-SERVER/1.1"),
+                new ResponseContent(),
+                new ResponseConnControl());
         this.reqistry = new UriHttpRequestHandlerMapper();
         this.serversocket = new ServerSocket(0);
     }

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/DefaultConnectingIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/DefaultConnectingIOReactor.java
@@ -284,7 +284,7 @@ public class DefaultConnectingIOReactor extends AbstractMultiworkerIOReactor
                                 @Override
                                 public Boolean run() throws IOException {
                                     return socketChannel.connect(targetAddress);
-                                };
+                                }
                             });
                 } catch (final PrivilegedActionException e) {
                     Asserts.check(e.getCause() instanceof  IOException,

--- a/httpcore-nio/src/main/java/org/apache/http/nio/NHttpConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/NHttpConnection.java
@@ -50,9 +50,9 @@ import org.apache.http.protocol.HttpContext;
  */
 public interface NHttpConnection extends HttpConnection, IOControl {
 
-    public static final int ACTIVE      = 0;
-    public static final int CLOSING     = 1;
-    public static final int CLOSED      = 2;
+    int ACTIVE      = 0;
+    int CLOSING     = 1;
+    int CLOSED      = 2;
 
     /**
      * Returns status of the connection:

--- a/httpcore-nio/src/main/java/org/apache/http/nio/params/NIOReactorPNames.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/params/NIOReactorPNames.java
@@ -44,7 +44,7 @@ public interface NIOReactorPNames {
      * This parameter expects a value of type {@link Integer}.
      * </p>
      */
-    public static final String CONTENT_BUFFER_SIZE = "http.nio.content-buffer-size";
+    String CONTENT_BUFFER_SIZE = "http.nio.content-buffer-size";
 
     /**
      * Determines the time interval in milliseconds at which the
@@ -53,7 +53,7 @@ public interface NIOReactorPNames {
      * This parameter expects a value of type {@link Long}.
      * </p>
      */
-    public static final String SELECT_INTERVAL = "http.nio.select-interval";
+    String SELECT_INTERVAL = "http.nio.select-interval";
 
     /**
      * Determines the grace period the I/O reactors are expected to block
@@ -62,7 +62,7 @@ public interface NIOReactorPNames {
      * This parameter expects a value of type {@link Long}.
      * </p>
      */
-    public static final String GRACE_PERIOD = "http.nio.grace-period";
+    String GRACE_PERIOD = "http.nio.grace-period";
 
     /**
      * Determines whether interestOps() queueing is enabled for the I/O reactors.
@@ -72,6 +72,6 @@ public interface NIOReactorPNames {
      *
      * @since 4.1
      */
-    public static final String INTEREST_OPS_QUEUEING = "http.nio.interest-ops-queueing";
+    String INTEREST_OPS_QUEUEING = "http.nio.interest-ops-queueing";
 
 }

--- a/httpcore-nio/src/main/java/org/apache/http/nio/reactor/EventMask.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/reactor/EventMask.java
@@ -39,16 +39,16 @@ public interface EventMask {
     /**
      * Interest in data input.
      */
-    public static final int READ = SelectionKey.OP_READ;
+    int READ = SelectionKey.OP_READ;
 
     /**
      * Interest in data output.
      */
-    public static final int WRITE = SelectionKey.OP_WRITE;
+    int WRITE = SelectionKey.OP_WRITE;
 
     /**
      * Interest in data input/output.
      */
-    public static final int READ_WRITE = READ | WRITE;
+    int READ_WRITE = READ | WRITE;
 
 }

--- a/httpcore-nio/src/main/java/org/apache/http/nio/reactor/IOEventDispatch.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/reactor/IOEventDispatch.java
@@ -42,7 +42,7 @@ public interface IOEventDispatch {
     /**
      * Attribute name of an object that represents a non-blocking connection.
      */
-    public static final String CONNECTION_KEY = "http.connection";
+    String CONNECTION_KEY = "http.connection";
 
     /**
      * Triggered after the given session has been just created.

--- a/httpcore-nio/src/main/java/org/apache/http/nio/reactor/IOSession.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/reactor/IOSession.java
@@ -52,11 +52,11 @@ public interface IOSession {
      * Name of the context attribute key, which can be used to obtain the
      * session attachment object.
      */
-    public static final String ATTACHMENT_KEY = "http.session.attachment";
+    String ATTACHMENT_KEY = "http.session.attachment";
 
-    public static final int ACTIVE       = 0;
-    public static final int CLOSING      = 1;
-    public static final int CLOSED       = Integer.MAX_VALUE;
+    int ACTIVE       = 0;
+    int CLOSING      = 1;
+    int CLOSED       = Integer.MAX_VALUE;
 
     /**
      * Returns the underlying I/O channel associated with this session.

--- a/httpcore-nio/src/test/java/org/apache/http/impl/nio/reactor/TestDefaultListeningIOReactor.java
+++ b/httpcore-nio/src/test/java/org/apache/http/impl/nio/reactor/TestDefaultListeningIOReactor.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.config.ConnectionConfig;
 import org.apache.http.impl.nio.DefaultHttpServerIODispatch;
 import org.apache.http.nio.protocol.HttpAsyncService;
@@ -59,12 +58,11 @@ import org.junit.Test;
 public class TestDefaultListeningIOReactor {
 
     private static IOEventDispatch createIOEventDispatch() {
-        final HttpProcessor httpproc = new ImmutableHttpProcessor(new HttpResponseInterceptor[] {
+        final HttpProcessor httpproc = new ImmutableHttpProcessor(
                 new ResponseDate(),
                 new ResponseServer(),
                 new ResponseContent(),
-                new ResponseConnControl()
-        });
+                new ResponseConnControl());
         final HttpAsyncService serviceHandler = new HttpAsyncService(httpproc,
                 new UriHttpAsyncRequestHandlerMapper());
         return new DefaultHttpServerIODispatch(serviceHandler, ConnectionConfig.DEFAULT);

--- a/httpcore/src/main/java-deprecated/org/apache/http/impl/SocketHttpClientConnection.java
+++ b/httpcore/src/main/java-deprecated/org/apache/http/impl/SocketHttpClientConnection.java
@@ -212,7 +212,7 @@ public class SocketHttpClientConnection
             try {
                 return this.socket.getSoTimeout();
             } catch (final SocketException ignore) {
-                return -1;
+                // ignore
             }
         }
         return -1;

--- a/httpcore/src/main/java-deprecated/org/apache/http/impl/SocketHttpServerConnection.java
+++ b/httpcore/src/main/java-deprecated/org/apache/http/impl/SocketHttpServerConnection.java
@@ -204,7 +204,7 @@ public class SocketHttpServerConnection extends
             try {
                 return this.socket.getSoTimeout();
             } catch (final SocketException ignore) {
-                return -1;
+                // ignore
             }
         }
         return -1;

--- a/httpcore/src/main/java-deprecated/org/apache/http/protocol/BasicHttpProcessor.java
+++ b/httpcore/src/main/java-deprecated/org/apache/http/protocol/BasicHttpProcessor.java
@@ -105,11 +105,11 @@ public final class BasicHttpProcessor implements
         }
     }
 
-    public final void addInterceptor(final HttpRequestInterceptor interceptor) {
+    public void addInterceptor(final HttpRequestInterceptor interceptor) {
         addRequestInterceptor(interceptor);
     }
 
-     public final void addInterceptor(final HttpRequestInterceptor interceptor, final int index) {
+     public void addInterceptor(final HttpRequestInterceptor interceptor, final int index) {
         addRequestInterceptor(interceptor, index);
     }
 
@@ -139,11 +139,11 @@ public final class BasicHttpProcessor implements
         this.responseInterceptors.add(itcp);
     }
 
-    public final void addInterceptor(final HttpResponseInterceptor interceptor) {
+    public void addInterceptor(final HttpResponseInterceptor interceptor) {
         addResponseInterceptor(interceptor);
     }
 
-    public final void addInterceptor(final HttpResponseInterceptor interceptor, final int index) {
+    public void addInterceptor(final HttpResponseInterceptor interceptor, final int index) {
         addResponseInterceptor(interceptor, index);
     }
 

--- a/httpcore/src/main/java-deprecated/org/apache/http/protocol/ExecutionContext.java
+++ b/httpcore/src/main/java-deprecated/org/apache/http/protocol/ExecutionContext.java
@@ -41,25 +41,25 @@ public interface ExecutionContext {
      * Attribute name of a {@link org.apache.http.HttpConnection} object that
      * represents the actual HTTP connection.
      */
-    public static final String HTTP_CONNECTION  = "http.connection";
+    String HTTP_CONNECTION  = "http.connection";
 
     /**
      * Attribute name of a {@link org.apache.http.HttpRequest} object that
      * represents the actual HTTP request.
      */
-    public static final String HTTP_REQUEST     = "http.request";
+    String HTTP_REQUEST     = "http.request";
 
     /**
      * Attribute name of a {@link org.apache.http.HttpResponse} object that
      * represents the actual HTTP response.
      */
-    public static final String HTTP_RESPONSE    = "http.response";
+    String HTTP_RESPONSE    = "http.response";
 
     /**
      * Attribute name of a {@link org.apache.http.HttpHost} object that
      * represents the connection target.
      */
-    public static final String HTTP_TARGET_HOST = "http.target_host";
+    String HTTP_TARGET_HOST = "http.target_host";
 
     /**
      * Attribute name of a {@link org.apache.http.HttpHost} object that
@@ -67,14 +67,13 @@ public interface ExecutionContext {
      *
      * @deprecated (4.3) do not use.
      */
-    @Deprecated
-    public static final String HTTP_PROXY_HOST  = "http.proxy_host";
+    @Deprecated String HTTP_PROXY_HOST  = "http.proxy_host";
 
     /**
      * Attribute name of a {@link Boolean} object that represents the
      * the flag indicating whether the actual request has been fully transmitted
      * to the target host.
      */
-    public static final String HTTP_REQ_SENT    = "http.request_sent";
+    String HTTP_REQ_SENT    = "http.request_sent";
 
 }

--- a/httpcore/src/main/java/org/apache/http/ExceptionLogger.java
+++ b/httpcore/src/main/java/org/apache/http/ExceptionLogger.java
@@ -31,7 +31,7 @@ package org.apache.http;
  */
 public interface ExceptionLogger {
 
-    public static final ExceptionLogger NO_OP = new ExceptionLogger() {
+    ExceptionLogger NO_OP = new ExceptionLogger() {
 
         @Override
         public void log(final Exception ex) {
@@ -40,7 +40,7 @@ public interface ExceptionLogger {
 
     };
 
-    public static final ExceptionLogger STD_ERR = new ExceptionLogger() {
+    ExceptionLogger STD_ERR = new ExceptionLogger() {
 
         @Override
         public void log(final Exception ex) {

--- a/httpcore/src/main/java/org/apache/http/HttpStatus.java
+++ b/httpcore/src/main/java/org/apache/http/HttpStatus.java
@@ -43,90 +43,90 @@ public interface HttpStatus {
     // --- 1xx Informational ---
 
     /** {@code 100 Continue} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_CONTINUE = 100;
+    int SC_CONTINUE = 100;
     /** {@code 101 Switching Protocols} (HTTP/1.1 - RFC 2616)*/
-    public static final int SC_SWITCHING_PROTOCOLS = 101;
+    int SC_SWITCHING_PROTOCOLS = 101;
     /** {@code 102 Processing} (WebDAV - RFC 2518) */
-    public static final int SC_PROCESSING = 102;
+    int SC_PROCESSING = 102;
 
     // --- 2xx Success ---
 
     /** {@code 200 OK} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_OK = 200;
+    int SC_OK = 200;
     /** {@code 201 Created} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_CREATED = 201;
+    int SC_CREATED = 201;
     /** {@code 202 Accepted} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_ACCEPTED = 202;
+    int SC_ACCEPTED = 202;
     /** {@code 203 Non Authoritative Information} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_NON_AUTHORITATIVE_INFORMATION = 203;
+    int SC_NON_AUTHORITATIVE_INFORMATION = 203;
     /** {@code 204 No Content} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_NO_CONTENT = 204;
+    int SC_NO_CONTENT = 204;
     /** {@code 205 Reset Content} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_RESET_CONTENT = 205;
+    int SC_RESET_CONTENT = 205;
     /** {@code 206 Partial Content} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_PARTIAL_CONTENT = 206;
+    int SC_PARTIAL_CONTENT = 206;
     /**
      * {@code 207 Multi-Status} (WebDAV - RFC 2518)
      * or
      * {@code 207 Partial Update OK} (HTTP/1.1 - draft-ietf-http-v11-spec-rev-01?)
      */
-    public static final int SC_MULTI_STATUS = 207;
+    int SC_MULTI_STATUS = 207;
 
     // --- 3xx Redirection ---
 
     /** {@code 300 Mutliple Choices} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_MULTIPLE_CHOICES = 300;
+    int SC_MULTIPLE_CHOICES = 300;
     /** {@code 301 Moved Permanently} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_MOVED_PERMANENTLY = 301;
+    int SC_MOVED_PERMANENTLY = 301;
     /** {@code 302 Moved Temporarily} (Sometimes {@code Found}) (HTTP/1.0 - RFC 1945) */
-    public static final int SC_MOVED_TEMPORARILY = 302;
+    int SC_MOVED_TEMPORARILY = 302;
     /** {@code 303 See Other} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_SEE_OTHER = 303;
+    int SC_SEE_OTHER = 303;
     /** {@code 304 Not Modified} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_NOT_MODIFIED = 304;
+    int SC_NOT_MODIFIED = 304;
     /** {@code 305 Use Proxy} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_USE_PROXY = 305;
+    int SC_USE_PROXY = 305;
     /** {@code 307 Temporary Redirect} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_TEMPORARY_REDIRECT = 307;
+    int SC_TEMPORARY_REDIRECT = 307;
 
     // --- 4xx Client Error ---
 
     /** {@code 400 Bad Request} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_BAD_REQUEST = 400;
+    int SC_BAD_REQUEST = 400;
     /** {@code 401 Unauthorized} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_UNAUTHORIZED = 401;
+    int SC_UNAUTHORIZED = 401;
     /** {@code 402 Payment Required} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_PAYMENT_REQUIRED = 402;
+    int SC_PAYMENT_REQUIRED = 402;
     /** {@code 403 Forbidden} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_FORBIDDEN = 403;
+    int SC_FORBIDDEN = 403;
     /** {@code 404 Not Found} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_NOT_FOUND = 404;
+    int SC_NOT_FOUND = 404;
     /** {@code 405 Method Not Allowed} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_METHOD_NOT_ALLOWED = 405;
+    int SC_METHOD_NOT_ALLOWED = 405;
     /** {@code 406 Not Acceptable} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_NOT_ACCEPTABLE = 406;
+    int SC_NOT_ACCEPTABLE = 406;
     /** {@code 407 Proxy Authentication Required} (HTTP/1.1 - RFC 2616)*/
-    public static final int SC_PROXY_AUTHENTICATION_REQUIRED = 407;
+    int SC_PROXY_AUTHENTICATION_REQUIRED = 407;
     /** {@code 408 Request Timeout} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_REQUEST_TIMEOUT = 408;
+    int SC_REQUEST_TIMEOUT = 408;
     /** {@code 409 Conflict} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_CONFLICT = 409;
+    int SC_CONFLICT = 409;
     /** {@code 410 Gone} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_GONE = 410;
+    int SC_GONE = 410;
     /** {@code 411 Length Required} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_LENGTH_REQUIRED = 411;
+    int SC_LENGTH_REQUIRED = 411;
     /** {@code 412 Precondition Failed} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_PRECONDITION_FAILED = 412;
+    int SC_PRECONDITION_FAILED = 412;
     /** {@code 413 Request Entity Too Large} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_REQUEST_TOO_LONG = 413;
+    int SC_REQUEST_TOO_LONG = 413;
     /** {@code 414 Request-URI Too Long} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_REQUEST_URI_TOO_LONG = 414;
+    int SC_REQUEST_URI_TOO_LONG = 414;
     /** {@code 415 Unsupported Media Type} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_UNSUPPORTED_MEDIA_TYPE = 415;
+    int SC_UNSUPPORTED_MEDIA_TYPE = 415;
     /** {@code 416 Requested Range Not Satisfiable} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    int SC_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
     /** {@code 417 Expectation Failed} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_EXPECTATION_FAILED = 417;
+    int SC_EXPECTATION_FAILED = 417;
 
     /**
      * Static constant for a 418 error.
@@ -143,36 +143,36 @@ public interface HttpStatus {
      * or {@code 419 Proxy Reauthentication Required}
      * (HTTP/1.1 drafts?)
      */
-    public static final int SC_INSUFFICIENT_SPACE_ON_RESOURCE = 419;
+    int SC_INSUFFICIENT_SPACE_ON_RESOURCE = 419;
     /**
      * Static constant for a 420 error.
      * {@code 420 Method Failure}
      * (WebDAV - draft-ietf-webdav-protocol-05?)
      */
-    public static final int SC_METHOD_FAILURE = 420;
+    int SC_METHOD_FAILURE = 420;
     /** {@code 422 Unprocessable Entity} (WebDAV - RFC 2518) */
-    public static final int SC_UNPROCESSABLE_ENTITY = 422;
+    int SC_UNPROCESSABLE_ENTITY = 422;
     /** {@code 423 Locked} (WebDAV - RFC 2518) */
-    public static final int SC_LOCKED = 423;
+    int SC_LOCKED = 423;
     /** {@code 424 Failed Dependency} (WebDAV - RFC 2518) */
-    public static final int SC_FAILED_DEPENDENCY = 424;
+    int SC_FAILED_DEPENDENCY = 424;
 
     // --- 5xx Server Error ---
 
     /** {@code 500 Server Error} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_INTERNAL_SERVER_ERROR = 500;
+    int SC_INTERNAL_SERVER_ERROR = 500;
     /** {@code 501 Not Implemented} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_NOT_IMPLEMENTED = 501;
+    int SC_NOT_IMPLEMENTED = 501;
     /** {@code 502 Bad Gateway} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_BAD_GATEWAY = 502;
+    int SC_BAD_GATEWAY = 502;
     /** {@code 503 Service Unavailable} (HTTP/1.0 - RFC 1945) */
-    public static final int SC_SERVICE_UNAVAILABLE = 503;
+    int SC_SERVICE_UNAVAILABLE = 503;
     /** {@code 504 Gateway Timeout} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_GATEWAY_TIMEOUT = 504;
+    int SC_GATEWAY_TIMEOUT = 504;
     /** {@code 505 HTTP Version Not Supported} (HTTP/1.1 - RFC 2616) */
-    public static final int SC_HTTP_VERSION_NOT_SUPPORTED = 505;
+    int SC_HTTP_VERSION_NOT_SUPPORTED = 505;
 
     /** {@code 507 Insufficient Storage} (WebDAV - RFC 2518) */
-    public static final int SC_INSUFFICIENT_STORAGE = 507;
+    int SC_INSUFFICIENT_STORAGE = 507;
 
 }

--- a/httpcore/src/main/java/org/apache/http/entity/ContentLengthStrategy.java
+++ b/httpcore/src/main/java/org/apache/http/entity/ContentLengthStrategy.java
@@ -38,8 +38,8 @@ import org.apache.http.HttpMessage;
  */
 public interface ContentLengthStrategy {
 
-    public static final int IDENTITY         = -1;
-    public static final int CHUNKED          = -2;
+    int IDENTITY         = -1;
+    int CHUNKED          = -2;
 
     /**
      * Returns length of the given message in bytes. The returned value

--- a/httpcore/src/main/java/org/apache/http/entity/ContentType.java
+++ b/httpcore/src/main/java/org/apache/http/entity/ContentType.java
@@ -370,7 +370,7 @@ public final class ContentType implements Serializable {
                     return create(elements[0], false);
                 }
             } catch (final ParseException ex) {
-                return null;
+                // ignore
             }
         }
         return null;

--- a/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
+++ b/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
@@ -289,7 +289,7 @@ public class BHttpConnectionBase implements HttpInetConnection {
             try {
                 return socket.getSoTimeout();
             } catch (final SocketException ignore) {
-                return -1;
+                // ignore
             }
         }
         return -1;

--- a/httpcore/src/main/java/org/apache/http/params/CoreConnectionPNames.java
+++ b/httpcore/src/main/java/org/apache/http/params/CoreConnectionPNames.java
@@ -48,7 +48,7 @@ public interface CoreConnectionPNames {
      * </p>
      * @see java.net.SocketOptions#SO_TIMEOUT
      */
-    public static final String SO_TIMEOUT = "http.socket.timeout";
+    String SO_TIMEOUT = "http.socket.timeout";
 
     /**
      * Determines whether Nagle's algorithm is to be used. The Nagle's algorithm
@@ -62,7 +62,7 @@ public interface CoreConnectionPNames {
      * </p>
      * @see java.net.SocketOptions#TCP_NODELAY
      */
-    public static final String TCP_NODELAY = "http.tcp.nodelay";
+    String TCP_NODELAY = "http.tcp.nodelay";
 
     /**
      * Determines the size of the internal socket buffer used to buffer data
@@ -71,7 +71,7 @@ public interface CoreConnectionPNames {
      * This parameter expects a value of type {@link Integer}.
      * </p>
      */
-    public static final String SOCKET_BUFFER_SIZE = "http.socket.buffer-size";
+    String SOCKET_BUFFER_SIZE = "http.socket.buffer-size";
 
     /**
      * Sets SO_LINGER with the specified linger time in seconds. The maximum
@@ -83,7 +83,7 @@ public interface CoreConnectionPNames {
      * </p>
      * @see java.net.SocketOptions#SO_LINGER
      */
-    public static final String SO_LINGER = "http.socket.linger";
+    String SO_LINGER = "http.socket.linger";
 
     /**
      * Defines whether the socket can be bound even though a previous connection is
@@ -95,7 +95,7 @@ public interface CoreConnectionPNames {
      *
      * @since 4.1
      */
-    public static final String SO_REUSEADDR = "http.socket.reuseaddr";
+    String SO_REUSEADDR = "http.socket.reuseaddr";
 
     /**
      * Determines the timeout in milliseconds until a connection is established.
@@ -107,7 +107,7 @@ public interface CoreConnectionPNames {
      * This parameter expects a value of type {@link Integer}.
      * </p>
      */
-    public static final String CONNECTION_TIMEOUT = "http.connection.timeout";
+    String CONNECTION_TIMEOUT = "http.connection.timeout";
 
     /**
      * Determines whether stale connection check is to be used. The stale
@@ -118,7 +118,7 @@ public interface CoreConnectionPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String STALE_CONNECTION_CHECK = "http.connection.stalecheck";
+    String STALE_CONNECTION_CHECK = "http.connection.stalecheck";
 
     /**
      * Determines the maximum line length limit. If set to a positive value,
@@ -128,7 +128,7 @@ public interface CoreConnectionPNames {
      * This parameter expects a value of type {@link Integer}.
      * </p>
      */
-    public static final String MAX_LINE_LENGTH = "http.connection.max-line-length";
+    String MAX_LINE_LENGTH = "http.connection.max-line-length";
 
     /**
      * Determines the maximum HTTP header count allowed. If set to a positive
@@ -139,7 +139,7 @@ public interface CoreConnectionPNames {
      * This parameter expects a value of type {@link Integer}.
      * </p>
      */
-    public static final String MAX_HEADER_COUNT = "http.connection.max-header-count";
+    String MAX_HEADER_COUNT = "http.connection.max-header-count";
 
     /**
      * Defines the size limit below which data chunks should be buffered in a session I/O buffer
@@ -152,7 +152,7 @@ public interface CoreConnectionPNames {
      *
      * @since 4.1
      */
-    public static final String MIN_CHUNK_LIMIT = "http.connection.min-chunk-limit";
+    String MIN_CHUNK_LIMIT = "http.connection.min-chunk-limit";
 
 
     /**
@@ -165,6 +165,6 @@ public interface CoreConnectionPNames {
      * @see java.net.SocketOptions#SO_KEEPALIVE
      * @since 4.2
      */
-    public static final String SO_KEEPALIVE = "http.socket.keepalive";
+    String SO_KEEPALIVE = "http.socket.keepalive";
 
 }

--- a/httpcore/src/main/java/org/apache/http/params/CoreProtocolPNames.java
+++ b/httpcore/src/main/java/org/apache/http/params/CoreProtocolPNames.java
@@ -44,7 +44,7 @@ public interface CoreProtocolPNames {
      * This parameter expects a value of type {@link org.apache.http.ProtocolVersion}.
      * </p>
      */
-    public static final String PROTOCOL_VERSION = "http.protocol.version";
+    String PROTOCOL_VERSION = "http.protocol.version";
 
     /**
      * Defines the charset to be used for encoding HTTP protocol elements.
@@ -52,7 +52,7 @@ public interface CoreProtocolPNames {
      * This parameter expects a value of type {@link String}.
      * </p>
      */
-    public static final String HTTP_ELEMENT_CHARSET = "http.protocol.element-charset";
+    String HTTP_ELEMENT_CHARSET = "http.protocol.element-charset";
 
     /**
      * Defines the charset to be used per default for encoding content body.
@@ -60,7 +60,7 @@ public interface CoreProtocolPNames {
      * This parameter expects a value of type {@link String}.
      * </p>
      */
-    public static final String HTTP_CONTENT_CHARSET = "http.protocol.content-charset";
+    String HTTP_CONTENT_CHARSET = "http.protocol.content-charset";
 
     /**
      * Defines the content of the {@code User-Agent} header.
@@ -68,7 +68,7 @@ public interface CoreProtocolPNames {
      * This parameter expects a value of type {@link String}.
      * </p>
      */
-    public static final String USER_AGENT = "http.useragent";
+    String USER_AGENT = "http.useragent";
 
     /**
      * Defines the content of the {@code Server} header.
@@ -76,7 +76,7 @@ public interface CoreProtocolPNames {
      * This parameter expects a value of type {@link String}.
      * </p>
      */
-    public static final String ORIGIN_SERVER = "http.origin-server";
+    String ORIGIN_SERVER = "http.origin-server";
 
     /**
      * Defines whether responses with an invalid {@code Transfer-Encoding}
@@ -85,7 +85,7 @@ public interface CoreProtocolPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String STRICT_TRANSFER_ENCODING = "http.protocol.strict-transfer-encoding";
+    String STRICT_TRANSFER_ENCODING = "http.protocol.strict-transfer-encoding";
 
     /**
      * <p>
@@ -112,7 +112,7 @@ public interface CoreProtocolPNames {
      *
      * This parameter expects a value of type {@link Boolean}.
      */
-    public static final String USE_EXPECT_CONTINUE = "http.protocol.expect-continue";
+    String USE_EXPECT_CONTINUE = "http.protocol.expect-continue";
 
     /**
      * <p>
@@ -122,7 +122,7 @@ public interface CoreProtocolPNames {
      *
      * This parameter expects a value of type {@link Integer}.
      */
-    public static final String WAIT_FOR_CONTINUE = "http.protocol.wait-for-continue";
+    String WAIT_FOR_CONTINUE = "http.protocol.wait-for-continue";
 
     /**
      * <p>
@@ -134,7 +134,7 @@ public interface CoreProtocolPNames {
      *
      * @since 4.2
      */
-    public static final String HTTP_MALFORMED_INPUT_ACTION = "http.malformed.input.action";
+    String HTTP_MALFORMED_INPUT_ACTION = "http.malformed.input.action";
 
     /**
      * <p>
@@ -147,6 +147,6 @@ public interface CoreProtocolPNames {
      *
      * @since 4.2
      */
-    public static final String HTTP_UNMAPPABLE_INPUT_ACTION = "http.unmappable.input.action";
+    String HTTP_UNMAPPABLE_INPUT_ACTION = "http.unmappable.input.action";
 
 }

--- a/httpcore/src/main/java/org/apache/http/protocol/HttpContext.java
+++ b/httpcore/src/main/java/org/apache/http/protocol/HttpContext.java
@@ -48,7 +48,7 @@ package org.apache.http.protocol;
 public interface HttpContext {
 
     /** The prefix reserved for use by HTTP components. "http." */
-    public static final String RESERVED_PREFIX  = "http.";
+    String RESERVED_PREFIX  = "http.";
 
     /**
      * Obtains attribute with the given name.

--- a/httpcore/src/main/java/org/apache/http/ssl/SSLContextBuilder.java
+++ b/httpcore/src/main/java/org/apache/http/ssl/SSLContextBuilder.java
@@ -46,6 +46,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -232,9 +233,7 @@ public class SSLContextBuilder {
                     }
                 }
             }
-            for (final TrustManager tm : tms) {
-                this.trustManagers.add(tm);
-            }
+            Collections.addAll(this.trustManagers, tms);
         }
         return this;
     }
@@ -310,9 +309,7 @@ public class SSLContextBuilder {
                     }
                 }
             }
-            for (final KeyManager km : kms) {
-                keyManagers.add(km);
-            }
+            Collections.addAll(keyManagers, kms);
         }
         return this;
     }

--- a/httpcore/src/test/java/org/apache/http/integration/TestSyncHttp.java
+++ b/httpcore/src/test/java/org/apache/http/integration/TestSyncHttp.java
@@ -845,11 +845,10 @@ public class TestSyncHttp {
             post.setEntity(null);
 
             this.client = new HttpClient(new ImmutableHttpProcessor(
-                    new HttpRequestInterceptor[] {
-                            new RequestTargetHost(),
-                            new RequestConnControl(),
-                            new RequestUserAgent(),
-                            new RequestExpectContinue(true) }));
+                    new RequestTargetHost(),
+                    new RequestConnControl(),
+                    new RequestUserAgent(),
+                    new RequestExpectContinue(true)));
 
             final HttpResponse response = this.client.execute(post, host, conn);
             Assert.assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
@@ -898,21 +897,16 @@ public class TestSyncHttp {
             post.setEntity(null);
 
             this.client = new HttpClient(new ImmutableHttpProcessor(
-                    new HttpRequestInterceptor[] {
-                            new HttpRequestInterceptor() {
+                    new HttpRequestInterceptor() {
 
-                                @Override
-                                public void process(
-                                        final HttpRequest request,
-                                        final HttpContext context) throws HttpException, IOException {
-                                    request.addHeader(HTTP.TRANSFER_ENCODING, "identity");
-                                }
+                        @Override
+                        public void process(
+                                final HttpRequest request,
+                                final HttpContext context) throws HttpException, IOException {
+                            request.addHeader(HTTP.TRANSFER_ENCODING, "identity");
+                        }
 
-                            },
-                            new RequestTargetHost(),
-                            new RequestConnControl(),
-                            new RequestUserAgent(),
-                            new RequestExpectContinue(true) }));
+                    }, new RequestTargetHost(), new RequestConnControl(), new RequestUserAgent(), new RequestExpectContinue(true)));
 
             final HttpResponse response = this.client.execute(post, host, conn);
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());

--- a/httpcore/src/test/java/org/apache/http/pool/TestConnPool.java
+++ b/httpcore/src/test/java/org/apache/http/pool/TestConnPool.java
@@ -43,7 +43,7 @@ public class TestConnPool {
 
     private static final int GRACE_PERIOD = 10000;
 
-    static interface LocalConnFactory extends ConnFactory<String, HttpConnection> {
+    interface LocalConnFactory extends ConnFactory<String, HttpConnection> {
     }
 
     static class LocalPoolEntry extends PoolEntry<String, HttpConnection> {

--- a/httpcore/src/test/java/org/apache/http/ssl/TestSSLContextBuilder.java
+++ b/httpcore/src/test/java/org/apache/http/ssl/TestSSLContextBuilder.java
@@ -562,7 +562,7 @@ public class TestSSLContextBuilder {
         final PrivateKeyStrategy privateKeyStrategy = new PrivateKeyStrategy() {
             @Override
             public String chooseAlias(final Map<String, PrivateKeyDetails> aliases, final Socket socket) {
-                return aliases.keySet().contains("client2") ? "client2" : null;
+                return aliases.containsKey("client2") ? "client2" : null;
             }
         };
 


### PR DESCRIPTION
Each commit in this PR comprise one kind of cleanup/change:

- Make better use of Map APIs.
- Remove redundant modifiers.
- Use Collections.addAll() API instead of loops.
- Remove redundant returns.
- No need to explicitly declare an array when calling a vararg method.
- Remote extra semicolons (;).