### PR TITLE
Adds utility method to add name value pair for uri builder

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -697,6 +697,7 @@ public class URIBuilder {
      * </p>
      *
      * @return this.
+     * @since 5.2
      */
     public URIBuilder addParameter(final NameValuePair nvp) {
         if (this.queryParams == null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -685,10 +685,24 @@ public class URIBuilder {
      * @return this.
      */
     public URIBuilder addParameter(final String param, final String value) {
+        return addParameter(new BasicNameValuePair(param, value));
+    }
+
+    /**
+     * Adds parameter to URI query. The parameter name and value are expected to be unescaped
+     * and may contain non ASCII characters.
+     * <p>
+     * Please note query parameters and custom query component are mutually exclusive. This method
+     * will remove custom query if present.
+     * </p>
+     *
+     * @return this.
+     */
+    public URIBuilder addParameter(final NameValuePair nvp) {
         if (this.queryParams == null) {
             this.queryParams = new ArrayList<>();
         }
-        this.queryParams.add(new BasicNameValuePair(param, value));
+        this.queryParams.add(nvp);
         this.encodedQuery = null;
         this.encodedSchemeSpecificPart = null;
         this.query = null;


### PR DESCRIPTION
What?
Adding an overloaded method to uri builder to add NameValuePair as query param.

Why?
At times some of the query params are constant and do not change in terms of key and value.
In those cases it is better to make NameValuePair instances as static and re-using them instead of
creating an instance everytime.