### PR TITLE
Fix TextUtils.toHexString having incorrect result for negative values

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -10,6 +10,7 @@ new features as well as bug fixes from the stable 5.0.x and 5.1.x branches.
 * Add URIBuilder#getFirstQueryParam(String) to query a parameter by name. #264.
   Contributed by Gary Gregory <garydgregory at gmail.com>
 
+* Bug fix: TextUtils.toHexString(byte[]) returned wrong result for negative byte values
 
 Release 5.1
 -----------

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -102,17 +102,26 @@ public final class TextUtils {
         return false;
     }
 
+    /**
+     * Returns a hexadecimal string with lowercase letters, representing the
+     * values of the {@code bytes}.
+     *
+     * @param bytes whose hex string should be created
+     * @return hex string for the bytes
+     *
+     * @since 5.0
+     */
     public static String toHexString(final byte[] bytes) {
         if (bytes == null) {
             return null;
         }
         final StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < bytes.length; i++) {
-            final byte b = bytes[i];
-            if (b < 16) {
+            final int unsignedB = bytes[i] & 0xff;
+            if (unsignedB < 16) {
                 buffer.append('0');
             }
-            buffer.append(Integer.toHexString(b & 0xff));
+            buffer.append(Integer.toHexString(unsignedB));
         }
         return buffer.toString();
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityConsumer.java
@@ -47,7 +47,7 @@ public class TestDigestingEntityConsumer {
         consumer.streamEnd(null);
 
         Assert.assertEquals("12345", consumer.getContent());
-        Assert.assertEquals("0827c0cb0e0ea08a706c4c340a1680910f84e7b", TextUtils.toHexString(consumer.getDigest()));
+        Assert.assertEquals("827ccb0eea8a706c4c34a16891f84e7b", TextUtils.toHexString(consumer.getDigest()));
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityProducer.java
@@ -59,7 +59,7 @@ public class TestDigestingEntityProducer {
         Assert.assertEquals("digest-algo", trailers.get(0).getName());
         Assert.assertEquals("MD5", trailers.get(0).getValue());
         Assert.assertEquals("digest", trailers.get(1).getName());
-        Assert.assertEquals("0827c0cb0e0ea08a706c4c340a1680910f84e7b", trailers.get(1).getValue());
+        Assert.assertEquals("827ccb0eea8a706c4c34a16891f84e7b", trailers.get(1).getValue());
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTextUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTextUtils.java
@@ -63,7 +63,7 @@ public class TestTextUtils {
 
     @Test
     public void testToHexString() {
-        Assert.assertEquals("000c2001", TextUtils.toHexString(new byte[] { 0, 12, 32, 1 }));
+        Assert.assertEquals("000c2001ff", TextUtils.toHexString(new byte[] { 0, 12, 32, 1 , -1}));
         Assert.assertEquals(null, TextUtils.toHexString(null));
     }
 


### PR DESCRIPTION
The check `b < 16` was faulty and would have added a '0' for negative values.
E.g. for `(byte) 0xFF` the result would have been `"0ff"`.