### PR TITLE
HTTPCORE-695 Unhandled CancelledKeyException during processPendingInt…

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
@@ -465,7 +465,11 @@ public abstract class AbstractIOReactor implements IOReactor {
             final SelectionKey key = entry.getSelectionKey();
             final int eventMask = entry.getEventMask();
             if (key.isValid()) {
-                key.interestOps(eventMask);
+                try {
+                    key.interestOps(eventMask);
+                } catch (CancelledKeyException ex) {
+                    // ignore and move on
+                }
             }
         }
     }


### PR DESCRIPTION
…erestOps leads to a shutdown of the underlying IOReactor