### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Apache HttpComponents Core
 
 Welcome to the HttpCore component of the Apache HttpComponents project.
 
-[![Build Status](https://travis-ci.org/apache/httpcomponents-core.svg?branch=trunk)](https://travis-ci.org/apache/httpcomponents-core)
+[![Build Status](https://travis-ci.com/apache/httpcomponents-core.svg?branch=master)](https://travis-ci.com/apache/httpcomponents-core)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.httpcomponents.core5/httpcore5/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.httpcomponents.core5/httpcore5)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Building Instructions
 ---------------------
 
-For building from source instructions please refer to BUILDING.txt.
+For building from source instructions please refer to [BUILDING.txt](./BUILDING.txt).
 
 Dependencies
 ------------
@@ -39,7 +39,17 @@ Licensing
 ---------
 
 Apache HttpComponents Core is licensed under the Apache License 2.0.
-See the files called LICENSE.txt and NOTICE.txt for more information.
+See the files [LICENSE.txt](./LICENSE.txt) and [NOTICE.txt](./NOTICE.txt) for more information.
+
+Contact
+-------
+
+- For general information visit the main project site at  
+  https://hc.apache.org/
+- For current status information visit the status page at  
+  https://hc.apache.org/status.html
+- If you want to contribute visit  
+  https://hc.apache.org/get-involved.html
 
 Cryptographic Software Notice
 -----------------------------
@@ -50,7 +60,7 @@ may have restrictions on the import, possession, use, and/or re-export
 to another country, of encryption software. BEFORE using any encryption
 software, please check your country's laws, regulations and policies
 concerning the import, possession, or use, and re-export of encryption
-software, to see if this is permitted. See <http://www.wassenaar.org/>
+software, to see if this is permitted. See https://www.wassenaar.org/
 for more information.
 
 The U.S. Government Department of Commerce, Bureau of Industry and
@@ -66,19 +76,9 @@ code and source code.
 The following provides more details on the included software that
 may be subject to export controls on cryptographic software:
 
-  Apache HttpComponents Core interfaces with the
-  Java Secure Socket Extension (JSSE) API to provide
-
-    - HTTPS support
-
-  Apache HttpComponents Core does not include any
-  implementation of JSSE.
-
-Contact
--------
-
-  o For general information visit the main project site at
-    http://hc.apache.org/
-
-  o For current status information visit the status page at
-    http://hc.apache.org/status.html
+> Apache HttpComponents Core interfaces with the
+> Java Secure Socket Extension (JSSE) API to provide
+> - HTTPS support
+> 
+> Apache HttpComponents Core does not include any
+> implementation of JSSE.


### PR DESCRIPTION
Notable changes:
- Fix Travis badge
- Link to BUILDING, LICENSE and NOTICE
- Move "Contact" section above "Cryptographic Software Notice" because it is likely more important for most users
- Use HTTPS links

Preview can be seen [here](https://github.com/Marcono1234/httpcomponents-core/blob/patch-1/README.md).

Would it maybe also make sense to delete README.txt? Having two README files might confuse users and can cause issues when you have to keep two files up to date.

Maybe it would also be good to link to the javadoc? However based on the URL https://hc.apache.org/httpcomponents-core-5.0.x/httpcore5/apidocs/ seems to be only for version 5.0.x, therefore this link could easily become outdated once 5.1 or higher is released. Maybe it would be better to use a [javadoc.io](https://www.javadoc.io/doc/org.apache.httpcomponents.core5/httpcore5/latest/index.html) link instead  (though that shows the javadoc for the beta version by default)?