### PR TITLE
HTTPCORE-616: Make parsing IPv6 ready

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URISupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URISupport.java
@@ -34,6 +34,7 @@ import org.apache.hc.core5.util.Tokenizer;
 final class URISupport {
 
     static final BitSet HOST_SEPARATORS = new BitSet(256);
+    static final BitSet IPV6_HOST_TERMINATORS = new BitSet(256);
     static final BitSet PORT_SEPARATORS = new BitSet(256);
     static final BitSet TERMINATORS = new BitSet(256);
 
@@ -43,6 +44,7 @@ final class URISupport {
         TERMINATORS.set('?');
         HOST_SEPARATORS.or(TERMINATORS);
         HOST_SEPARATORS.set('@');
+        IPV6_HOST_TERMINATORS.set(']');
         PORT_SEPARATORS.or(TERMINATORS);
         PORT_SEPARATORS.set(':');
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
@@ -230,4 +230,44 @@ public class TestHttpHost {
         }
     }
 
+    @Test
+    public void testIpv6HostAndPort() throws Exception {
+        final HttpHost host = HttpHost.create("[::1]:80");
+        Assert.assertEquals("http", host.getSchemeName());
+        Assert.assertEquals("::1", host.getHostName());
+        Assert.assertEquals(80, host.getPort());
+    }
+
+    @Test
+    public void testIpv6HostAndPortWithScheme() throws Exception {
+        final HttpHost host = HttpHost.create("https://[::1]:80");
+        Assert.assertEquals("https", host.getSchemeName());
+        Assert.assertEquals("::1", host.getHostName());
+        Assert.assertEquals(80, host.getPort());
+    }
+
+    @Test
+    public void testIpv6HostAndPortWithoutBrackets() throws Exception {
+        try {
+            // ambiguous
+            HttpHost.create("::1:80");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+        }
+    }
+
+    @Test
+    public void testIpv6HostWithoutPort() throws Exception {
+        try {
+            HttpHost.create("::1");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+        }
+    }
+
+    @Test
+    public void testIpv6HostToString() {
+        Assert.assertEquals("http://[::1]:80", new HttpHost("::1", 80).toString());
+        Assert.assertEquals("http://[::1]", new HttpHost("::1", -1).toString());
+    }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestHost.java
@@ -129,4 +129,37 @@ public class TestHost {
         }
     }
 
+    @Test
+    public void testIpv6HostAndPort() throws Exception {
+        final Host host = Host.create("[::1]:80");
+        Assert.assertEquals("::1", host.getHostName());
+        Assert.assertEquals(80, host.getPort());
+    }
+
+    @Test
+    public void testIpv6HostAndPortWithoutBrackets() {
+        try {
+            // ambiguous
+            Host.create("::1:80");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Expected IPv6 address to be enclosed in brackets"));
+        }
+    }
+
+    @Test
+    public void testIpv6HostWithoutPort() {
+        try {
+            Host.create("::1");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Expected IPv6 address to be enclosed in brackets"));
+        }
+    }
+
+    @Test
+    public void testIpv6HostToString() {
+        Assert.assertEquals("[::1]:80", new Host("::1", 80).toString());
+        Assert.assertEquals("[::1]", new Host("::1", -1).toString());
+    }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
@@ -220,4 +220,35 @@ public class TestURIAuthority {
         }
     }
 
+    @Test
+    public void testCreateFromIPv6String() throws Exception {
+        Assert.assertEquals(new URIAuthority("::1", 8080), URIAuthority.create("[::1]:8080"));
+        Assert.assertEquals(new URIAuthority("::1", -1), URIAuthority.create("[::1]"));
+        try {
+            URIAuthority.create("::1");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+        }
+        try {
+            URIAuthority.create("[::1");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Expected an IPv6 closing bracket"));
+        }
+
+        try {
+            URIAuthority.create("[a]:8080");
+            Assert.fail("URISyntaxException expected");
+        } catch (final URISyntaxException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Expected an IPv6 address"));
+        }
+    }
+
+    @Test
+    public void testIpv6HostToString() {
+        Assert.assertEquals("[::1]:80", new URIAuthority("::1", 80).toString());
+        Assert.assertEquals("user@[::1]:80", new URIAuthority("user", "::1", 80).toString());
+        Assert.assertEquals("[::1]", new URIAuthority("::1", -1).toString());
+        Assert.assertEquals("user@[::1]", new URIAuthority("user", "::1", -1).toString());
+    }
 }


### PR DESCRIPTION
This adds support for bracketed IPv6 host parsing to the following:
* `org.apache.hc.core5.net.Host.create(String)`
* `org.apache.hc.core5.net.URIAuthority.create(String)`
* `org.apache.hc.core5.http.HttpHost.create(String)`

This commit does not address "InetAddressUtils: Parsing may fail when an
IPv6 scope id might be provided." which does not appear to be relevant to
URI encoding, I need to find the original discussion to better understand
this piece.