### PR TITLE
HTTPCORE-665 - add http status code 509 Bandwidth Limit Exceeded

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpStatus.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpStatus.java
@@ -223,6 +223,11 @@ public final class HttpStatus {
     public static final int SC_LOOP_DETECTED = 508;
 
     /**
+     * {@code 509 Bandwidth Limit Exceeded}
+     */
+    public static final int SC_BANDWIDTH_LIMIT_EXCEEDED = 509;
+
+    /**
      * {@code 510 Not Extended} (An HTTP Extension Framework - RFC 2774, p. 10, section 7)
      */
     public static final int SC_NOT_EXTENDED = 510;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/EnglishReasonPhraseCatalog.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/EnglishReasonPhraseCatalog.java
@@ -222,6 +222,8 @@ public class EnglishReasonPhraseCatalog implements ReasonPhraseCatalog {
                   "Insufficient Storage");
         setReason(HttpStatus.SC_LOOP_DETECTED,
                 "Loop Detected");
+        setReason(HttpStatus.SC_BANDWIDTH_LIMIT_EXCEEDED,
+                "Bandwidth Limit Exceeded");
         setReason(HttpStatus.SC_NOT_EXTENDED,
                 "Not Extended");
         setReason(HttpStatus.SC_FAILED_DEPENDENCY,


### PR DESCRIPTION
Would be nice to have the HTTP code 509. This status code, while used by many servers, is not specified in any RFCs.
 
509 Bandwidth Limit Exceeded
Currently, the HTTP Status code list doesn't include this codes.