### PR TITLE
Add HttpStatus.SC_TOO_MANY_REQUESTS 429 Too Many Requests

### DIFF
--- a/httpcore/src/main/java/org/apache/http/HttpStatus.java
+++ b/httpcore/src/main/java/org/apache/http/HttpStatus.java
@@ -156,6 +156,8 @@ public interface HttpStatus {
     int SC_LOCKED = 423;
     /** {@code 424 Failed Dependency} (WebDAV - RFC 2518) */
     int SC_FAILED_DEPENDENCY = 424;
+    /** {@code 429 Too Many Requests} (Additional HTTP Status Codes - RFC 6585) */
+    int SC_TOO_MANY_REQUESTS = 429;
 
     // --- 5xx Server Error ---
 

--- a/httpcore/src/main/java/org/apache/http/impl/EnglishReasonPhraseCatalog.java
+++ b/httpcore/src/main/java/org/apache/http/impl/EnglishReasonPhraseCatalog.java
@@ -93,7 +93,7 @@ public class EnglishReasonPhraseCatalog implements ReasonPhraseCatalog {
         new String[3],  // 1xx
         new String[8],  // 2xx
         new String[8],  // 3xx
-        new String[25], // 4xx
+        new String[30], // 4xx
         new String[8]   // 5xx
     };
 
@@ -140,6 +140,8 @@ public class EnglishReasonPhraseCatalog implements ReasonPhraseCatalog {
                   "Forbidden");
         setReason(HttpStatus.SC_NOT_FOUND,
                   "Not Found");
+        setReason(HttpStatus.SC_TOO_MANY_REQUESTS,
+                "Too Many Requests");
         setReason(HttpStatus.SC_INTERNAL_SERVER_ERROR,
                   "Internal Server Error");
         setReason(HttpStatus.SC_NOT_IMPLEMENTED,

--- a/httpcore/src/main/java/org/apache/http/impl/EnglishReasonPhraseCatalog.java
+++ b/httpcore/src/main/java/org/apache/http/impl/EnglishReasonPhraseCatalog.java
@@ -141,7 +141,7 @@ public class EnglishReasonPhraseCatalog implements ReasonPhraseCatalog {
         setReason(HttpStatus.SC_NOT_FOUND,
                   "Not Found");
         setReason(HttpStatus.SC_TOO_MANY_REQUESTS,
-                "Too Many Requests");
+                  "Too Many Requests");
         setReason(HttpStatus.SC_INTERNAL_SERVER_ERROR,
                   "Internal Server Error");
         setReason(HttpStatus.SC_NOT_IMPLEMENTED,


### PR DESCRIPTION
Hi guys!
The 4.x version of the project doesn't provide `429 Too Many Requests` status by `org.apache.http.HttpStatus`.

This is a little PR to extend it. Because we prefer use HTTP Statuses via this library.