### PR TITLE
Add maven-bundle-plugin to create OSGi-ready packages

### DIFF
--- a/httpcore5-h2/pom.xml
+++ b/httpcore5-h2/pom.xml
@@ -34,7 +34,7 @@
   <name>Apache HttpComponents Core HTTP/2</name>
   <description>Apache HttpComponents HTTP/2 Core Components</description>
   <url>https://hc.apache.org/httpcomponents-core-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.core5.httpcore5.h2</Automatic-Module-Name>
@@ -77,6 +77,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.apache.hc.core5.http2.*</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <reporting>
     <plugins>

--- a/httpcore5-reactive/pom.xml
+++ b/httpcore5-reactive/pom.xml
@@ -35,7 +35,7 @@
   <name>Apache HttpComponents Core Reactive Extensions</name>
   <description>Apache HttpComponents Reactive Streams Bindings</description>
   <url>https://hc.apache.org/httpcomponents-core-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.core5.httpcore5.reactive</Automatic-Module-Name>
@@ -64,6 +64,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
 
   <reporting>
     <plugins>

--- a/httpcore5/pom.xml
+++ b/httpcore5/pom.xml
@@ -35,7 +35,7 @@
   <inceptionYear>2005</inceptionYear>
   <description>Apache HttpComponents HTTP/1.1 core components</description>
   <url>https://hc.apache.org/httpcomponents-core-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.core5.httpcore5</Automatic-Module-Name>
@@ -90,6 +90,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.apache.hc.core5.*</Export-Package>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The Felix maven-bundle-plugin adds a manifest file within the resulting jar that OSGi uses when wiring together dependencies. By default, the plugin ignores packages named impl, so explicit instructions have been added to the poms of httpcore5 and httpcore-h2 to publish all packages in the manifest. The resulting package is still a jar file, so non-OSGi consumers need not do anything different.