### PR TITLE
Allow setting parameters to null arrays and lists to behave like empty

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -632,13 +632,15 @@ public class URIBuilder {
      *
      * @return this.
      */
-    public URIBuilder setParameters(final List <NameValuePair> nvps) {
+    public URIBuilder setParameters(final List <NameValuePair> nameValuePairs) {
         if (this.queryParams == null) {
             this.queryParams = new ArrayList<>();
         } else {
             this.queryParams.clear();
         }
-        this.queryParams.addAll(nvps);
+        if (nameValuePairs != null) {
+            this.queryParams.addAll(nameValuePairs);
+        }
         this.encodedQuery = null;
         this.encodedSchemeSpecificPart = null;
         this.query = null;
@@ -655,11 +657,13 @@ public class URIBuilder {
      *
      * @return this.
      */
-    public URIBuilder addParameters(final List <NameValuePair> nvps) {
+    public URIBuilder addParameters(final List<NameValuePair> nameValuePairs) {
         if (this.queryParams == null) {
             this.queryParams = new ArrayList<>();
         }
-        this.queryParams.addAll(nvps);
+        if (nameValuePairs != null) {
+            this.queryParams.addAll(nameValuePairs);
+        }
         this.encodedQuery = null;
         this.encodedSchemeSpecificPart = null;
         this.query = null;
@@ -676,13 +680,15 @@ public class URIBuilder {
      *
      * @return this.
      */
-    public URIBuilder setParameters(final NameValuePair... nvps) {
+    public URIBuilder setParameters(final NameValuePair... nameValuePairs) {
         if (this.queryParams == null) {
             this.queryParams = new ArrayList<>();
         } else {
             this.queryParams.clear();
         }
-        Collections.addAll(this.queryParams, nvps);
+        if (nameValuePairs != null) {
+            Collections.addAll(this.queryParams, nameValuePairs);
+        }
         this.encodedQuery = null;
         this.encodedSchemeSpecificPart = null;
         this.query = null;
@@ -714,11 +720,13 @@ public class URIBuilder {
      * @return this.
      * @since 5.2
      */
-    public URIBuilder addParameter(final NameValuePair nvp) {
+    public URIBuilder addParameter(final NameValuePair nameValuePair) {
         if (this.queryParams == null) {
             this.queryParams = new ArrayList<>();
         }
-        this.queryParams.add(nvp);
+        if (nameValuePair != null) {
+            this.queryParams.add(nameValuePair);
+        }
         this.encodedQuery = null;
         this.encodedSchemeSpecificPart = null;
         this.query = null;

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -346,9 +346,17 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetParametersWithEmptyArg() throws Exception {
+    public void testSetParametersWithEmptyArrayArg() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameters();
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("http://localhost:80/test"), result);
+    }
+
+    @Test
+    public void testSetParametersWithNullArrayArg() throws Exception {
+        final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
+        final URIBuilder uribuilder = new URIBuilder(uri).setParameters((NameValuePair[]) null);
         final URI result = uribuilder.build();
         Assert.assertEquals(new URI("http://localhost:80/test"), result);
     }
@@ -357,6 +365,14 @@ public class TestURIBuilder {
     public void testSetParametersWithEmptyList() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameters(Collections.emptyList());
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("http://localhost:80/test"), result);
+    }
+
+    @Test
+    public void testSetParametersWithNullList() throws Exception {
+        final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
+        final URIBuilder uribuilder = new URIBuilder(uri).setParameters((List<NameValuePair>) null);
         final URI result = uribuilder.build();
         Assert.assertEquals(new URI("http://localhost:80/test"), result);
     }
@@ -454,9 +470,15 @@ public class TestURIBuilder {
     public void assertAddParameters(final Charset charset) throws Exception {
         final URI uri = new URIBuilder("https://somehost.com/stuff")
                 .setCharset(charset)
-                .addParameters(createParameters()).build();
+                .addParameters(createParameterList()).build();
 
         assertBuild(charset, uri);
+        // null addParameters
+        final URI uri2 = new URIBuilder("https://somehost.com/stuff")
+                .setCharset(charset)
+                .addParameters(null).build();
+
+        Assert.assertEquals("https://somehost.com/stuff", uri2.toString());
     }
 
     @Test
@@ -472,7 +494,7 @@ public class TestURIBuilder {
     public void assertSetParameters(final Charset charset) throws Exception {
         final URI uri = new URIBuilder("https://somehost.com/stuff")
                 .setCharset(charset)
-                .setParameters(createParameters()).build();
+                .setParameters(createParameterList()).build();
 
         assertBuild(charset, uri);
     }
@@ -486,7 +508,7 @@ public class TestURIBuilder {
         Assert.assertEquals(uriExpected, uri.toString());
     }
 
-    private List<NameValuePair> createParameters() {
+    private List<NameValuePair> createParameterList() {
         final List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("parameter1", "value1"));
         parameters.add(new BasicNameValuePair("parameter2", "\"1\u00aa position\""));


### PR DESCRIPTION
arrays and lists instead of throwing exceptions.