### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,14 @@ install: skip
 script: mvn verify -B -P docker
 
 jobs:
+  fast_finish: true
   include:
     - name: arm64
       arch: arm64
       script: mvn verify -B
   allow_failures:
     - jdk: openjdk-ea
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

If there are any inappropriate modifications in this PR, please give me feedback and I will change them.
