### PR TITLE
Let ResourceHolder implement java.lang.AutoCloseable.

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -1663,7 +1663,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         }
 
         void releaseResources() {
-            handler.releaseResources();
+            handler.close();
             channel.requestOutput();
         }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamHandler.java
@@ -254,16 +254,16 @@ class ClientH2StreamHandler implements H2StreamHandler {
                 }
             }
         } finally {
-            releaseResources();
+            close();
         }
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (done.compareAndSet(false, true)) {
             responseState = MessageState.COMPLETE;
             requestState = MessageState.COMPLETE;
-            exchangeHandler.releaseResources();
+            exchangeHandler.close();
         }
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientPushH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientPushH2StreamHandler.java
@@ -185,7 +185,7 @@ class ClientPushH2StreamHandler implements H2StreamHandler {
                 }
             }
         } finally {
-            releaseResources();
+            close();
         }
     }
 
@@ -195,12 +195,12 @@ class ClientPushH2StreamHandler implements H2StreamHandler {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (done.compareAndSet(false, true)) {
             responseState = MessageState.COMPLETE;
             requestState = MessageState.COMPLETE;
             if (exchangeHandler != null) {
-                exchangeHandler.releaseResources();
+                exchangeHandler.close();
             }
         }
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamHandler.java
@@ -328,17 +328,17 @@ class ServerH2StreamHandler implements H2StreamHandler {
                 }
             }
         } finally {
-            releaseResources();
+            close();
         }
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (done.compareAndSet(false, true)) {
             requestState = MessageState.COMPLETE;
             responseState = MessageState.COMPLETE;
             if (exchangeHandler != null) {
-                exchangeHandler.releaseResources();
+                exchangeHandler.close();
             }
         }
     }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerPushH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerPushH2StreamHandler.java
@@ -239,16 +239,16 @@ class ServerPushH2StreamHandler implements H2StreamHandler {
                 pushProducer.failed(cause);
             }
         } finally {
-            releaseResources();
+            close();
         }
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (done.compareAndSet(false, true)) {
             requestState = MessageState.COMPLETE;
             responseState = MessageState.COMPLETE;
-            pushProducer.releaseResources();
+            pushProducer.close();
         }
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequester.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequester.java
@@ -163,8 +163,8 @@ public class H2MultiplexingRequester extends AsyncRequester{
                         ioSession.enqueue(new RequestExecutionCommand(new AsyncClientExchangeHandler() {
 
                             @Override
-                            public void releaseResources() {
-                                exchangeHandler.releaseResources();
+                            public void close() {
+                                exchangeHandler.close();
                             }
 
                             @Override

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2FullDuplexClientExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2FullDuplexClientExample.java
@@ -130,9 +130,9 @@ public class H2FullDuplexClientExample {
         requester.execute(new AsyncClientExchangeHandler() {
 
             @Override
-            public void releaseResources() {
-                requestProducer.releaseResources();
-                responseConsumer.releaseResources();
+            public void close() {
+                requestProducer.close();
+                responseConsumer.close();
                 latch.countDown();
             }
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2FullDuplexServerExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2FullDuplexServerExample.java
@@ -213,7 +213,7 @@ public class H2FullDuplexServerExample {
                     }
 
                     @Override
-                    public void releaseResources() {
+                    public void close() {
                     }
 
                 })

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataConsumer.java
@@ -114,7 +114,7 @@ final class ReactiveDataConsumer implements AsyncDataConsumer, Publisher<ByteBuf
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         this.capacityChannel = null;
     }
 

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataProducer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveDataProducer.java
@@ -161,7 +161,7 @@ final class ReactiveDataProducer implements AsyncDataProducer, Subscriber<ByteBu
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         final Subscription s = subscription.getAndSet(null);
         if (s != null) {
             s.cancel();

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveEntityProducer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveEntityProducer.java
@@ -83,8 +83,8 @@ public final class ReactiveEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
-        reactiveDataProducer.releaseResources();
+    public void close() {
+        reactiveDataProducer.close();
     }
 
     @Override
@@ -94,7 +94,7 @@ public final class ReactiveEntityProducer implements AsyncEntityProducer {
 
     @Override
     public void failed(final Exception cause) {
-        releaseResources();
+        close();
     }
 
     @Override
@@ -121,4 +121,17 @@ public final class ReactiveEntityProducer implements AsyncEntityProducer {
     public Set<String> getTrailerNames() {
         return null;
     }
+
+    /**
+     * Deprecated, use {@link #close()}.
+     *
+     * @deprecated use {@link #close()}.
+     */
+    @Deprecated
+    @Override
+    // JApicmp can't handle default this method use case? releaseResources() was abstract, now is default.
+    public void releaseResources() {
+        close();
+    }
+
 }

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveResponseConsumer.java
@@ -164,11 +164,24 @@ public final class ReactiveResponseConsumer implements AsyncResponseConsumer<Voi
     }
 
     @Override
-    public void releaseResources() {
-        reactiveDataConsumer.releaseResources();
+    public void close() {
+        reactiveDataConsumer.close();
         responseFuture.cancel();
         if (responseCompletion != null) {
             responseCompletion.cancel();
         }
     }
+
+    /**
+     * Deprecated, use {@link #close()}.
+     *
+     * @deprecated use {@link #close()}.
+     */
+    @Deprecated
+    @Override
+    // JApicmp can't handle default this method use case? releaseResources() was abstract, now is default.
+    public void releaseResources() {
+        close();
+    }
+
 }

--- a/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveServerExchangeHandler.java
+++ b/httpcore5-reactive/src/main/java/org/apache/hc/core5/reactive/ReactiveServerExchangeHandler.java
@@ -128,11 +128,23 @@ public final class ReactiveServerExchangeHandler implements AsyncServerExchangeH
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         final ReactiveDataProducer p = responseProducer.get();
         if (p != null) {
-            p.releaseResources();
+            p.close();
         }
-        requestConsumer.releaseResources();
+        requestConsumer.close();
+    }
+
+    /**
+     * Deprecated, use {@link #close()}.
+     *
+     * @deprecated use {@link #close()}.
+     */
+    @Deprecated
+    @Override
+    // JApicmp can't handle default this method use case? releaseResources() was abstract, now is default.
+    public void releaseResources() {
+        close();
     }
 }

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
@@ -94,75 +94,77 @@ public class TestReactiveDataConsumer {
 
     @Test
     public void testCancellation() throws Exception {
-        final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
-        consumer.subscribe(new Subscriber<ByteBuffer>() {
-            @Override
-            public void onSubscribe(final Subscription s) {
-                s.cancel();
-            }
+        try (final ReactiveDataConsumer consumer = new ReactiveDataConsumer()) {
+            consumer.subscribe(new Subscriber<ByteBuffer>() {
+                @Override
+                public void onSubscribe(final Subscription s) {
+                    s.cancel();
+                }
 
-            @Override
-            public void onNext(final ByteBuffer byteBuffer) {
-            }
+                @Override
+                public void onNext(final ByteBuffer byteBuffer) {
+                }
 
-            @Override
-            public void onError(final Throwable throwable) {
-            }
+                @Override
+                public void onError(final Throwable throwable) {
+                }
 
-            @Override
-            public void onComplete() {
-            }
-        });
+                @Override
+                public void onComplete() {
+                }
+            });
 
-        Assert.assertThrows(HttpStreamResetException.class, () ->
-            consumer.consume(ByteBuffer.wrap(new byte[1024])));
+            Assert.assertThrows(HttpStreamResetException.class,
+                    () -> consumer.consume(ByteBuffer.wrap(new byte[1024])));
+        }
     }
 
     @Test
     public void testCapacityIncrements() throws Exception {
-        final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
-        final ByteBuffer data = ByteBuffer.wrap(new byte[1024]);
+        try (final ReactiveDataConsumer consumer = new ReactiveDataConsumer()) {
+            final ByteBuffer data = ByteBuffer.wrap(new byte[1024]);
 
-        final AtomicInteger lastIncrement = new AtomicInteger(-1);
-        final CapacityChannel channel = lastIncrement::set;
-        consumer.updateCapacity(channel);
-        Assert.assertEquals("CapacityChannel#update should not have been invoked yet", -1, lastIncrement.get());
+            final AtomicInteger lastIncrement = new AtomicInteger(-1);
+            final CapacityChannel channel = lastIncrement::set;
+            consumer.updateCapacity(channel);
+            Assert.assertEquals("CapacityChannel#update should not have been invoked yet", -1, lastIncrement.get());
 
-        final AtomicInteger received = new AtomicInteger(0);
-        final AtomicReference<Subscription> subscription = new AtomicReference<>();
-        consumer.subscribe(new Subscriber<ByteBuffer>() {
-            @Override
-            public void onSubscribe(final Subscription s) {
-                subscription.set(s);
-            }
+            final AtomicInteger received = new AtomicInteger(0);
+            final AtomicReference<Subscription> subscription = new AtomicReference<>();
+            consumer.subscribe(new Subscriber<ByteBuffer>() {
+                @Override
+                public void onSubscribe(final Subscription s) {
+                    subscription.set(s);
+                }
 
-            @Override
-            public void onNext(final ByteBuffer byteBuffer) {
-                received.incrementAndGet();
-            }
+                @Override
+                public void onNext(final ByteBuffer byteBuffer) {
+                    received.incrementAndGet();
+                }
 
-            @Override
-            public void onError(final Throwable throwable) {
-            }
+                @Override
+                public void onError(final Throwable throwable) {
+                }
 
-            @Override
-            public void onComplete() {
-            }
-        });
+                @Override
+                public void onComplete() {
+                }
+            });
 
-        consumer.consume(data.duplicate());
-        consumer.consume(data.duplicate());
-        consumer.consume(data.duplicate());
-        consumer.consume(data.duplicate());
+            consumer.consume(data.duplicate());
+            consumer.consume(data.duplicate());
+            consumer.consume(data.duplicate());
+            consumer.consume(data.duplicate());
 
-        subscription.get().request(1);
-        Assert.assertEquals(1024, lastIncrement.get());
+            subscription.get().request(1);
+            Assert.assertEquals(1024, lastIncrement.get());
 
-        subscription.get().request(2);
-        Assert.assertEquals(2 * 1024, lastIncrement.get());
+            subscription.get().request(2);
+            Assert.assertEquals(2 * 1024, lastIncrement.get());
 
-        subscription.get().request(99);
-        Assert.assertEquals(1024, lastIncrement.get());
+            subscription.get().request(99);
+            Assert.assertEquals(1024, lastIncrement.get());
+        }
     }
 
     @Test

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/BenchmarkWorker.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/BenchmarkWorker.java
@@ -167,9 +167,9 @@ class BenchmarkWorker implements ResourceHolder {
             }
 
             @Override
-            public void releaseResources() {
+            public void close() {
                 if (entityProducer != null) {
-                    entityProducer.releaseResources();
+                    entityProducer.close();
                 }
             }
 
@@ -266,7 +266,7 @@ class BenchmarkWorker implements ResourceHolder {
             }
 
             @Override
-            public void releaseResources() {
+            public void close() {
             }
 
         };
@@ -355,7 +355,7 @@ class BenchmarkWorker implements ResourceHolder {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         final AsyncClientEndpoint endpoint = endpointRef.getAndSet(null);
         if (endpoint != null) {
             endpoint.releaseAndDiscard();

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/HttpBenchmark.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/benchmark/HttpBenchmark.java
@@ -488,7 +488,7 @@ public class HttpBenchmark {
         final long endTime = System.currentTimeMillis();
 
         for (int i = 0; i < workers.length; i++) {
-            workers[i].releaseResources();
+            workers[i].close();
         }
 
         return new Results(

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/EchoHandler.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/EchoHandler.java
@@ -140,7 +140,7 @@ public class EchoHandler implements AsyncServerExchangeHandler {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
     }
 
 }

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
@@ -748,61 +748,70 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
         final Future<IOSession> sessionFuture = client.requestSession(
                 new HttpHost("localhost", serverEndpoint.getPort()), TIMEOUT, null);
         final IOSession ioSession = sessionFuture.get();
-        final ClientSessionEndpoint streamEndpoint = new ClientSessionEndpoint(ioSession);
+        try (final ClientSessionEndpoint streamEndpoint = new ClientSessionEndpoint(ioSession)) {
 
-        final HttpRequest request1 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
-        request1.addHeader("password", "secret");
-        final Future<Message<HttpResponse, String>> future1 = streamEndpoint.execute(
-                new BasicRequestProducer(request1, new MultiLineEntityProducer("0123456789abcdef", 1000)),
-                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
-        final Message<HttpResponse, String> result1 = future1.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
-        Assert.assertNotNull(result1);
-        final HttpResponse response1 = result1.getHead();
-        Assert.assertNotNull(response1);
-        Assert.assertEquals(200, response1.getCode());
-        Assert.assertNotNull("All is well", result1.getBody());
+            final HttpRequest request1 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
+            request1.addHeader("password", "secret");
+            // @formatter:off
+            final Future<Message<HttpResponse, String>> future1 = streamEndpoint.execute(
+                    new BasicRequestProducer(request1, new MultiLineEntityProducer("0123456789abcdef", 1000)),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
+            // @formatter:on
+            final Message<HttpResponse, String> result1 = future1.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assert.assertNotNull(result1);
+            final HttpResponse response1 = result1.getHead();
+            Assert.assertNotNull(response1);
+            Assert.assertEquals(200, response1.getCode());
+            Assert.assertNotNull("All is well", result1.getBody());
 
-        Assert.assertTrue(ioSession.isOpen());
+            Assert.assertTrue(ioSession.isOpen());
 
-        final HttpRequest request2 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
-        final Future<Message<HttpResponse, String>> future2 = streamEndpoint.execute(
-                new BasicRequestProducer(request2, new MultiLineEntityProducer("0123456789abcdef", 5000)),
-                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
-        final Message<HttpResponse, String> result2 = future2.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
-        Assert.assertNotNull(result2);
-        final HttpResponse response2 = result2.getHead();
-        Assert.assertNotNull(response2);
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response2.getCode());
-        Assert.assertNotNull("You shall not pass", result2.getBody());
+            final HttpRequest request2 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
+            // @formatter:off
+            final Future<Message<HttpResponse, String>> future2 = streamEndpoint.execute(
+                    new BasicRequestProducer(request2, new MultiLineEntityProducer("0123456789abcdef", 5000)),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
+            // @formatter:on
+            final Message<HttpResponse, String> result2 = future2.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assert.assertNotNull(result2);
+            final HttpResponse response2 = result2.getHead();
+            Assert.assertNotNull(response2);
+            Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response2.getCode());
+            Assert.assertNotNull("You shall not pass", result2.getBody());
 
-        Assert.assertTrue(ioSession.isOpen());
+            Assert.assertTrue(ioSession.isOpen());
 
-        final HttpRequest request3 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
-        request3.addHeader("password", "secret");
-        final Future<Message<HttpResponse, String>> future3 = streamEndpoint.execute(
-                new BasicRequestProducer(request3, new MultiLineEntityProducer("0123456789abcdef", 1000)),
-                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
-        final Message<HttpResponse, String> result3 = future3.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
-        Assert.assertNotNull(result3);
-        final HttpResponse response3 = result3.getHead();
-        Assert.assertNotNull(response3);
-        Assert.assertEquals(200, response3.getCode());
-        Assert.assertNotNull("All is well", result3.getBody());
+            final HttpRequest request3 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
+            request3.addHeader("password", "secret");
+            // @formatter:off
+            final Future<Message<HttpResponse, String>> future3 = streamEndpoint.execute(
+                    new BasicRequestProducer(request3, new MultiLineEntityProducer("0123456789abcdef", 1000)),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
+            // @formatter:on
+            final Message<HttpResponse, String> result3 = future3.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assert.assertNotNull(result3);
+            final HttpResponse response3 = result3.getHead();
+            Assert.assertNotNull(response3);
+            Assert.assertEquals(200, response3.getCode());
+            Assert.assertNotNull("All is well", result3.getBody());
 
-        Assert.assertTrue(ioSession.isOpen());
+            Assert.assertTrue(ioSession.isOpen());
 
-        final HttpRequest request4 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
-        final Future<Message<HttpResponse, String>> future4 = streamEndpoint.execute(
-                new BasicRequestProducer(request4, AsyncEntityProducers.create("blah")),
-                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
-        final Message<HttpResponse, String> result4 = future4.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
-        Assert.assertNotNull(result4);
-        final HttpResponse response4 = result4.getHead();
-        Assert.assertNotNull(response4);
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response4.getCode());
-        Assert.assertNotNull("You shall not pass", result4.getBody());
+            final HttpRequest request4 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
+            // @formatter:off
+            final Future<Message<HttpResponse, String>> future4 = streamEndpoint.execute(
+                    new BasicRequestProducer(request4, AsyncEntityProducers.create("blah")),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
+            // @formatter:on
+            final Message<HttpResponse, String> result4 = future4.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assert.assertNotNull(result4);
+            final HttpResponse response4 = result4.getHead();
+            Assert.assertNotNull(response4);
+            Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response4.getCode());
+            Assert.assertNotNull("You shall not pass", result4.getBody());
 
-        Assert.assertFalse(ioSession.isOpen());
+            Assert.assertFalse(ioSession.isOpen());
+        }
     }
 
     @Test
@@ -837,23 +846,26 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
         final Future<IOSession> sessionFuture = client.requestSession(
                 new HttpHost("localhost", serverEndpoint.getPort()), TIMEOUT, null);
         final IOSession ioSession = sessionFuture.get();
-        final ClientSessionEndpoint streamEndpoint = new ClientSessionEndpoint(ioSession);
+        try (final ClientSessionEndpoint streamEndpoint = new ClientSessionEndpoint(ioSession)) {
 
-        final HttpRequest request1 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
-        final Future<Message<HttpResponse, String>> future1 = streamEndpoint.execute(
-                new BasicRequestProducer(request1, new MultiBinEntityProducer(
-                        new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'},
-                        100000,
-                        ContentType.TEXT_PLAIN)),
-                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
-        final Message<HttpResponse, String> result1 = future1.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
-        Assert.assertNotNull(result1);
-        final HttpResponse response1 = result1.getHead();
-        Assert.assertNotNull(response1);
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response1.getCode());
-        Assert.assertNotNull("You shall not pass", result1.getBody());
+            final HttpRequest request1 = new BasicHttpRequest(Method.POST, createRequestURI(serverEndpoint, "/echo"));
+            // @formatter:off
+            final Future<Message<HttpResponse, String>> future1 = streamEndpoint.execute(
+                    new BasicRequestProducer(request1, new MultiBinEntityProducer(
+                            new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'},
+                            100000,
+                            ContentType.TEXT_PLAIN)),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
+            // @formatter:on
+            final Message<HttpResponse, String> result1 = future1.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assert.assertNotNull(result1);
+            final HttpResponse response1 = result1.getHead();
+            Assert.assertNotNull(response1);
+            Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response1.getCode());
+            Assert.assertNotNull("You shall not pass", result1.getBody());
 
-        Assert.assertFalse(streamEndpoint.isOpen());
+            Assert.assertFalse(streamEndpoint.isOpen());
+        }
     }
 
     @Test
@@ -923,7 +935,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
             }
 
             @Override
-            public void releaseResources() {
+            public void close() {
             }
 
         });
@@ -1005,7 +1017,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
             }
 
             @Override
-            public void releaseResources() {
+            public void close() {
             }
         });
         final InetSocketAddress serverEndpoint = server.start();
@@ -1446,7 +1458,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
         final StringAsyncEntityConsumer entityConsumer = new StringAsyncEntityConsumer() {
 
             @Override
-            public void releaseResources() {
+            public void close() {
                 // Do not clear internal content buffer
             }
 
@@ -1641,8 +1653,8 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
             private final StringAsyncEntityProducer entityProducer = new StringAsyncEntityProducer("Everyting is OK");
 
             @Override
-            public void releaseResources() {
-                entityProducer.releaseResources();
+            public void close() {
+                entityProducer.close();
             }
 
             @Override
@@ -1684,7 +1696,7 @@ public class Http1IntegrationTest extends InternalHttp1ServerTestBase {
 
             @Override
             public void failed(final Exception cause) {
-                releaseResources();
+                close();
             }
 
         });

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiBinEntityProducer.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiBinEntityProducer.java
@@ -90,10 +90,10 @@ public class MultiBinEntityProducer extends AbstractBinAsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         count = 0;
         bytebuf.clear();
-        super.releaseResources();
+        super.close();
     }
 
 }

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiLineEntityProducer.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiLineEntityProducer.java
@@ -86,10 +86,10 @@ public class MultiLineEntityProducer extends AbstractCharAsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         count = 0;
         charbuf.clear();
-        super.releaseResources();
+        super.close();
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
@@ -297,9 +297,9 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
                         endpoint.execute(new AsyncClientExchangeHandler() {
 
                             @Override
-                            public void releaseResources() {
+                            public void close() {
                                 endpoint.releaseAndDiscard();
-                                exchangeHandler.releaseResources();
+                                exchangeHandler.close();
                             }
 
                             @Override
@@ -487,7 +487,7 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
                 try {
                     exchangeHandler.failed(new ConnectionClosedException());
                 } finally {
-                    exchangeHandler.releaseResources();
+                    exchangeHandler.close();
                 }
             }
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
@@ -179,19 +179,19 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     void terminate(final Exception exception) {
         if (incoming != null) {
             incoming.failed(exception);
-            incoming.releaseResources();
+            incoming.close();
             incoming = null;
         }
         if (outgoing != null) {
             outgoing.failed(exception);
-            outgoing.releaseResources();
+            outgoing.close();
             outgoing = null;
         }
         for (;;) {
             final ClientHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
                 handler.failed(exception);
-                handler.releaseResources();
+                handler.close();
             } else {
                 break;
             }
@@ -204,21 +204,21 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             if (!incoming.isCompleted()) {
                 incoming.failed(new ConnectionClosedException());
             }
-            incoming.releaseResources();
+            incoming.close();
             incoming = null;
         }
         if (outgoing != null) {
             if (!outgoing.isCompleted()) {
                 outgoing.failed(new ConnectionClosedException());
             }
-            outgoing.releaseResources();
+            outgoing.close();
             outgoing = null;
         }
         for (;;) {
             final ClientHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
                 handler.failed(new ConnectionClosedException());
-                handler.releaseResources();
+                handler.close();
             } else {
                 break;
             }
@@ -300,7 +300,7 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     void outputEnd() throws HttpException, IOException {
         if (outgoing != null) {
             if (outgoing.isCompleted()) {
-                outgoing.releaseResources();
+                outgoing.close();
             }
             outgoing = null;
         }
@@ -373,7 +373,7 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
                 streamListener.onExchangeComplete(this, isOpen());
             }
             if (incoming.isCompleted()) {
-                incoming.releaseResources();
+                incoming.close();
             }
             incoming = null;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamHandler.java
@@ -287,11 +287,11 @@ class ClientHttp1StreamHandler implements ResourceHolder {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (done.compareAndSet(false, true)) {
             responseState = MessageState.COMPLETE;
             requestState = MessageState.COMPLETE;
-            exchangeHandler.releaseResources();
+            exchangeHandler.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
@@ -190,19 +190,19 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     void terminate(final Exception exception) {
         if (incoming != null) {
             incoming.failed(exception);
-            incoming.releaseResources();
+            incoming.close();
             incoming = null;
         }
         if (outgoing != null) {
             outgoing.failed(exception);
-            outgoing.releaseResources();
+            outgoing.close();
             outgoing = null;
         }
         for (;;) {
             final ServerHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
                 handler.failed(exception);
-                handler.releaseResources();
+                handler.close();
             } else {
                 break;
             }
@@ -215,21 +215,21 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             if (!incoming.isCompleted()) {
                 incoming.failed(new ConnectionClosedException());
             }
-            incoming.releaseResources();
+            incoming.close();
             incoming = null;
         }
         if (outgoing != null) {
             if (!outgoing.isCompleted()) {
                 outgoing.failed(new ConnectionClosedException());
             }
-            outgoing.releaseResources();
+            outgoing.close();
             outgoing = null;
         }
         for (;;) {
             final ServerHttp1StreamHandler handler = pipeline.poll();
             if (handler != null) {
                 handler.failed(new ConnectionClosedException());
-                handler.releaseResources();
+                handler.close();
             } else {
                 break;
             }
@@ -389,7 +389,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     void inputEnd() throws HttpException, IOException {
         if (incoming != null) {
             if (incoming.isCompleted()) {
-                incoming.releaseResources();
+                incoming.close();
             }
             incoming = null;
         }
@@ -422,7 +422,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
                 streamListener.onExchangeComplete(this, outgoing.keepAlive());
             }
             if (outgoing.isCompleted()) {
-                outgoing.releaseResources();
+                outgoing.close();
             }
             outgoing = null;
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
@@ -329,11 +329,11 @@ class ServerHttp1StreamHandler implements ResourceHolder {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (done.compareAndSet(false, true)) {
             requestState = MessageState.COMPLETE;
             responseState = MessageState.COMPLETE;
-            exchangeHandler.releaseResources();
+            exchangeHandler.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncEntityProducer.java
@@ -37,7 +37,7 @@ public interface AsyncEntityProducer extends AsyncDataProducer, EntityDetails {
 
     /**
      * Determines whether the producer can consistently produce the same content
-     * after invocation of {@link ResourceHolder#releaseResources()}.
+     * after invocation of {@link ResourceHolder#close()}.
      */
     boolean isRepeatable();
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncRequestProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/AsyncRequestProducer.java
@@ -51,7 +51,7 @@ public interface AsyncRequestProducer extends AsyncDataProducer {
 
     /**
      * Determines whether the producer can consistently produce the same content
-     * after invocation of {@link ResourceHolder#releaseResources()}.
+     * after invocation of {@link ResourceHolder#close()}.
      */
     boolean isRepeatable();
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ResourceHolder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/ResourceHolder.java
@@ -40,10 +40,29 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
  * </p>
  *
  * @since 5.0
+ * @since 5.2 extends AutoCloseable. This interface could go away in a future major release.
  */
 @Contract(threading = ThreadingBehavior.SAFE)
-public interface ResourceHolder {
+public interface ResourceHolder extends AutoCloseable {
 
-    void releaseResources();
+    /**
+     * Closes this resource. The default implementation calls {@link #releaseResources()}.
+     *
+     * @since 5.2
+     */
+    @Override
+    default void close() {
+        releaseResources();
+    }
+
+    /**
+     * Releases resources. The default implementation does nothing.
+     *
+     * @deprecated Use {@link #close()}.
+     */
+    @Deprecated
+    default void releaseResources() {
+        // do nothing
+    }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/CommandSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/CommandSupport.java
@@ -54,7 +54,7 @@ public final class CommandSupport {
                 try {
                     exchangeHandler.failed(ex);
                 } finally {
-                    exchangeHandler.releaseResources();
+                    exchangeHandler.close();
                 }
             } else {
                 command.cancel();
@@ -78,7 +78,7 @@ public final class CommandSupport {
                         exchangeHandler.cancel();
                     }
                 } finally {
-                    exchangeHandler.releaseResources();
+                    exchangeHandler.close();
                 }
             } else {
                 command.cancel();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/RequestExecutionCommand.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/command/RequestExecutionCommand.java
@@ -94,7 +94,7 @@ public final class RequestExecutionCommand extends ExecutableCommand {
         try {
             exchangeHandler.failed(ex);
         } finally {
-            exchangeHandler.releaseResources();
+            exchangeHandler.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityConsumer.java
@@ -83,7 +83,7 @@ public abstract class AbstractBinAsyncEntityConsumer<T> extends AbstractBinDataC
         if (resultCallback != null) {
             resultCallback.completed(content);
         }
-        releaseResources();
+        close();
     }
 
     @Override
@@ -91,7 +91,7 @@ public abstract class AbstractBinAsyncEntityConsumer<T> extends AbstractBinDataC
         if (resultCallback != null) {
             resultCallback.failed(cause);
         }
-        releaseResources();
+        close();
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractBinAsyncEntityProducer.java
@@ -203,7 +203,7 @@ public abstract class AbstractBinAsyncEntityProducer implements AsyncEntityProdu
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         state = State.ACTIVE;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityConsumer.java
@@ -92,7 +92,7 @@ public abstract class AbstractCharAsyncEntityConsumer<T> extends AbstractCharDat
         if (resultCallback != null) {
             resultCallback.completed(content);
         }
-        releaseResources();
+        close();
     }
 
     @Override
@@ -100,7 +100,7 @@ public abstract class AbstractCharAsyncEntityConsumer<T> extends AbstractCharDat
         if (resultCallback != null) {
             resultCallback.failed(cause);
         }
-        releaseResources();
+        close();
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityProducer.java
@@ -230,7 +230,7 @@ public abstract class AbstractCharAsyncEntityProducer implements AsyncEntityProd
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         state = State.ACTIVE;
         charsetEncoder.reset();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AsyncEntityProducerWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AsyncEntityProducerWrapper.java
@@ -99,8 +99,8 @@ public class AsyncEntityProducerWrapper implements AsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
-        wrappedEntityProducer.releaseResources();
+    public void close() {
+        wrappedEntityProducer.close();
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityConsumer.java
@@ -69,7 +69,7 @@ public class BasicAsyncEntityConsumer extends AbstractBinAsyncEntityConsumer<byt
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         buffer.clear();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
@@ -139,7 +139,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     @Override
     public final void failed(final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
-            releaseResources();
+            close();
         }
     }
 
@@ -148,7 +148,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         bytebuf.clear();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityConsumer.java
@@ -104,8 +104,8 @@ public class DigestingEntityConsumer<T> implements AsyncEntityConsumer<T> {
     }
 
     @Override
-    public void releaseResources() {
-        wrapped.releaseResources();
+    public void close() {
+        wrapped.close();
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DigestingEntityProducer.java
@@ -154,8 +154,8 @@ public class DigestingEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
-        wrapped.releaseResources();
+    public void close() {
+        wrapped.close();
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DiscardingEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/DiscardingEntityConsumer.java
@@ -81,8 +81,4 @@ public final class DiscardingEntityConsumer<T> implements AsyncEntityConsumer<T>
         return null;
     }
 
-    @Override
-    public void releaseResources() {
-    }
-
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/FileEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/FileEntityProducer.java
@@ -135,14 +135,14 @@ public final class FileEntityProducer implements AsyncEntityProducer {
         }
         if (eof && byteBuffer.position() == 0) {
             channel.endStream();
-            releaseResources();
+            close();
         }
     }
 
     @Override
     public void failed(final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
-            releaseResources();
+            close();
         }
     }
 
@@ -151,7 +151,7 @@ public final class FileEntityProducer implements AsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         eof = false;
         Closer.closeQuietly(accessFileRef.getAndSet(null));
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/NoopEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/NoopEntityConsumer.java
@@ -85,7 +85,7 @@ public final class NoopEntityConsumer implements AsyncEntityConsumer<Void> {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/PathEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/PathEntityProducer.java
@@ -94,7 +94,7 @@ public final class PathEntityProducer implements AsyncEntityProducer {
     @Override
     public void failed(final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
-            releaseResources();
+            close();
         }
     }
 
@@ -152,12 +152,12 @@ public final class PathEntityProducer implements AsyncEntityProducer {
         }
         if (eof && byteBuffer.position() == 0) {
             dataStreamChannel.endStream();
-            releaseResources();
+            close();
         }
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         eof = false;
         Closer.closeQuietly(channelRef.getAndSet(null));
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityConsumer.java
@@ -88,7 +88,7 @@ public class StringAsyncEntityConsumer extends AbstractCharAsyncEntityConsumer<S
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         content.clear();
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
@@ -91,7 +91,7 @@ public class StringAsyncEntityProducer extends AbstractCharAsyncEntityProducer {
     @Override
     public void failed(final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
-            releaseResources();
+            close();
         }
     }
 
@@ -100,9 +100,21 @@ public class StringAsyncEntityProducer extends AbstractCharAsyncEntityProducer {
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         this.content.clear();
-        super.releaseResources();
+        super.close();
+    }
+
+    /**
+     * Deprecated, use {@link #close()}.
+     *
+     * @deprecated use {@link #close()}.
+     */
+    @Deprecated
+    @Override
+    // JApicmp can't handle default this method use case? releaseResources() was abstract, now is default.
+    public void releaseResources() {
+        close();
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncPushHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncPushHandler.java
@@ -95,12 +95,12 @@ public abstract class AbstractAsyncPushHandler<T> implements AsyncPushConsumer {
             @Override
             public void failed(final Exception cause) {
                 handleError(promise, cause);
-                releaseResources();
+                close();
             }
 
             @Override
             public void cancelled() {
-                releaseResources();
+                close();
             }
 
         });
@@ -124,13 +124,13 @@ public abstract class AbstractAsyncPushHandler<T> implements AsyncPushConsumer {
     @Override
     public final void failed(final Exception cause) {
         responseConsumer.failed(cause);
-        releaseResources();
+        close();
     }
 
     @Override
-    public final void releaseResources() {
+    public final void close() {
         if (responseConsumer != null) {
-            responseConsumer.releaseResources();
+            responseConsumer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncRequesterConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncRequesterConsumer.java
@@ -130,14 +130,14 @@ public abstract class AbstractAsyncRequesterConsumer<T, E> implements AsyncReque
 
     @Override
     public final void failed(final Exception cause) {
-        releaseResources();
+        close();
     }
 
     @Override
-    public final void releaseResources() {
+    public final void close() {
         final AsyncEntityConsumer<E> dataConsumer = dataConsumerRef.getAndSet(null);
         if (dataConsumer != null) {
-            dataConsumer.releaseResources();
+            dataConsumer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncResponseConsumer.java
@@ -145,14 +145,14 @@ public abstract class AbstractAsyncResponseConsumer<T, E> implements AsyncRespon
 
     @Override
     public final void failed(final Exception cause) {
-        releaseResources();
+        close();
     }
 
     @Override
-    public final void releaseResources() {
+    public final void close() {
         final AsyncEntityConsumer<E> dataConsumer = dataConsumerRef.getAndSet(null);
         if (dataConsumer != null) {
-            dataConsumer.releaseResources();
+            dataConsumer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncServerAuthFilter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractAsyncServerAuthFilter.java
@@ -160,9 +160,9 @@ public abstract class AbstractAsyncServerAuthFilter<T> implements AsyncFilterHan
             }
 
             @Override
-            public void releaseResources() {
+            public void close() {
                 if (responseContentProducer != null) {
-                    responseContentProducer.releaseResources();
+                    responseContentProducer.close();
                 }
             }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractServerExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AbstractServerExchangeHandler.java
@@ -158,7 +158,7 @@ public abstract class AbstractServerExchangeHandler<T> implements AsyncServerExc
 
             @Override
             public void cancelled() {
-                releaseResources();
+                close();
             }
 
         });
@@ -211,20 +211,32 @@ public abstract class AbstractServerExchangeHandler<T> implements AsyncServerExc
                 dataProducer.failed(cause);
             }
         } finally {
-            releaseResources();
+            close();
         }
     }
 
     @Override
-    public final void releaseResources() {
+    public final void close() {
         final AsyncRequestConsumer<T> requestConsumer = requestConsumerRef.getAndSet(null);
         if (requestConsumer != null) {
-            requestConsumer.releaseResources();
+            requestConsumer.close();
         }
         final AsyncResponseProducer dataProducer = responseProducerRef.getAndSet(null);
         if (dataProducer != null) {
-            dataProducer.releaseResources();
+            dataProducer.close();
         }
+    }
+
+    /**
+     * Deprecated, use {@link #close()}.
+     *
+     * @deprecated use {@link #close()}.
+     */
+    @Deprecated
+    @Override
+    // JApicmp can't handle default this method use case? releaseResources() was abstract, now is default.
+    public final void releaseResources() {
+        close();
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncServerFilterChainExchangeHandlerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncServerFilterChainExchangeHandlerFactory.java
@@ -163,14 +163,14 @@ public final class AsyncServerFilterChainExchangeHandlerFactory implements Handl
             }
 
             @Override
-            public void releaseResources() {
+            public void close() {
                 final AsyncDataConsumer dataConsumer = dataConsumerRef.getAndSet(null);
                 if (dataConsumer != null) {
-                    dataConsumer.releaseResources();
+                    dataConsumer.close();
                 }
                 final AsyncResponseProducer responseProducer = responseProducerRef.getAndSet(null);
                 if (responseProducer != null) {
-                    responseProducer.releaseResources();
+                    responseProducer.close();
                 }
             }
         };

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicAsyncServerExpectationDecorator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicAsyncServerExpectationDecorator.java
@@ -155,11 +155,11 @@ public class BasicAsyncServerExpectationDecorator implements AsyncServerExchange
     }
 
     @Override
-    public final void releaseResources() {
-        handler.releaseResources();
+    public final void close() {
+        handler.close();
         final AsyncResponseProducer dataProducer = responseProducerRef.getAndSet(null);
         if (dataProducer != null) {
-            dataProducer.releaseResources();
+            dataProducer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicClientExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicClientExchangeHandler.java
@@ -100,7 +100,7 @@ public final class BasicClientExchangeHandler<T> implements AsyncClientExchangeH
     public void consumeResponse(final HttpResponse response, final EntityDetails entityDetails, final HttpContext httpContext) throws HttpException, IOException {
         if (response.getCode() >= HttpStatus.SC_CLIENT_ERROR) {
             outputTerminated.set(true);
-            requestProducer.releaseResources();
+            requestProducer.close();
         }
         responseConsumer.consumeResponse(response, entityDetails, httpContext, new FutureCallback<T>() {
 
@@ -193,12 +193,12 @@ public final class BasicClientExchangeHandler<T> implements AsyncClientExchangeH
     }
 
     private void internalReleaseResources() {
-        requestProducer.releaseResources();
-        responseConsumer.releaseResources();
+        requestProducer.close();
+        responseConsumer.close();
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicPushProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicPushProducer.java
@@ -82,13 +82,13 @@ public class BasicPushProducer implements AsyncPushProducer {
 
     @Override
     public void failed(final Exception cause) {
-        releaseResources();
+        close();
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (dataProducer != null) {
-            dataProducer.releaseResources();
+            dataProducer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicRequestConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicRequestConsumer.java
@@ -118,14 +118,14 @@ public class BasicRequestConsumer<T> implements AsyncRequestConsumer<Message<Htt
 
     @Override
     public void failed(final Exception cause) {
-        releaseResources();
+        close();
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         final AsyncEntityConsumer<T> dataConsumer = dataConsumerRef.getAndSet(null);
         if (dataConsumer != null) {
-            dataConsumer.releaseResources();
+            dataConsumer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicRequestProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicRequestProducer.java
@@ -117,14 +117,14 @@ public class BasicRequestProducer implements AsyncRequestProducer {
                 dataProducer.failed(cause);
             }
         } finally {
-            releaseResources();
+            close();
         }
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (dataProducer != null) {
-            dataProducer.releaseResources();
+            dataProducer.close();
         }
     }
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseConsumer.java
@@ -126,14 +126,14 @@ public class BasicResponseConsumer<T> implements AsyncResponseConsumer<Message<H
         if (dataConsumer != null) {
             dataConsumer.failed(cause);
         }
-        releaseResources();
+        close();
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         final AsyncEntityConsumer<T> dataConsumer = dataConsumerRef.getAndSet(null);
         if (dataConsumer != null) {
-            dataConsumer.releaseResources();
+            dataConsumer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/BasicResponseProducer.java
@@ -108,13 +108,13 @@ public class BasicResponseProducer implements AsyncResponseProducer {
         if (dataProducer != null) {
             dataProducer.failed(cause);
         }
-        releaseResources();
+        close();
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
         if (dataProducer != null) {
-            dataProducer.releaseResources();
+            dataProducer.close();
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/ImmediateResponseExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/ImmediateResponseExchangeHandler.java
@@ -103,12 +103,12 @@ public final class ImmediateResponseExchangeHandler implements AsyncServerExchan
     @Override
     public void failed(final Exception cause) {
         responseProducer.failed(cause);
-        releaseResources();
+        close();
     }
 
     @Override
-    public void releaseResources() {
-        responseProducer.releaseResources();
+    public void close() {
+        responseProducer.close();
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/TerminalAsyncServerFilter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/TerminalAsyncServerFilter.java
@@ -132,8 +132,8 @@ public final class TerminalAsyncServerFilter implements AsyncFilterHandler {
                         }
 
                         @Override
-                        public void releaseResources() {
-                            exchangeHandler.releaseResources();
+                        public void close() {
+                            exchangeHandler.close();
                         }
 
                     } : null);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityConsumer.java
@@ -122,7 +122,7 @@ public abstract class AbstractClassicEntityConsumer<T> implements AsyncEntityCon
     @Override
     public final void failed(final Exception cause) {
         if (exceptionRef.compareAndSet(null, cause)) {
-            releaseResources();
+            close();
         }
     }
 
@@ -136,7 +136,7 @@ public abstract class AbstractClassicEntityConsumer<T> implements AsyncEntityCon
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicEntityProducer.java
@@ -125,7 +125,7 @@ public abstract class AbstractClassicEntityProducer implements AsyncEntityProduc
     @Override
     public final void failed(final Exception cause) {
         if (exception.compareAndSet(null, cause)) {
-            releaseResources();
+            close();
         }
     }
 
@@ -134,7 +134,7 @@ public abstract class AbstractClassicEntityProducer implements AsyncEntityProduc
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicServerExchangeHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/AbstractClassicServerExchangeHandler.java
@@ -284,11 +284,11 @@ public abstract class AbstractClassicServerExchangeHandler implements AsyncServe
     @Override
     public final void failed(final Exception cause) {
         exception.compareAndSet(null, cause);
-        releaseResources();
+        close();
     }
 
     @Override
-    public void releaseResources() {
+    public void close() {
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexClientExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexClientExample.java
@@ -119,9 +119,9 @@ public class AsyncFullDuplexClientExample {
         requester.execute(new AsyncClientExchangeHandler() {
 
             @Override
-            public void releaseResources() {
-                requestProducer.releaseResources();
-                responseConsumer.releaseResources();
+            public void close() {
+                requestProducer.close();
+                responseConsumer.close();
                 latch.countDown();
             }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexServerExample.java
@@ -194,7 +194,7 @@ public class AsyncFullDuplexServerExample {
                     }
 
                     @Override
-                    public void releaseResources() {
+                    public void close() {
                     }
 
                 })

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
@@ -436,7 +436,7 @@ public class AsyncReverseProxyExample {
         }
 
         @Override
-        public void releaseResources() {
+        public void close() {
             synchronized (exchangeState) {
                 exchangeState.responseMessageChannel = null;
                 exchangeState.responseDataChannel = null;
@@ -669,7 +669,7 @@ public class AsyncReverseProxyExample {
         }
 
         @Override
-        public void releaseResources() {
+        public void close() {
             synchronized (exchangeState) {
                 exchangeState.requestDataChannel = null;
                 exchangeState.responseCapacityChannel = null;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
@@ -43,15 +43,16 @@ public class TestHttpEntityWrapper {
     @Test
     public void testBasics() throws Exception {
         final StringEntity entity = new StringEntity("Message content", ContentType.TEXT_PLAIN, "blah", false);
-        final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity);
+        try (final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity)) {
 
-        Assert.assertEquals(entity.getContentLength(), wrapped.getContentLength());
-        Assert.assertEquals(entity.getContentType(), wrapped.getContentType());
-        Assert.assertEquals(entity.getContentEncoding(), wrapped.getContentEncoding());
-        Assert.assertEquals(entity.isChunked(), wrapped.isChunked());
-        Assert.assertEquals(entity.isRepeatable(), wrapped.isRepeatable());
-        Assert.assertEquals(entity.isStreaming(), wrapped.isStreaming());
-        Assert.assertNotNull(wrapped.getContent());
+            Assert.assertEquals(entity.getContentLength(), wrapped.getContentLength());
+            Assert.assertEquals(entity.getContentType(), wrapped.getContentType());
+            Assert.assertEquals(entity.getContentEncoding(), wrapped.getContentEncoding());
+            Assert.assertEquals(entity.isChunked(), wrapped.isChunked());
+            Assert.assertEquals(entity.isRepeatable(), wrapped.isRepeatable());
+            Assert.assertEquals(entity.isStreaming(), wrapped.isStreaming());
+            Assert.assertNotNull(wrapped.getContent());
+        }
     }
 
     @Test
@@ -64,27 +65,28 @@ public class TestHttpEntityWrapper {
         final String s = "Message content";
         final byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
         final StringEntity entity = new StringEntity(s);
-        final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity);
+        try (final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity)) {
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        wrapped.writeTo(out);
-        byte[] bytes2 = out.toByteArray();
-        Assert.assertNotNull(bytes2);
-        Assert.assertEquals(bytes.length, bytes2.length);
-        for (int i = 0; i < bytes.length; i++) {
-            Assert.assertEquals(bytes[i], bytes2[i]);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            wrapped.writeTo(out);
+            byte[] bytes2 = out.toByteArray();
+            Assert.assertNotNull(bytes2);
+            Assert.assertEquals(bytes.length, bytes2.length);
+            for (int i = 0; i < bytes.length; i++) {
+                Assert.assertEquals(bytes[i], bytes2[i]);
+            }
+
+            out = new ByteArrayOutputStream();
+            wrapped.writeTo(out);
+            bytes2 = out.toByteArray();
+            Assert.assertNotNull(bytes2);
+            Assert.assertEquals(bytes.length, bytes2.length);
+            for (int i = 0; i < bytes.length; i++) {
+                Assert.assertEquals(bytes[i], bytes2[i]);
+            }
+
+            Assert.assertThrows(NullPointerException.class, () -> wrapped.writeTo(null));
         }
-
-        out = new ByteArrayOutputStream();
-        wrapped.writeTo(out);
-        bytes2 = out.toByteArray();
-        Assert.assertNotNull(bytes2);
-        Assert.assertEquals(bytes.length, bytes2.length);
-        for (int i = 0; i < bytes.length; i++) {
-            Assert.assertEquals(bytes[i], bytes2[i]);
-        }
-
-        Assert.assertThrows(NullPointerException.class, () -> wrapped.writeTo(null));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityConsumer.java
@@ -71,7 +71,7 @@ public class TestAbstractBinAsyncEntityConsumer {
         }
 
         @Override
-        public void releaseResources() {
+        public void close() {
         }
 
     }
@@ -79,37 +79,39 @@ public class TestAbstractBinAsyncEntityConsumer {
     @Test
     public void testConsumeData() throws Exception {
 
-        final AsyncEntityConsumer<byte[]> consumer = new ByteArrayAsyncEntityConsumer();
+        try (final AsyncEntityConsumer<byte[]> consumer = new ByteArrayAsyncEntityConsumer()) {
 
-        final AtomicLong count = new AtomicLong(0);
-        consumer.streamStart(new BasicEntityDetails(-1, ContentType.APPLICATION_OCTET_STREAM), new FutureCallback<byte[]>() {
+            final AtomicLong count = new AtomicLong(0);
+            consumer.streamStart(new BasicEntityDetails(-1, ContentType.APPLICATION_OCTET_STREAM),
+                    new FutureCallback<byte[]>() {
 
-            @Override
-            public void completed(final byte[] result) {
-                count.incrementAndGet();
-            }
+                        @Override
+                        public void completed(final byte[] result) {
+                            count.incrementAndGet();
+                        }
 
-            @Override
-            public void failed(final Exception ex) {
-                count.incrementAndGet();
-            }
+                        @Override
+                        public void failed(final Exception ex) {
+                            count.incrementAndGet();
+                        }
 
-            @Override
-            public void cancelled() {
-                count.incrementAndGet();
-            }
+                        @Override
+                        public void cancelled() {
+                            count.incrementAndGet();
+                        }
 
-        });
+                    });
 
-        consumer.consume(ByteBuffer.wrap(new byte[]{'1', '2', '3'}));
-        consumer.consume(ByteBuffer.wrap(new byte[]{'4', '5'}));
-        consumer.consume(ByteBuffer.wrap(new byte[]{}));
+            consumer.consume(ByteBuffer.wrap(new byte[] { '1', '2', '3' }));
+            consumer.consume(ByteBuffer.wrap(new byte[] { '4', '5' }));
+            consumer.consume(ByteBuffer.wrap(new byte[] {}));
 
-        Assert.assertNull(consumer.getContent());
-        consumer.streamEnd(null);
+            Assert.assertNull(consumer.getContent());
+            consumer.streamEnd(null);
 
-        Assert.assertArrayEquals(new byte[] {'1', '2', '3', '4', '5'}, consumer.getContent());
-        Assert.assertEquals(1L, count.longValue());
+            Assert.assertArrayEquals(new byte[] { '1', '2', '3', '4', '5' }, consumer.getContent());
+            Assert.assertEquals(1L, count.longValue());
+        }
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityProducer.java
@@ -85,63 +85,65 @@ public class TestAbstractBinAsyncEntityProducer {
     @Test
     public void testProduceDataNoBuffering() throws Exception {
 
-        final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
+        try (final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
                 0, ContentType.TEXT_PLAIN,
                 new byte[] { '1', '2', '3' },
-                new byte[] { '4', '5', '6' });
+                new byte[] { '4', '5', '6' })) {
 
-        Assert.assertEquals(-1, producer.getContentLength());
-        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(-1, producer.getContentLength());
+            Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("123", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("123", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("456", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("456", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
     public void testProduceDataWithBuffering1() throws Exception {
 
-        final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
+        try (final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
                 5, ContentType.TEXT_PLAIN,
                 new byte[] { '1', '2', '3' },
                 new byte[] { '4', '5', '6' },
                 new byte[] { '7', '8' },
-                new byte[] { '9', '0' });
+                new byte[] { '9', '0' })) {
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("123", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("123", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("45678", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("45678", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("90", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("90", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
     public void testProduceDataWithBuffering2() throws Exception {
 
-        final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
+        try (final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
                 5, ContentType.TEXT_PLAIN,
                 new byte[] { '1' },
                 new byte[] { '2' },
@@ -149,39 +151,40 @@ public class TestAbstractBinAsyncEntityProducer {
                 new byte[] { '4', '5' },
                 new byte[] { '6' },
                 new byte[] { '7', '8' },
-                new byte[] { '9', '0' });
+                new byte[] { '9', '0' })) {
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("12345", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("12345", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("67890", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("67890", byteChannel.dump(StandardCharsets.US_ASCII));
 
+        }
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityConsumer.java
@@ -71,7 +71,7 @@ public class TestAbstractCharAsyncEntityConsumer {
         }
 
         @Override
-        public void releaseResources() {
+        public void close() {
             buffer.setLength(0);
         }
 
@@ -80,37 +80,38 @@ public class TestAbstractCharAsyncEntityConsumer {
     @Test
     public void testConsumeData() throws Exception {
 
-        final AsyncEntityConsumer<String> consumer = new StringBuilderAsyncEntityConsumer();
+        try (final AsyncEntityConsumer<String> consumer = new StringBuilderAsyncEntityConsumer()) {
 
-        final AtomicLong count = new AtomicLong(0);
-        consumer.streamStart(new BasicEntityDetails(-1, ContentType.TEXT_PLAIN), new FutureCallback<String>() {
+            final AtomicLong count = new AtomicLong(0);
+            consumer.streamStart(new BasicEntityDetails(-1, ContentType.TEXT_PLAIN), new FutureCallback<String>() {
 
-            @Override
-            public void completed(final String result) {
-                count.incrementAndGet();
-            }
+                @Override
+                public void completed(final String result) {
+                    count.incrementAndGet();
+                }
 
-            @Override
-            public void failed(final Exception ex) {
-                count.incrementAndGet();
-            }
+                @Override
+                public void failed(final Exception ex) {
+                    count.incrementAndGet();
+                }
 
-            @Override
-            public void cancelled() {
-                count.incrementAndGet();
-            }
+                @Override
+                public void cancelled() {
+                    count.incrementAndGet();
+                }
 
-        });
+            });
 
-        consumer.consume(ByteBuffer.wrap(new byte[]{'1', '2', '3'}));
-        consumer.consume(ByteBuffer.wrap(new byte[]{'4', '5'}));
-        consumer.consume(ByteBuffer.wrap(new byte[]{}));
+            consumer.consume(ByteBuffer.wrap(new byte[] { '1', '2', '3' }));
+            consumer.consume(ByteBuffer.wrap(new byte[] { '4', '5' }));
+            consumer.consume(ByteBuffer.wrap(new byte[] {}));
 
-        Assert.assertNull(consumer.getContent());
-        consumer.streamEnd(null);
+            Assert.assertNull(consumer.getContent());
+            consumer.streamEnd(null);
 
-        Assert.assertEquals("12345", consumer.getContent());
-        Assert.assertEquals(1L, count.longValue());
+            Assert.assertEquals("12345", consumer.getContent());
+            Assert.assertEquals(1L, count.longValue());
+        }
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityProducer.java
@@ -86,51 +86,53 @@ public class TestAbstractCharAsyncEntityProducer {
     @Test
     public void testProduceDataNoBuffering() throws Exception {
 
-        final AsyncEntityProducer producer = new ChunkCharAsyncEntityProducer(
-                256, 0, ContentType.TEXT_PLAIN, "this", "this and that");
+        try (final AsyncEntityProducer producer = new ChunkCharAsyncEntityProducer(
+                256, 0, ContentType.TEXT_PLAIN, "this", "this and that")) {
 
-        Assert.assertEquals(-1, producer.getContentLength());
-        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(-1, producer.getContentLength());
+            Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("this", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("this", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("this and that", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("this and that", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
     public void testProduceDataWithBuffering() throws Exception {
 
-        final AsyncEntityProducer producer = new ChunkCharAsyncEntityProducer(
-                256, 5, ContentType.TEXT_PLAIN, "this", " and that", "all", " sorts of stuff");
+        try (final AsyncEntityProducer producer = new ChunkCharAsyncEntityProducer(256, 5, ContentType.TEXT_PLAIN,
+                "this", " and that", "all", " sorts of stuff")) {
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("this and that", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("this and that", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertTrue(byteChannel.isOpen());
-        Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertTrue(byteChannel.isOpen());
+            Assert.assertEquals("", byteChannel.dump(StandardCharsets.US_ASCII));
 
-        producer.produce(streamChannel);
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("all sorts of stuff", byteChannel.dump(StandardCharsets.US_ASCII));
+            producer.produce(streamChannel);
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("all sorts of stuff", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAsyncEntityProducers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAsyncEntityProducers.java
@@ -56,7 +56,7 @@ public class TestAsyncEntityProducers {
             Assert.assertEquals(Files.size(path), producer.getContentLength());
             Assert.assertEquals(ContentType.APPLICATION_OCTET_STREAM.toString(), producer.getContentType());
         } finally {
-            producer.releaseResources();
+            producer.close();
         }
     }
 
@@ -72,7 +72,7 @@ public class TestAsyncEntityProducers {
             Assert.assertEquals(-1, producer.getContentLength());
             Assert.assertEquals(ContentType.APPLICATION_OCTET_STREAM.toString(), producer.getContentType());
         } finally {
-            producer.releaseResources();
+            producer.close();
         }
     }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestBasicAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestBasicAsyncEntityProducer.java
@@ -42,39 +42,41 @@ public class TestBasicAsyncEntityProducer {
     @Test
     public void testBinaryContent() throws Exception {
 
-        final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
-                new byte[] { 'a', 'b', 'c' }, ContentType.DEFAULT_BINARY);
+        try (final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
+                new byte[] { 'a', 'b', 'c' }, ContentType.DEFAULT_BINARY)) {
 
-        Assert.assertEquals(3, producer.getContentLength());
-        Assert.assertEquals(ContentType.DEFAULT_BINARY.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(3, producer.getContentLength());
+            Assert.assertEquals(ContentType.DEFAULT_BINARY.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
     public void testTextContent() throws Exception {
 
-        final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
-                "abc", ContentType.TEXT_PLAIN);
+        try (final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
+                "abc", ContentType.TEXT_PLAIN)) {
 
-        Assert.assertEquals(3, producer.getContentLength());
-        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(3, producer.getContentLength());
+            Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
@@ -95,7 +97,7 @@ public class TestBasicAsyncEntityProducer {
             Assert.assertFalse(byteChannel.isOpen());
             Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
 
-            producer.releaseResources();
+            producer.close();
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityConsumer.java
@@ -38,16 +38,17 @@ public class TestDigestingEntityConsumer {
     @Test
     public void testConsumeData() throws Exception {
 
-        final DigestingEntityConsumer<String> consumer = new DigestingEntityConsumer<>("MD5",
-                new StringAsyncEntityConsumer());
+        try (final DigestingEntityConsumer<String> consumer = new DigestingEntityConsumer<>("MD5",
+                new StringAsyncEntityConsumer())) {
 
-        consumer.consume(ByteBuffer.wrap(new byte[]{'1', '2', '3'}));
-        consumer.consume(ByteBuffer.wrap(new byte[]{'4', '5'}));
-        consumer.consume(ByteBuffer.wrap(new byte[]{}));
-        consumer.streamEnd(null);
+            consumer.consume(ByteBuffer.wrap(new byte[] { '1', '2', '3' }));
+            consumer.consume(ByteBuffer.wrap(new byte[] { '4', '5' }));
+            consumer.consume(ByteBuffer.wrap(new byte[] {}));
+            consumer.streamEnd(null);
 
-        Assert.assertEquals("12345", consumer.getContent());
-        Assert.assertEquals("827ccb0eea8a706c4c34a16891f84e7b", TextUtils.toHexString(consumer.getDigest()));
+            Assert.assertEquals("12345", consumer.getContent());
+            Assert.assertEquals("827ccb0eea8a706c4c34a16891f84e7b", TextUtils.toHexString(consumer.getDigest()));
+        }
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityProducer.java
@@ -42,24 +42,25 @@ public class TestDigestingEntityProducer {
     @Test
     public void testProduceData() throws Exception {
 
-        final DigestingEntityProducer producer = new DigestingEntityProducer("MD5",
-                new StringAsyncEntityProducer("12345", ContentType.TEXT_PLAIN));
+        try (final DigestingEntityProducer producer = new DigestingEntityProducer("MD5",
+                new StringAsyncEntityProducer("12345", ContentType.TEXT_PLAIN))) {
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final BasicDataStreamChannel dataStreamChannel = new BasicDataStreamChannel(byteChannel);
-        while (byteChannel.isOpen()) {
-            producer.produce(dataStreamChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final BasicDataStreamChannel dataStreamChannel = new BasicDataStreamChannel(byteChannel);
+            while (byteChannel.isOpen()) {
+                producer.produce(dataStreamChannel);
+            }
+
+            Assert.assertEquals("12345", byteChannel.dump(StandardCharsets.US_ASCII));
+            final List<Header> trailers = dataStreamChannel.getTrailers();
+            Assert.assertNotNull(trailers);
+            Assert.assertEquals(2, trailers.size());
+
+            Assert.assertEquals("digest-algo", trailers.get(0).getName());
+            Assert.assertEquals("MD5", trailers.get(0).getValue());
+            Assert.assertEquals("digest", trailers.get(1).getName());
+            Assert.assertEquals("827ccb0eea8a706c4c34a16891f84e7b", trailers.get(1).getValue());
         }
-
-        Assert.assertEquals("12345", byteChannel.dump(StandardCharsets.US_ASCII));
-        final List<Header> trailers = dataStreamChannel.getTrailers();
-        Assert.assertNotNull(trailers);
-        Assert.assertEquals(2, trailers.size());
-
-        Assert.assertEquals("digest-algo", trailers.get(0).getName());
-        Assert.assertEquals("MD5", trailers.get(0).getValue());
-        Assert.assertEquals("digest", trailers.get(1).getName());
-        Assert.assertEquals("827ccb0eea8a706c4c34a16891f84e7b", trailers.get(1).getValue());
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileAsyncEntityProducer.java
@@ -66,20 +66,21 @@ public class TestFileAsyncEntityProducer {
     @Test
     public void testTextContent() throws Exception {
 
-        final AsyncEntityProducer producer = new FileEntityProducer(tempFile, ContentType.TEXT_PLAIN);
+        try (final AsyncEntityProducer producer = new FileEntityProducer(tempFile, ContentType.TEXT_PLAIN)) {
 
-        Assert.assertEquals(6, producer.getContentLength());
-        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(6, producer.getContentLength());
+            Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
@@ -100,7 +101,7 @@ public class TestFileAsyncEntityProducer {
             Assert.assertFalse(byteChannel.isOpen());
             Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
 
-            producer.releaseResources();
+            producer.close();
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileEntityProducer.java
@@ -49,8 +49,9 @@ public class TestFileEntityProducer {
         try (RandomAccessFile raFile = new RandomAccessFile(file, "rw")) {
             final long expectedLength = 1L + Integer.MAX_VALUE;
             raFile.setLength(expectedLength);
-            final FileEntityProducer fileEntityProducer = new FileEntityProducer(file);
-            Assert.assertEquals(expectedLength, fileEntityProducer.getContentLength());
+            try (final FileEntityProducer fileEntityProducer = new FileEntityProducer(file)) {
+                Assert.assertEquals(expectedLength, fileEntityProducer.getContentLength());
+            }
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
@@ -70,20 +70,22 @@ public class TestPathAsyncEntityProducer {
     public void testTextContent() throws Exception {
 
         final Path tempPath = tempFile.toPath();
-        final AsyncEntityProducer producer = new PathEntityProducer(tempPath, ContentType.TEXT_PLAIN, StandardOpenOption.READ);
+        try (final AsyncEntityProducer producer = new PathEntityProducer(tempPath, ContentType.TEXT_PLAIN,
+                StandardOpenOption.READ)) {
 
-        Assert.assertEquals(6, producer.getContentLength());
-        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(6, producer.getContentLength());
+            Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
@@ -105,7 +107,7 @@ public class TestPathAsyncEntityProducer {
             Assert.assertFalse(byteChannel.isOpen());
             Assert.assertEquals("abcdef", byteChannel.dump(StandardCharsets.US_ASCII));
 
-            producer.releaseResources();
+            producer.close();
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathEntityProducer.java
@@ -52,8 +52,9 @@ public class TestPathEntityProducer {
         try (RandomAccessFile raFile = new RandomAccessFile(file, "rw")) {
             final long expectedLength = 1L + Integer.MAX_VALUE;
             raFile.setLength(expectedLength);
-            final PathEntityProducer fileEntityProducer = new PathEntityProducer(path, StandardOpenOption.READ);
-            Assert.assertEquals(expectedLength, fileEntityProducer.getContentLength());
+            try (final PathEntityProducer fileEntityProducer = new PathEntityProducer(path, StandardOpenOption.READ)) {
+                Assert.assertEquals(expectedLength, fileEntityProducer.getContentLength());
+            }
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestStringAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestStringAsyncEntityProducer.java
@@ -42,20 +42,20 @@ public class TestStringAsyncEntityProducer {
     @Test
     public void testTextContent() throws Exception {
 
-        final AsyncEntityProducer producer = new StringAsyncEntityProducer(
-                "abc", ContentType.TEXT_PLAIN);
+        try (final AsyncEntityProducer producer = new StringAsyncEntityProducer("abc", ContentType.TEXT_PLAIN)) {
 
-        Assert.assertEquals(-1, producer.getContentLength());
-        Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
-        Assert.assertNull(producer.getContentEncoding());
+            Assert.assertEquals(-1, producer.getContentLength());
+            Assert.assertEquals(ContentType.TEXT_PLAIN.toString(), producer.getContentType());
+            Assert.assertNull(producer.getContentEncoding());
 
-        final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
-        final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
 
-        producer.produce(streamChannel);
+            producer.produce(streamChannel);
 
-        Assert.assertFalse(byteChannel.isOpen());
-        Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
+            Assert.assertFalse(byteChannel.isOpen());
+            Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
+        }
     }
 
     @Test
@@ -76,7 +76,7 @@ public class TestStringAsyncEntityProducer {
             Assert.assertFalse(byteChannel.isOpen());
             Assert.assertEquals("abc", byteChannel.dump(StandardCharsets.US_ASCII));
 
-            producer.releaseResources();
+            producer.close();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,8 +187,19 @@
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
             <overrideCompatibilityChangeParameters>
+              <!--  These three allow Java 8 default methods. -->
               <overrideCompatibilityChangeParameter>
                 <compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+                <binaryCompatible>true</binaryCompatible>
+                <sourceCompatible>true</sourceCompatible>
+              </overrideCompatibilityChangeParameter>
+              <overrideCompatibilityChangeParameter>
+                <compatibilityChange>METHOD_ABSTRACT_NOW_DEFAULT</compatibilityChange>
+                <binaryCompatible>true</binaryCompatible>
+                <sourceCompatible>true</sourceCompatible>
+              </overrideCompatibilityChangeParameter>
+              <overrideCompatibilityChangeParameter>
+                <compatibilityChange>METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE</compatibilityChange>
                 <binaryCompatible>true</binaryCompatible>
                 <sourceCompatible>true</sourceCompatible>
               </overrideCompatibilityChangeParameter>


### PR DESCRIPTION
- This happens to highlight where tests using implementations of
ResourceHolder where not testing closing down any resources. Tests are
updated but only close the resource, assertions to validate close states
are not added.
- JApiCmp does not seem to know that Java 8's default methods provide
binary and source compatibility.