### PR TITLE
Add URIBuilder#getFirstQueryParam(String) to query a parameter by name.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -343,6 +343,7 @@ public class URIBuilder {
                 this.host = PercentCodec.decode(uriAuthority.getHostName(), charset);
                 this.port = uriAuthority.getPort();
             } catch (final URISyntaxException ignore) {
+                // ignore
             }
         }
         this.encodedPath = uri.getRawPath();
@@ -810,6 +811,17 @@ public class URIBuilder {
 
     public List<NameValuePair> getQueryParams() {
         return this.queryParams != null ? new ArrayList<>(this.queryParams) : Collections.<NameValuePair>emptyList();
+    }
+
+    /**
+     * Gets the first {@link NameValuePair} for a given name.
+     *
+     * @param name the name
+     * @return the first named {@link NameValuePair} or null if not found.
+     * @since 5.2
+     */
+    public NameValuePair getFirstQueryParam(final String name) {
+        return queryParams.stream().filter(e -> name.equals(e.getName())).findFirst().orElse(null);
     }
 
     public String getFragment() {

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -301,9 +301,23 @@ public class TestURIBuilder {
     public void testSetParameter() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameter("param", "some other stuff")
-            .setParameter("blah", "blah");
+                .setParameter("blah", "blah")
+                .setParameter("blah", "blah2");
         final URI result = uribuilder.build();
-        Assert.assertEquals(new URI("http://localhost:80/?param=some%20other%20stuff&blah=blah"), result);
+        Assert.assertEquals(new URI("http://localhost:80/?param=some%20other%20stuff&blah=blah2"), result);
+    }
+
+    @Test
+    public void testGetFirstNamedParameter() throws Exception {
+        final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
+        URIBuilder uribuilder = new URIBuilder(uri).setParameter("param", "some other stuff")
+            .setParameter("blah", "blah");
+        Assert.assertEquals("some other stuff", uribuilder.getFirstQueryParam("param").getValue());
+        Assert.assertEquals("blah", uribuilder.getFirstQueryParam("blah").getValue());
+        Assert.assertNull(uribuilder.getFirstQueryParam("DoesNotExist"));
+        //
+        uribuilder = new URIBuilder("http://localhost:80/?param=some%20other%20stuff&blah=blah&blah=blah2");
+        Assert.assertEquals("blah", uribuilder.getFirstQueryParam("blah").getValue());
     }
 
     @Test


### PR DESCRIPTION
Add `URIBuilder#getFirstQueryParam(String)` to query a parameter by name.