### PR TITLE
HTTPCORE-656: Improve HttpEntity.getContent() documentation

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpEntity.java
@@ -85,12 +85,12 @@ public interface HttpEntity extends EntityDetails, Closeable {
      * to return the same {@link InputStream} instance and therefore
      * may not be consumed more than once.
      * <p>
-     * If this entity belongs to an HTTP response, calling
+     * If this entity belongs to an incoming HTTP message, calling
      * {@link InputStream#close()} on the returned {@code InputStream} will
      * try to consume the complete entity content to keep the connection
      * alive. In cases where this is undesired, e.g. when only a small part
-     * of the response is relevant and consuming the complete entity content
-     * would be too inefficient, <i>only</i> the HTTP response from which
+     * of the content is relevant and consuming the complete entity content
+     * would be too inefficient, <i>only</i> the HTTP message from which
      * this entity was obtained should be closed (if supported).
      * </p>
      * <p>

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpEntity.java
@@ -85,6 +85,15 @@ public interface HttpEntity extends EntityDetails, Closeable {
      * to return the same {@link InputStream} instance and therefore
      * may not be consumed more than once.
      * <p>
+     * If this entity belongs to an HTTP response, calling
+     * {@link InputStream#close()} on the returned {@code InputStream} will
+     * try to consume the complete entity content to keep the connection
+     * alive. In cases where this is undesired, e.g. when only a small part
+     * of the response is relevant and consuming the complete entity content
+     * would be too inefficient, <i>only</i> the HTTP response from which
+     * this entity was obtained should be closed (if supported).
+     * </p>
+     * <p>
      * IMPORTANT: Please note all entity implementations must ensure that
      * all allocated resources are properly deallocated after
      * the {@link InputStream#close()} method is invoked.


### PR DESCRIPTION
See [HTTPCORE-656](https://issues.apache.org/jira/browse/HTTPCORE-656)

While writing this, I noticed that `HttpEntity` is also used by HTTP requests, therefore I added that this only applies to HTTP entities from HTTP responses.

Additionally the [tutorial](https://hc.apache.org/httpcomponents-client-ga/tutorial/html/fundamentals.html#d5e145) which mentions this behavior is part of the HTTP client project, therefore I decided against linking it from the documentation because that might be confusing.