### PR TITLE
Stats: Adds the amount of reused connections to PoolStats

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/nio/pool/RouteSpecificPool.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/pool/RouteSpecificPool.java
@@ -46,6 +46,7 @@ abstract class RouteSpecificPool<T, C, E extends PoolEntry<T, C>> {
     private final Set<E> leased;
     private final LinkedList<E> available;
     private final Map<SessionRequest, BasicFuture<E>> pending;
+    private int reusedConnections;
 
     RouteSpecificPool(final T route) {
         super();
@@ -77,6 +78,10 @@ abstract class RouteSpecificPool<T, C, E extends PoolEntry<T, C>> {
         return this.available.size() + this.leased.size() + this.pending.size();
     }
 
+    public int getReusedConnections() {
+        return this.reusedConnections;
+    }
+
     public E getFree(final Object state) {
         if (!this.available.isEmpty()) {
             if (state != null) {
@@ -86,6 +91,7 @@ abstract class RouteSpecificPool<T, C, E extends PoolEntry<T, C>> {
                     if (state.equals(entry.getState())) {
                         it.remove();
                         this.leased.add(entry);
+                        this.reusedConnections++;
                         return entry;
                     }
                 }
@@ -96,6 +102,7 @@ abstract class RouteSpecificPool<T, C, E extends PoolEntry<T, C>> {
                 if (entry.getState() == null) {
                     it.remove();
                     this.leased.add(entry);
+                    this.reusedConnections++;
                     return entry;
                 }
             }
@@ -196,6 +203,8 @@ abstract class RouteSpecificPool<T, C, E extends PoolEntry<T, C>> {
         buffer.append(this.available.size());
         buffer.append("][pending: ");
         buffer.append(this.pending.size());
+        buffer.append("][reused: ");
+        buffer.append(this.reusedConnections);
         buffer.append("]");
         return buffer.toString();
     }

--- a/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
+++ b/httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
@@ -78,6 +78,7 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
     private final LinkedList<E> available;
     private final LinkedList<Future<E>> pending;
     private final Map<T, Integer> maxPerRoute;
+    private int reusedConnections;
 
     private volatile boolean isShutDown;
     private volatile int defaultMaxPerRoute;
@@ -343,6 +344,7 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
                 if (entry != null) {
                     this.available.remove(entry);
                     this.leased.add(entry);
+                    this.reusedConnections++;
                     onReuse(entry);
                     return entry;
                 }
@@ -524,7 +526,8 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
                     this.leased.size(),
                     this.pending.size(),
                     this.available.size(),
-                    this.maxTotal);
+                    this.maxTotal,
+                    this.reusedConnections);
         } finally {
             this.lock.unlock();
         }
@@ -540,7 +543,8 @@ public abstract class AbstractConnPool<T, C, E extends PoolEntry<T, C>>
                     pool.getLeasedCount(),
                     pool.getPendingCount(),
                     pool.getAvailableCount(),
-                    getMax(route));
+                    getMax(route),
+                    pool.getReusedConnections());
         } finally {
             this.lock.unlock();
         }

--- a/httpcore/src/main/java/org/apache/http/pool/PoolStats.java
+++ b/httpcore/src/main/java/org/apache/http/pool/PoolStats.java
@@ -48,13 +48,15 @@ public class PoolStats implements Serializable {
     private final int pending;
     private final int available;
     private final int max;
+    private final int reusedConnections;
 
-    public PoolStats(final int leased, final int pending, final int free, final int max) {
+    public PoolStats(final int leased, final int pending, final int free, final int max, final int reusedConnections) {
         super();
         this.leased = leased;
         this.pending = pending;
         this.available = free;
         this.max = max;
+        this.reusedConnections = reusedConnections;
     }
 
     /**
@@ -99,6 +101,15 @@ public class PoolStats implements Serializable {
      */
     public int getMax() {
         return this.max;
+    }
+
+    /**
+     * Gets the amount of reused connections
+     *
+     * @return the amount of reused connections
+     */
+    public int getReusedConnections() {
+        return reusedConnections;
     }
 
     @Override


### PR DESCRIPTION
Adds the amount of reused connections to PoolStats.

	modified:   httpcore-nio/src/main/java/org/apache/http/nio/pool/AbstractNIOConnPool.java
	modified:   httpcore-nio/src/main/java/org/apache/http/nio/pool/RouteSpecificPool.java
	modified:   httpcore/src/main/java/org/apache/http/pool/AbstractConnPool.java
	modified:   httpcore/src/main/java/org/apache/http/pool/PoolStats.java
	modified:   httpcore/src/main/java/org/apache/http/pool/RouteSpecificPool.java

https://stackoverflow.com/questions/66994366/get-stats-of-reused-connections-with-poolinghttpclientconnectionmanager