### PR TITLE
Let TimeValue/Timeout convert to and from Duration.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TimeValue.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TimeValue.java
@@ -28,7 +28,10 @@
 package org.apache.hc.core5.util;
 
 import java.text.ParseException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -141,11 +144,42 @@ public class TimeValue implements Comparable<TimeValue> {
      * Creates a TimeValue.
      *
      * @param duration the time duration in the given {@code timeUnit}.
-     * @param timeUnit the time unit for the given durarion.
-     * @return a Timeout
+     * @param timeUnit the time unit for the given duration.
+     * @return a Timeout.
      */
     public static TimeValue of(final long duration, final TimeUnit timeUnit) {
         return new TimeValue(duration, timeUnit);
+    }
+
+    /**
+     * Creates a TimeValue from a Duration.
+     *
+     * @param duration the time duration in the given {@code timeUnit}.
+     * @param timeUnit the time unit for the given duration.
+     * @return a Timeout
+     * @since 5.2
+     */
+    public static TimeValue of(final Duration duration) {
+        final long seconds = duration.getSeconds();
+        final long nanoOfSecond = duration.getNano();
+        if (seconds == 0) {
+            // no conversion
+            return of(nanoOfSecond, TimeUnit.NANOSECONDS);
+        } else if (nanoOfSecond == 0) {
+            // no conversion
+            return of(seconds, TimeUnit.SECONDS);
+        }
+        // conversion attempts
+        try {
+            return of(duration.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (final ArithmeticException e) {
+            try {
+                return of(duration.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (final ArithmeticException e1) {
+                // backstop
+                return of(seconds, TimeUnit.SECONDS);
+            }
+        }
     }
 
     public static TimeValue ofDays(final long days) {
@@ -174,6 +208,32 @@ public class TimeValue implements Comparable<TimeValue> {
 
     public static TimeValue ofSeconds(final long seconds) {
         return of(seconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Converts a {@link TimeUnit} to the equivalent {@link ChronoUnit}.
+     *
+     * @return the converted equivalent ChronoUnit
+     */
+    static ChronoUnit toChronoUnit(final TimeUnit timeUnit) {
+        switch (Objects.requireNonNull(timeUnit)) {
+        case NANOSECONDS:
+            return ChronoUnit.NANOS;
+        case MICROSECONDS:
+            return ChronoUnit.MICROS;
+        case MILLISECONDS:
+            return ChronoUnit.MILLIS;
+        case SECONDS:
+            return ChronoUnit.SECONDS;
+        case MINUTES:
+            return ChronoUnit.MINUTES;
+        case HOURS:
+            return ChronoUnit.HOURS;
+        case DAYS:
+            return ChronoUnit.DAYS;
+        default:
+            throw new IllegalArgumentException(timeUnit.toString());
+        }
     }
 
     /**
@@ -333,6 +393,16 @@ public class TimeValue implements Comparable<TimeValue> {
 
     public long toDays() {
         return timeUnit.toDays(duration);
+    }
+
+    /**
+     * Converts this instance of to a Duration.
+     *
+     * @return a Duration.
+     * @since 5.2
+     */
+    public Duration toDuration() {
+        return duration == 0 ? Duration.ZERO : Duration.of(duration, toChronoUnit(timeUnit));
     }
 
     public long toHours() {

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Timeout.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Timeout.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.util;
 
 import java.text.ParseException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -64,6 +65,37 @@ public class Timeout extends TimeValue {
      */
     public static Timeout defaultsToDisabled(final Timeout timeout) {
         return defaultsTo(timeout, DISABLED);
+    }
+
+    /**
+     * Creates a Timeout from a Duration.
+     *
+     * @param duration the time duration in the given {@code timeUnit}.
+     * @param timeUnit the time unit for the given duration.
+     * @return a Timeout.
+     * @since 5.2
+     */
+    public static Timeout of(final Duration duration) {
+        final long seconds = duration.getSeconds();
+        final long nanoOfSecond = duration.getNano();
+        if (seconds == 0) {
+            // no conversion
+            return of(nanoOfSecond, TimeUnit.NANOSECONDS);
+        } else if (nanoOfSecond == 0) {
+            // no conversion
+            return of(seconds, TimeUnit.SECONDS);
+        }
+        // conversion attempts
+        try {
+            return of(duration.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (final ArithmeticException e) {
+            try {
+                return of(duration.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (final ArithmeticException e1) {
+                // backstop
+                return of(seconds, TimeUnit.SECONDS);
+            }
+        }
     }
 
     /**

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeout.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeout.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.util;
 
 import java.text.ParseException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
@@ -98,6 +99,21 @@ public class TestTimeout {
     @Test
     public void testFactoryForDays() {
         testFactory(TimeUnit.DAYS);
+    }
+
+    @Test
+    public void testFactoryForDuration() {
+        assertConvertion(Duration.ZERO);
+        assertConvertion(Duration.ofDays(1));
+        assertConvertion(Duration.ofHours(1));
+        assertConvertion(Duration.ofMillis(1));
+        assertConvertion(Duration.ofNanos(1));
+        assertConvertion(Duration.ofSeconds(1));
+        assertConvertion(Duration.ofSeconds(1, 1));
+    }
+
+    private void assertConvertion(final Duration duration) {
+        Assert.assertEquals(duration, Timeout.of(duration).toDuration());
     }
 
     @Test


### PR DESCRIPTION
Java 8 delivers the `java.time` package including the `Duration` class which is a nice way to express timeouts, just like our `TimeValue` and `Timeout` classes. Therefore, this PRs allows conversions between our types and a Java Duration for use cases where an application already deals with Durations.

This PR also updates the tests affected to no longer use the deprecated `Assert.assertThat`.
