### PR TITLE
HTTPCORE-659 Race condition in IOSessionImpl when setting event

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
@@ -142,20 +142,25 @@ class IOSessionImpl implements IOSession {
 
     @Override
     public void setEventMask(final int newValue) {
-        if (isStatusClosed()) {
-            return;
+        lock.lock();
+        try {
+            if (isStatusClosed()) {
+                return;
+            }
+            this.key.interestOps(newValue);
+        } finally {
+            lock.unlock();
         }
-        this.key.interestOps(newValue);
         this.key.selector().wakeup();
     }
 
     @Override
     public void setEvent(final int op) {
-        if (isStatusClosed()) {
-            return;
-        }
         lock.lock();
         try {
+            if (isStatusClosed()) {
+                return;
+            }
             this.key.interestOps(this.key.interestOps() | op);
         } finally {
             lock.unlock();
@@ -165,11 +170,11 @@ class IOSessionImpl implements IOSession {
 
     @Override
     public void clearEvent(final int op) {
-        if (isStatusClosed()) {
-            return;
-        }
         lock.lock();
         try {
+            if (isStatusClosed()) {
+                return;
+            }
             this.key.interestOps(this.key.interestOps() & ~op);
         } finally {
             lock.unlock();


### PR DESCRIPTION
I'm not including change on `setEventMask(final int newValue)` method as there is currently no lock and I have no knowledge on its usage. Tell me if you want this modification as well.
I'm not including a new test case because the race condition is quite hard to reproduce without some "artificial" help like making the code sleep in the `setEvent()` method.  