### PR TITLE
Add appendPath and appendPathSegments methods to URIBuilder

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -505,9 +505,7 @@ public class URIBuilder {
      * @return this.
      */
     public URIBuilder appendPath(final String path) {
-        final List<String> segments = new ArrayList<>(getPathSegments());
-        segments.addAll(path != null ? splitPath(path) : new ArrayList<String>());
-        setPathSegments(segments);
+        appendPathSegments(path != null ? splitPath(path) : new ArrayList<String>());
         return this;
     }
 
@@ -530,10 +528,7 @@ public class URIBuilder {
      * @return this.
      */
     public URIBuilder appendPathSegments(final String... pathSegments) {
-        final List<String> segments = new ArrayList<>(getPathSegments());
-        segments.addAll(pathSegments.length > 0 ? Arrays.asList(pathSegments) : new ArrayList<String>());
-        setPathSegments(segments);
-        return this;
+        return appendPathSegments(Arrays.asList(pathSegments));
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -507,7 +507,7 @@ public class URIBuilder {
     public URIBuilder appendPath(final String path) {
         final List<String> segments = new ArrayList<>(getPathSegments());
         segments.addAll(path != null ? splitPath(path) : new ArrayList<String>());
-        setPathSegments( segments );
+        setPathSegments(segments);
         return this;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -500,6 +500,18 @@ public class URIBuilder {
     }
 
     /**
+     * Appends path to URI. The value is expected to be unescaped and may contain non ASCII characters.
+     *
+     * @return this.
+     */
+    public URIBuilder appendPath(final String path) {
+        final List<String> segments = new ArrayList<>(getPathSegments());
+        segments.addAll(path != null ? splitPath(path) : new ArrayList<String>());
+        setPathSegments( segments );
+        return this;
+    }
+
+    /**
      * Sets URI path. The value is expected to be unescaped and may contain non ASCII characters.
      *
      * @return this.

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -525,6 +525,18 @@ public class URIBuilder {
     }
 
     /**
+     * Appends segments URI path. The value is expected to be unescaped and may contain non ASCII characters.
+     *
+     * @return this.
+     */
+    public URIBuilder appendPathSegments(final String... pathSegments) {
+        final List<String> segments = new ArrayList<>(getPathSegments());
+        segments.addAll(pathSegments.length > 0 ? Arrays.asList(pathSegments) : new ArrayList<String>());
+        setPathSegments(segments);
+        return this;
+    }
+
+    /**
      * Sets rootless URI path (the first segment does not start with a /).
      * The value is expected to be unescaped and may contain non ASCII characters.
      *
@@ -550,6 +562,18 @@ public class URIBuilder {
         this.encodedSchemeSpecificPart = null;
         this.encodedPath = null;
         this.pathRootless = false;
+        return this;
+    }
+
+    /**
+     * Appends segments to URI path. The value is expected to be unescaped and may contain non ASCII characters.
+     *
+     * @return this.
+     */
+    public URIBuilder appendPathSegments(final List<String> pathSegments) {
+        final List<String> segments = new ArrayList<>(getPathSegments());
+        segments.addAll(pathSegments != null & pathSegments.size() > 0 ? pathSegments : new ArrayList<String>());
+        setPathSegments(segments);
         return this;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -505,7 +505,9 @@ public class URIBuilder {
      * @return this.
      */
     public URIBuilder appendPath(final String path) {
-        appendPathSegments(path != null ? splitPath(path) : new ArrayList<String>());
+        if (path != null) {
+            appendPathSegments(splitPath(path));
+        }
         return this;
     }
 
@@ -566,9 +568,11 @@ public class URIBuilder {
      * @return this.
      */
     public URIBuilder appendPathSegments(final List<String> pathSegments) {
-        final List<String> segments = new ArrayList<>(getPathSegments());
-        segments.addAll(pathSegments != null & pathSegments.size() > 0 ? pathSegments : new ArrayList<String>());
-        setPathSegments(segments);
+        if (pathSegments != null & pathSegments.size() > 0) {
+            final List<String> segments = new ArrayList<>(getPathSegments());
+            segments.addAll(pathSegments);
+            setPathSegments(segments);
+        }
         return this;
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -547,10 +547,10 @@ public class TestURIBuilder {
     @Test
     public void testAppendToExistingPath() throws Exception {
         final URI uri = new URIBuilder()
-            .setScheme( "https" )
-            .setHost( "somehost" )
-            .setPath( "api" )
-            .appendPath( "v1/resources" )
+            .setScheme("https")
+            .setHost("somehost")
+            .setPath("api")
+            .appendPath("v1/resources")
             .build();
         MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api/v1/resources")));
     }
@@ -558,9 +558,9 @@ public class TestURIBuilder {
     @Test
     public void testAppendToNonExistingPath() throws Exception {
         final URI uri = new URIBuilder()
-            .setScheme( "https" )
-            .setHost( "somehost" )
-            .appendPath( "api/v2/customers" )
+            .setScheme("https")
+            .setHost("somehost")
+            .appendPath("api/v2/customers")
             .build();
         MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api/v2/customers")));
     }
@@ -568,10 +568,10 @@ public class TestURIBuilder {
     @Test
     public void testAppendNullToExistingPath() throws Exception {
         final URI uri = new URIBuilder()
-            .setScheme( "https" )
-            .setHost( "somehost" )
-            .setPath( "api" )
-            .appendPath( null )
+            .setScheme("https")
+            .setHost("somehost")
+            .setPath("api")
+            .appendPath(null)
             .build();
         MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api")));
     }
@@ -579,9 +579,9 @@ public class TestURIBuilder {
     @Test
     public void testAppendNullToNonExistingPath() throws Exception {
         final URI uri = new URIBuilder()
-            .setScheme( "https" )
-            .setHost( "somehost" )
-            .appendPath( null )
+            .setScheme("https")
+            .setHost("somehost")
+            .appendPath(null)
             .build();
         MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost")));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -587,6 +587,48 @@ public class TestURIBuilder {
     }
 
     @Test
+    public void testAppendSegmentsToExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme("https")
+            .setHost("myhost")
+            .setPath("api")
+            .appendPathSegments("v3", "products")
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://myhost/api/v3/products")));
+    }
+
+    @Test
+    public void testAppendSegmentsToNonExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme("https")
+            .setHost("somehost")
+            .appendPathSegments("api", "v2", "customers")
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api/v2/customers")));
+    }
+
+    @Test
+    public void testAppendSegmentsListToExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme("http")
+            .setHost("myhost")
+            .setPath("api")
+            .appendPathSegments(Arrays.asList("v3", "products"))
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("http://myhost/api/v3/products")));
+    }
+
+    @Test
+    public void testAppendSegmentsListToNonExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme("http")
+            .setHost("myhost")
+            .appendPathSegments(Arrays.asList("api", "v3", "customers"))
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("http://myhost/api/v3/customers")));
+    }
+
+    @Test
     public void testNoAuthorityAndPathSegments() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("file")

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -545,6 +545,48 @@ public class TestURIBuilder {
     }
 
     @Test
+    public void testAppendToExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme( "https" )
+            .setHost( "somehost" )
+            .setPath( "api" )
+            .appendPath( "v1/resources" )
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api/v1/resources")));
+    }
+
+    @Test
+    public void testAppendToNonExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme( "https" )
+            .setHost( "somehost" )
+            .appendPath( "api/v2/customers" )
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api/v2/customers")));
+    }
+
+    @Test
+    public void testAppendNullToExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme( "https" )
+            .setHost( "somehost" )
+            .setPath( "api" )
+            .appendPath( null )
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost/api")));
+    }
+
+    @Test
+    public void testAppendNullToNonExistingPath() throws Exception {
+        final URI uri = new URIBuilder()
+            .setScheme( "https" )
+            .setHost( "somehost" )
+            .appendPath( null )
+            .build();
+        MatcherAssert.assertThat(uri, CoreMatchers.equalTo(URI.create("https://somehost")));
+    }
+
+    @Test
     public void testNoAuthorityAndPathSegments() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("file")


### PR DESCRIPTION
This PR is adding `appendPath` and `appendPathSegments` methods to `URIBuilder`.

The added benefit of these methods is allowing a URI to be built successively throughout an application. As an example, one method could set the base URL, pass the `URIBuilder` along to the next method which can set an API version, and have a third method set the context path.

This functionality does not fit nicely in an external utility method, as it breaks the builder pattern/fluent style.

This would be equivalent to Spring's [UriComponentsBuilder # path](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/util/UriComponentsBuilder.html#path-java.lang.String-). When migrating a recent application from Spring to HTTP Components, an equivalent for this method was lacking.
 