### PR TITLE
HTTPCORE-692 add new rules for H2 header check

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2RequestConverter.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2RequestConverter.java
@@ -106,7 +106,12 @@ public final class DefaultH2RequestConverter implements H2MessageConverter<HttpR
                         throw new ProtocolException("Unsupported request header '%s'", name);
                 }
             } else {
-                if (name.equalsIgnoreCase(HttpHeaders.CONNECTION)) {
+                if (name.equalsIgnoreCase(HttpHeaders.CONNECTION) || name.equalsIgnoreCase(HttpHeaders.KEEP_ALIVE)
+                    || name.equalsIgnoreCase(HttpHeaders.PROXY_CONNECTION) || name.equalsIgnoreCase(HttpHeaders.TRANSFER_ENCODING)
+                    || name.equalsIgnoreCase(HttpHeaders.HOST) || name.equalsIgnoreCase(HttpHeaders.UPGRADE)) {
+                    throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", header.getName(), header.getValue());
+                }
+                if (name.equalsIgnoreCase(HttpHeaders.TE) && !value.equalsIgnoreCase("trailers")) {
                     throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", header.getName(), header.getValue());
                 }
                 messageHeaders.add(header);
@@ -189,8 +194,13 @@ public final class DefaultH2RequestConverter implements H2MessageConverter<HttpR
             if (name.startsWith(":")) {
                 throw new ProtocolException("Header name '%s' is invalid", name);
             }
-            if (name.equalsIgnoreCase(HttpHeaders.CONNECTION)) {
-                throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", name, value);
+            if (name.equalsIgnoreCase(HttpHeaders.CONNECTION) || name.equalsIgnoreCase(HttpHeaders.KEEP_ALIVE)
+                || name.equalsIgnoreCase(HttpHeaders.PROXY_CONNECTION) || name.equalsIgnoreCase(HttpHeaders.TRANSFER_ENCODING)
+                || name.equalsIgnoreCase(HttpHeaders.HOST) || name.equalsIgnoreCase(HttpHeaders.UPGRADE)) {
+                throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", header.getName(), header.getValue());
+            }
+            if (name.equalsIgnoreCase(HttpHeaders.TE) && !value.equalsIgnoreCase("trailers")) {
+                throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", header.getName(), header.getValue());
             }
             headers.add(new BasicHeader(TextUtils.toLowerCase(name), value));
         }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2ResponseConverter.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2ResponseConverter.java
@@ -82,7 +82,8 @@ public class DefaultH2ResponseConverter implements H2MessageConverter<HttpRespon
                     throw new ProtocolException("Unsupported response header '%s'", name);
                 }
             } else {
-                if (name.equalsIgnoreCase(HttpHeaders.CONNECTION)) {
+                if (name.equalsIgnoreCase(HttpHeaders.CONNECTION) || name.equalsIgnoreCase(HttpHeaders.KEEP_ALIVE)
+                    || name.equalsIgnoreCase(HttpHeaders.TRANSFER_ENCODING) || name.equalsIgnoreCase(HttpHeaders.UPGRADE)) {
                     throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", header.getName(), header.getValue());
                 }
                 messageHeaders.add(header);
@@ -123,8 +124,9 @@ public class DefaultH2ResponseConverter implements H2MessageConverter<HttpRespon
             if (name.startsWith(":")) {
                 throw new ProtocolException("Header name '%s' is invalid", name);
             }
-            if (name.equalsIgnoreCase(HttpHeaders.CONNECTION)) {
-                throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", name, value);
+            if (name.equalsIgnoreCase(HttpHeaders.CONNECTION) || name.equalsIgnoreCase(HttpHeaders.KEEP_ALIVE)
+                || name.equalsIgnoreCase(HttpHeaders.TRANSFER_ENCODING) || name.equalsIgnoreCase(HttpHeaders.UPGRADE)) {
+                throw new ProtocolException("Header '%s: %s' is illegal for HTTP/2 messages", header.getName(), header.getValue());
             }
             headers.add(new BasicHeader(TextUtils.toLowerCase(name), value));
         }

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/TestDefaultH2ResponseConverter.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/TestDefaultH2ResponseConverter.java
@@ -96,6 +96,42 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
+    public void testConvertFromFieldsKeepAliveHeader() throws Exception {
+        final List<Header> headers = Arrays.asList(
+            new BasicHeader(":status", "200"),
+            new BasicHeader("location", "http://www.example.com/"),
+            new BasicHeader("keep-alive", "timeout=5, max=1000"));
+
+        final DefaultH2ResponseConverter converter = new DefaultH2ResponseConverter();
+        Assert.assertThrows("Header 'keep-alive: timeout=5, max=1000' is illegal for HTTP/2 messages",
+                            HttpException.class, () -> converter.convert(headers));
+    }
+
+    @Test
+    public void testConvertFromFieldsTransferEncodingHeader() throws Exception {
+        final List<Header> headers = Arrays.asList(
+            new BasicHeader(":status", "200"),
+            new BasicHeader("location", "http://www.example.com/"),
+            new BasicHeader("transfer-encoding", "gzip"));
+
+        final DefaultH2ResponseConverter converter = new DefaultH2ResponseConverter();
+        Assert.assertThrows("Header 'transfer-encoding: gzip' is illegal for HTTP/2 messages",
+                            HttpException.class, () -> converter.convert(headers));
+    }
+
+    @Test
+    public void testConvertFromFieldsUpgradeHeader() throws Exception {
+        final List<Header> headers = Arrays.asList(
+            new BasicHeader(":status", "200"),
+            new BasicHeader("location", "http://www.example.com/"),
+            new BasicHeader("upgrade", "example/1, foo/2"));
+
+        final DefaultH2ResponseConverter converter = new DefaultH2ResponseConverter();
+        Assert.assertThrows("Header 'upgrade: example/1, foo/2' is illegal for HTTP/2 messages",
+                            HttpException.class, () -> converter.convert(headers));
+    }
+
+    @Test
     public void testConvertFromFieldsMissingStatus() throws Exception {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader("location", "http://www.example.com/"),

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHeaders.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHeaders.java
@@ -167,6 +167,8 @@ public final class HttpHeaders {
 
     public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
 
+    public static final String PROXY_CONNECTION = "Proxy-Connection";
+
     public static final String RANGE = "Range";
 
     public static final String REFERER = "Referer";


### PR DESCRIPTION
as rfc7540 section 8.1.2.2 defined.