### PR TITLE
Don't change conn flow control window based on remote SETTINGS

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -1192,7 +1192,6 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         initOutputWinSize = remoteConfig.getInitialWindowSize();
 
         if (delta != 0) {
-            updateOutputWindow(0, connOutputWindow, delta);
             if (!streamMap.isEmpty()) {
                 for (final Iterator<Map.Entry<Integer, H2Stream>> it = streamMap.entrySet().iterator(); it.hasNext(); ) {
                     final Map.Entry<Integer, H2Stream> entry = it.next();


### PR DESCRIPTION
From RFC7540 §6.9.2:

> The connection flow-control window can only be changed using
> WINDOW_UPDATE frames.