### PR TITLE
Remove a check if inPlainBuf has remaining capacity prior to writing …

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -588,7 +588,6 @@ public class SSLIOSession implements IOSession {
                         if (sslEngine.isInboundDone()) {
                             endOfStream = true;
                         }
-        
                         if(inPlainBuf.position() > 0) {
                             inPlainBuf.flip();
                             try {
@@ -597,7 +596,6 @@ public class SSLIOSession implements IOSession {
                                 inPlainBuf.clear();
                             }
                         }
-
                         if (result.getStatus() != SSLEngineResult.Status.OK) {
                             if (result.getStatus() == SSLEngineResult.Status.BUFFER_UNDERFLOW && endOfStream) {
                                 throw new SSLException("Unable to decrypt incoming data due to unexpected end of stream");

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -588,12 +588,14 @@ public class SSLIOSession implements IOSession {
                         if (sslEngine.isInboundDone()) {
                             endOfStream = true;
                         }
-
-                        inPlainBuf.flip();
-                        try {
-                            ensureHandler().inputReady(protocolSession, inPlainBuf.hasRemaining() ? inPlainBuf : null);
-                        } finally {
-                            inPlainBuf.clear();
+        
+                        if(inPlainBuf.position() > 0) {
+                            inPlainBuf.flip();
+                            try {
+                                ensureHandler().inputReady(protocolSession, inPlainBuf.hasRemaining() ? inPlainBuf : null);
+                            } finally {
+                                inPlainBuf.clear();
+                            }
                         }
 
                         if (result.getStatus() != SSLEngineResult.Status.OK) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -588,14 +588,14 @@ public class SSLIOSession implements IOSession {
                         if (sslEngine.isInboundDone()) {
                             endOfStream = true;
                         }
-                        if (inPlainBuf.hasRemaining()) {
-                            inPlainBuf.flip();
-                            try {
-                                ensureHandler().inputReady(protocolSession, inPlainBuf.hasRemaining() ? inPlainBuf : null);
-                            } finally {
-                                inPlainBuf.clear();
-                            }
+
+                        inPlainBuf.flip();
+                        try {
+                            ensureHandler().inputReady(protocolSession, inPlainBuf.hasRemaining() ? inPlainBuf : null);
+                        } finally {
+                            inPlainBuf.clear();
                         }
+
                         if (result.getStatus() != SSLEngineResult.Status.OK) {
                             if (result.getStatus() == SSLEngineResult.Status.BUFFER_UNDERFLOW && endOfStream) {
                                 throw new SSLException("Unable to decrypt incoming data due to unexpected end of stream");


### PR DESCRIPTION
…it out.  This causes an endless loop if the inEncrypted buffer is larger than the inPlainBuf.

https://issues.apache.org/jira/browse/HTTPCORE-694 