### PR TITLE
Use jep244 (ALPN support) was back-ported to java 8u251

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ services:
   - docker
 
 jdk:
-  - oraclejdk8
   - openjdk11
-  - oraclejdk11
   - oraclejdk16
   - openjdk-ea
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptSupport.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/ConscryptSupport.java
@@ -56,7 +56,7 @@ public final class ConscryptSupport {
                 sslEngine.setSSLParameters(sslParameters);
                 Conscrypt.setApplicationProtocols(sslEngine, appProtocols);
             } else {
-                H2TlsSupport.setApplicationProtocols(sslParameters, appProtocols);
+                sslParameters.setApplicationProtocols(appProtocols);
                 sslEngine.setSSLParameters(sslParameters);
             }
             if (initializer != null) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2TlsSupport.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/ssl/H2TlsSupport.java
@@ -46,6 +46,10 @@ public final class H2TlsSupport {
         ReflectionUtils.callSetter(sslParameters, "EnableRetransmissions", Boolean.TYPE, value);
     }
 
+    /**
+     * @deprecated Use {@link SSLParameters#setApplicationProtocols(String[])}.
+     */
+    @Deprecated
     public static void setApplicationProtocols(final SSLParameters sslParameters, final String[] values) {
         ReflectionUtils.callSetter(sslParameters, "ApplicationProtocols", String[].class, values);
     }
@@ -71,7 +75,7 @@ public final class H2TlsSupport {
             sslParameters.setProtocols(TLS.excludeWeak(sslParameters.getProtocols()));
             sslParameters.setCipherSuites(TlsCiphers.excludeH2Blacklisted(sslParameters.getCipherSuites()));
             setEnableRetransmissions(sslParameters, false);
-            setApplicationProtocols(sslParameters, selectApplicationProtocols(attachment));
+            sslParameters.setApplicationProtocols(selectApplicationProtocols(attachment));
             sslEngine.setSSLParameters(sslParameters);
             if (initializer != null) {
                 initializer.initialize(endpoint, sslEngine);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2AlpnTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2AlpnTest.java
@@ -60,13 +60,9 @@ import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.ListenerEndpoint;
 import org.apache.hc.core5.testing.SSLTestContexts;
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.Timeout;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -164,18 +160,6 @@ public class H2AlpnTest {
         }
 
     };
-
-    private static int JAVA_VER;
-
-    @BeforeClass
-    public static void determineJavaVersion() {
-        JAVA_VER = ReflectionUtils.determineJRELevel();
-    }
-
-    @Before
-    public void checkVersion() {
-        Assume.assumeTrue("Java version must be 9 or greater and less than 16", JAVA_VER >= 9 && JAVA_VER < 16);
-    }
 
     @Test
     public void testALPN() throws Exception {

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
@@ -29,8 +29,6 @@ package org.apache.hc.core5.testing.nio;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Future;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHost;
@@ -57,13 +55,9 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.ListenerEndpoint;
 import org.apache.hc.core5.testing.SSLTestContexts;
 import org.apache.hc.core5.testing.classic.LoggingConnPoolListener;
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.Timeout;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -145,18 +139,6 @@ public class H2ProtocolNegotiationTest {
 
     };
 
-    private static int JAVA_VER;
-
-    @BeforeClass
-    public static void determineJavaVersion() {
-        JAVA_VER = ReflectionUtils.determineJRELevel();
-    }
-
-    @Before
-    public void checkVersion() {
-        Assume.assumeTrue("Java version must be 1.8 or greater", JAVA_VER >= 8);
-    }
-
     @Test
     public void testForceHttp1() throws Exception {
         server.start();
@@ -223,27 +205,7 @@ public class H2ProtocolNegotiationTest {
         MatcherAssert.assertThat(message1, CoreMatchers.notNullValue());
         final HttpResponse response1 = message1.getHead();
         MatcherAssert.assertThat(response1.getCode(), CoreMatchers.equalTo(HttpStatus.SC_OK));
-
-        if (isAlpnSupported()) {
-            MatcherAssert.assertThat(response1.getVersion(), CoreMatchers.equalTo(HttpVersion.HTTP_2));
-        } else {
-            MatcherAssert.assertThat(response1.getVersion(), CoreMatchers.equalTo(HttpVersion.HTTP_1_1));
-        }
-    }
-
-    private boolean isAlpnSupported() {
-        if (JAVA_VER == 8) {
-            // The 'java.version' property values are structured "1.8.0_[BUILD NUMBER]" in java 8 releases.
-            final Matcher matcher = Pattern.compile("^1\\.8\\.0_(\\d+)$")
-                    .matcher(System.getProperty("java.version"));
-            if (matcher.matches()) {
-                final int java8Build = Integer.parseInt(matcher.group(1));
-                // jep244 (alpn) was backported to java 8u251.
-                // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8230977
-                return java8Build >= 251;
-            }
-        }
-        return JAVA_VER > 8 && JAVA_VER < 16;
+        MatcherAssert.assertThat(response1.getVersion(), CoreMatchers.equalTo(HttpVersion.HTTP_2));
     }
 
 }

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerAndMultiplexingRequesterTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerAndMultiplexingRequesterTest.java
@@ -61,14 +61,10 @@ import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.ListenerEndpoint;
 import org.apache.hc.core5.testing.SSLTestContexts;
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -159,20 +155,6 @@ public class H2ServerAndMultiplexingRequesterTest {
         }
 
     };
-
-    private static int javaVersion;
-
-    @BeforeClass
-    public static void determineJavaVersion() {
-        javaVersion = ReflectionUtils.determineJRELevel();
-    }
-
-    @Before
-    public void checkVersion() {
-        if (scheme == URIScheme.HTTPS) {
-            Assume.assumeTrue("Java version must be 1.8 or greater",  javaVersion > 7);
-        }
-    }
 
     @Test
     public void testSequentialRequests() throws Exception {

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerAndRequesterTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerAndRequesterTest.java
@@ -59,13 +59,9 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.ListenerEndpoint;
 import org.apache.hc.core5.testing.SSLTestContexts;
 import org.apache.hc.core5.testing.classic.LoggingConnPoolListener;
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.Timeout;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -162,20 +158,6 @@ public class H2ServerAndRequesterTest {
         }
 
     };
-
-    private static int javaVersion;
-
-    @BeforeClass
-    public static void determineJavaVersion() {
-        javaVersion = ReflectionUtils.determineJRELevel();
-    }
-
-    @Before
-    public void checkVersion() {
-        if (scheme == URIScheme.HTTPS) {
-            Assume.assumeTrue("Java version must be 1.8 or greater",  javaVersion > 7);
-        }
-    }
 
     @Test
     public void testSequentialRequests() throws Exception {

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
@@ -52,13 +52,11 @@ import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.RequestValidateHost;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.conscrypt.Conscrypt;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -98,11 +96,6 @@ public class JSSEProviderIntegrationTest {
     private Provider securityProvider;
     private Http1TestServer server;
     private Http1TestClient client;
-
-    @BeforeClass
-    public static void determineJavaVersion() {
-        Assume.assumeTrue("Java version must be 8 or greater", ReflectionUtils.determineJRELevel() >= 8);
-    }
 
     @Rule
     public TestRule resourceRules = RuleChain.outerRule(new ExternalResource() {

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -57,7 +57,6 @@ import org.apache.hc.core5.reactor.IOEventHandler;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -381,7 +380,7 @@ public class SSLIOSession implements IOSession {
             }
             if (this.tlsDetails == null) {
                 final SSLSession sslSession = this.sslEngine.getSession();
-                final String applicationProtocol = ReflectionUtils.callGetter(this.sslEngine, "ApplicationProtocol", String.class);
+                final String applicationProtocol = this.sslEngine.getApplicationProtocol();
                 this.tlsDetails = new TlsDetails(sslSession, applicationProtocol);
             }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
@@ -59,12 +59,9 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManagerFactory;
 
-import org.apache.hc.core5.util.ReflectionUtils;
 import org.apache.hc.core5.util.Timeout;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -76,11 +73,6 @@ public class TestSSLContextBuilder {
 
     private static boolean isWindows() {
         return System.getProperty("os.name").contains("Windows");
-    }
-
-    @BeforeClass
-    public static void determineJavaVersion() {
-        Assume.assumeTrue("Java version must be 8 or greater", ReflectionUtils.determineJRELevel() >= 8);
     }
 
     private static final Timeout TIMEOUT = Timeout.ofSeconds(5);

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <log4j.version>2.8.2</log4j.version>
     <rxjava.version>2.2.8</rxjava.version>
     <api.comparison.version>5.1</api.comparison.version>
+    <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters</hc.animal-sniffer.signature.ignores>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Folks
I would like to replace reflective calls to ALPN related methods with new API introduced in Java 8u251. This will fix incompatibility with Java 16 onward without a full upgrade to Java 11. The downside is that the project can no longer be built with Oracle Java 8 and will hence on require a fairly recent OpenJDK. 

The 5.2 code builds correctly with Apache Jenkins but no longer builds with Travis CI Java 8 JDKs.
 
https://ci-builds.apache.org/job/HttpComponents/job/HttpComponents%20Core%205.2.x%20Java8u251/2/
https://github.com/apache/httpcomponents-core/runs/2679553610

@garydgregory @rschmitt Please let me know if it is OK with you.