### PR TITLE
Set a URIBuilder authority with with a URIAuthority or NamedEndpoint.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIAuthority.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIAuthority.java
@@ -87,6 +87,8 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
     }
 
     /**
+     * Constructs a new instance.
+     *
      * @throws IllegalArgumentException
      *             If the port parameter is outside the specified range of valid port values, which is between 0 and
      *             65535, inclusive. {@code -1} indicates the scheme default port.
@@ -133,7 +135,7 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
     }
 
     /**
-     * Creates {@code URIHost} instance from string. Text may not contain any blanks.
+     * Creates a {@code URIAuthority} instance from a string. Text may not contain any blanks.
      */
     public static URIAuthority create(final String s) throws URISyntaxException {
         if (TextUtils.isBlank(s)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -136,6 +136,34 @@ public class URIBuilder {
     }
 
     /**
+     * Sets the authority.
+     *
+     * @param charset the authority.
+     * @return this.
+     * @since 5.2
+     */
+    public URIBuilder setAuthority(final NamedEndpoint authority) {
+        setUserInfo(null);
+        setHost(authority.getHostName());
+        setPort(authority.getPort());
+        return this;
+    }
+
+    /**
+     * Sets the authority.
+     *
+     * @param charset the authority.
+     * @return this.
+     * @since 5.2
+     */
+    public URIBuilder setAuthority(final URIAuthority authority) {
+        setUserInfo(authority.getUserInfo());
+        setHost(authority.getHostName());
+        setPort(authority.getPort());
+        return this;
+    }
+
+    /**
      * Sets the Charset.
      *
      * @param charset the Charset.
@@ -144,6 +172,16 @@ public class URIBuilder {
     public URIBuilder setCharset(final Charset charset) {
         this.charset = charset;
         return this;
+    }
+
+    /**
+     * Gets the authority.
+     *
+     * @return the authority.
+     * @since 5.2
+     */
+    public URIAuthority getAuthority() {
+        return new URIAuthority(getUserInfo(), getHost(), getPort());
     }
 
     /**
@@ -491,7 +529,7 @@ public class URIBuilder {
      * @param httpHost the scheme, host name, and port.
      * @return this.
      */
-    public URIBuilder setHttpHost(final HttpHost httpHost ) {
+    public URIBuilder setHttpHost(final HttpHost httpHost) {
         setScheme(httpHost.getSchemeName());
         setHost(httpHost.getHostName());
         setPort(httpHost.getPort());

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -38,6 +38,7 @@ import java.util.List;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.NameValuePairListMatcher;
+import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -320,6 +321,53 @@ public class TestURIBuilder {
         final URIBuilder uribuilder = new URIBuilder(uri).removeQuery();
         final URI result = uribuilder.build();
         Assert.assertEquals(new URI("http://localhost:80/"), result);
+    }
+
+    @Test
+    public void testSetAuthorityFromNamedEndpointHost() throws Exception {
+        final Host host = Host.create("localhost:88");
+        final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(host);
+        // Check builder
+        Assert.assertNull(uribuilder.getUserInfo());
+        Assert.assertEquals(host.getHostName(), uribuilder.getAuthority().getHostName());
+        Assert.assertEquals(host.getHostName(), uribuilder.getHost());
+        // Check result
+        final URI result = uribuilder.build();
+        Assert.assertEquals(host.getHostName(), result.getHost());
+        Assert.assertEquals(host.getPort(), result.getPort());
+        Assert.assertEquals(new URI("http://localhost:88"), result);
+    }
+
+    @Test
+    public void testSetAuthorityFromNamedEndpointHttpHost() throws Exception {
+        final HttpHost httpHost = HttpHost.create("localhost:88");
+        final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(httpHost);
+        // Check builder
+        Assert.assertNull(uribuilder.getUserInfo());
+        Assert.assertEquals(httpHost.getHostName(), uribuilder.getAuthority().getHostName());
+        Assert.assertEquals(httpHost.getHostName(), uribuilder.getHost());
+        // Check result
+        final URI result = uribuilder.build();
+        Assert.assertEquals(httpHost.getHostName(), result.getHost());
+        Assert.assertEquals(httpHost.getPort(), result.getPort());
+        Assert.assertEquals(new URI("http://localhost:88"), result);
+    }
+
+    @Test
+    public void testSetAuthorityFromURIAuthority() throws Exception {
+        final URIAuthority authority = URIAuthority.create("u:p@localhost:88");
+        final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(authority);
+        // Check builder
+        Assert.assertEquals(authority.getUserInfo(), uribuilder.getAuthority().getUserInfo());
+        Assert.assertEquals(authority.getHostName(), uribuilder.getAuthority().getHostName());
+        Assert.assertEquals(authority.getHostName(), uribuilder.getHost());
+        // Check result
+        final URI result = uribuilder.build();
+        Assert.assertEquals(authority.getUserInfo(), result.getUserInfo());
+        Assert.assertEquals(authority.getHostName(), result.getHost());
+        Assert.assertEquals(authority.getPort(), result.getPort());
+        Assert.assertEquals(authority.toString(), result.getAuthority());
+        Assert.assertEquals(new URI("http://u:p@localhost:88"), result);
     }
 
     @Test


### PR DESCRIPTION
For the use case where you already have a `URIAuthority` you want to pass into a URIBuilder. The `NamedEndpoint` interface is also supported.

