### PR TITLE
Add PathEntityProducer, an NIO entity provider.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AsyncEntityProducers.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AsyncEntityProducers.java
@@ -32,6 +32,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -216,6 +219,20 @@ public final class AsyncEntityProducers {
 
     public static AsyncEntityProducer create(final File content, final ContentType contentType, final Header... trailers) {
         return withTrailers(create(content, contentType), trailers);
+    }
+
+    /**
+     * @since 5.2
+     */
+    public static AsyncEntityProducer create(final Path content, final ContentType contentType, final Header... trailers) throws IOException {
+        return withTrailers(new PathEntityProducer(content, contentType, StandardOpenOption.READ), trailers);
+    }
+
+    /**
+     * @since 5.2
+     */
+    public static AsyncEntityProducer create(final Path content, final ContentType contentType, final OpenOption... options) throws IOException {
+        return new PathEntityProducer(content, contentType, options);
     }
 
     public static AsyncEntityProducer createBinary(

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/PathEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/PathEntityProducer.java
@@ -1,0 +1,165 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http.nio.entity;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.io.Closer;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Asserts;
+
+/**
+ * {@link AsyncEntityProducer} implementation that generates a data stream from the content at a {@link Path}.
+ *
+ * @since 5.2
+ */
+public final class PathEntityProducer implements AsyncEntityProducer {
+
+    private static final int BUFFER_SIZE = 8192;
+    private final Path file;
+    private final OpenOption[] openOptions;
+    private final ByteBuffer byteBuffer;
+    private final long length;
+    private final ContentType contentType;
+    private final boolean chunked;
+    private final AtomicReference<Exception> exception;
+    private final AtomicReference<SeekableByteChannel> channelRef;
+    private boolean eof;
+
+    public PathEntityProducer(final Path file, final ContentType contentType, final boolean chunked,
+            final OpenOption... openOptions) throws IOException {
+        this(file, BUFFER_SIZE, contentType, chunked, openOptions);
+    }
+
+    public PathEntityProducer(final Path file, final ContentType contentType, final OpenOption... openOptions)
+            throws IOException {
+        this(file, contentType, false, openOptions);
+    }
+
+    public PathEntityProducer(final Path file, final int bufferSize, final ContentType contentType,
+            final boolean chunked, final OpenOption... openOptions) throws IOException {
+        this.file = Args.notNull(file, "file");
+        this.openOptions = openOptions;
+        this.length = Files.size(file);
+        this.byteBuffer = ByteBuffer.allocate(bufferSize);
+        this.contentType = contentType;
+        this.chunked = chunked;
+        this.channelRef = new AtomicReference<>();
+        this.exception = new AtomicReference<>();
+    }
+
+    public PathEntityProducer(final Path file, final OpenOption... openOptions) throws IOException {
+        this(file, ContentType.APPLICATION_OCTET_STREAM, openOptions);
+    }
+
+    @Override
+    public int available() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void failed(final Exception cause) {
+        if (exception.compareAndSet(null, cause)) {
+            releaseResources();
+        }
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return null;
+    }
+
+    @Override
+    public long getContentLength() {
+        return length;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType != null ? contentType.toString() : null;
+    }
+
+    public Exception getException() {
+        return exception.get();
+    }
+
+    @Override
+    public Set<String> getTrailerNames() {
+        return null;
+    }
+
+    @Override
+    public boolean isChunked() {
+        return chunked;
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return true;
+    }
+
+    @Override
+    public void produce(final DataStreamChannel dataStreamChannel) throws IOException {
+        SeekableByteChannel seekableByteChannel = channelRef.get();
+        if (seekableByteChannel == null) {
+            seekableByteChannel = Files.newByteChannel(file, openOptions);
+            Asserts.check(channelRef.getAndSet(seekableByteChannel) == null, "Illegal producer state");
+        }
+        if (!eof) {
+            final int bytesRead = seekableByteChannel.read(byteBuffer);
+            if (bytesRead < 0) {
+                eof = true;
+            }
+        }
+        if (byteBuffer.position() > 0) {
+            byteBuffer.flip();
+            dataStreamChannel.write(byteBuffer);
+            byteBuffer.compact();
+        }
+        if (eof && byteBuffer.position() == 0) {
+            dataStreamChannel.endStream();
+            releaseResources();
+        }
+    }
+
+    @Override
+    public void releaseResources() {
+        eof = false;
+        Closer.closeQuietly(channelRef.getAndSet(null));
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAsyncEntityProducers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAsyncEntityProducers.java
@@ -1,0 +1,78 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http.nio.entity;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link AsyncEntityProducers}.
+ */
+public class TestAsyncEntityProducers {
+
+    @Test
+    public void testPathEntityProducer() throws IOException {
+        final Path path = Paths.get("src/test/resources/test-ssl.txt");
+        final AsyncEntityProducer producer = AsyncEntityProducers.create(path, ContentType.APPLICATION_OCTET_STREAM,
+                StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+        try {
+            Assert.assertFalse(producer.isChunked());
+            Assert.assertEquals(Files.size(path), producer.getContentLength());
+            Assert.assertEquals(ContentType.APPLICATION_OCTET_STREAM.toString(), producer.getContentType());
+        } finally {
+            producer.releaseResources();
+        }
+    }
+
+    @Test
+    public void testPathEntityProducerWithTrailers() throws IOException {
+        final Path path = Paths.get("src/test/resources/test-ssl.txt");
+        final Header header1 = new BasicHeader("Tailer1", "Value1");
+        final Header header2 = new BasicHeader("Tailer2", "Value2");
+        final AsyncEntityProducer producer = AsyncEntityProducers.create(path, ContentType.APPLICATION_OCTET_STREAM,
+                header1, header2);
+        try {
+            Assert.assertTrue(producer.isChunked());
+            Assert.assertEquals(-1, producer.getContentLength());
+            Assert.assertEquals(ContentType.APPLICATION_OCTET_STREAM.toString(), producer.getContentType());
+        } finally {
+            producer.releaseResources();
+        }
+    }
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
@@ -1,0 +1,112 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http.nio.entity;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.WritableByteChannelMock;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+import org.apache.hc.core5.http.nio.BasicDataStreamChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPathAsyncEntityProducer {
+
+    private File tempFile;
+
+    @After
+    public void cleanup() {
+        if (tempFile != null) {
+            tempFile.delete();
+            tempFile = null;
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        tempFile = File.createTempFile("testing", ".txt");
+        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.US_ASCII)) {
+            writer.append("abcdef");
+            writer.flush();
+        }
+    }
+
+    @Test
+    public void testTextContent() throws Exception {
+
+        final Path tempPath = tempFile.toPath();
+        final AsyncEntityProducer producer = new PathEntityProducer(tempPath, ContentType.TEXT_PLAIN, StandardOpenOption.READ);
+
+        Assert.assertEquals(6, producer.getContentLength());
+        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+        Assert.assertNull(producer.getContentEncoding());
+
+        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+
+        producer.produce(streamChannel);
+        producer.produce(streamChannel);
+
+        Assert.assertFalse(byteChannel.isOpen());
+        Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
+    }
+
+    @Test
+    public void testTextContentRepeatable() throws Exception {
+        final Path tempPath = tempFile.toPath();
+        final AsyncEntityProducer producer = new PathEntityProducer(tempPath, ContentType.TEXT_PLAIN, StandardOpenOption.READ);
+
+        Assert.assertEquals(6, producer.getContentLength());
+        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+        Assert.assertNull(producer.getContentEncoding());
+
+        for (int i = 0; i < 3; i++) {
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+
+            producer.produce(streamChannel);
+            producer.produce(streamChannel);
+
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
+
+            producer.releaseResources();
+        }
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathEntityProducer.java
@@ -1,0 +1,60 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http.nio.entity;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @since 5.0
+ */
+public class TestPathEntityProducer {
+
+    @ClassRule
+    public static final TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testFileLengthMaxIntPlusOne() throws IOException {
+        final File file = tempFolder.newFile("test.bin");
+        final Path path = file.toPath();
+        try (RandomAccessFile raFile = new RandomAccessFile(file, "rw")) {
+            final long expectedLength = 1L + Integer.MAX_VALUE;
+            raFile.setLength(expectedLength);
+            final PathEntityProducer fileEntityProducer = new PathEntityProducer(path, StandardOpenOption.READ);
+            Assert.assertEquals(expectedLength, fileEntityProducer.getContentLength());
+        }
+    }
+
+}


### PR DESCRIPTION
This is in contrast to the "classic" IO based FileEntityProducer.