### PR TITLE
Do not explicitly declare runtime exceptions.

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -198,7 +198,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
             HttpProcessor httpProcessor,
             BasicHttpConnectionMetrics connMetrics) throws IOException;
 
-    private int updateWindow(final AtomicInteger window, final int delta) throws ArithmeticException {
+    private int updateWindow(final AtomicInteger window, final int delta) {
         for (;;) {
             final int current = window.get();
             long newValue = (long) current + delta;
@@ -220,7 +220,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
     }
 
     private int updateInputWindow(
-            final int streamId, final AtomicInteger window, final int delta) throws ArithmeticException {
+            final int streamId, final AtomicInteger window, final int delta) {
         final int newSize = updateWindow(window, delta);
         if (streamListener != null) {
             streamListener.onInputFlowControl(this, streamId, delta, newSize);
@@ -229,7 +229,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
     }
 
     private int updateOutputWindow(
-            final int streamId, final AtomicInteger window, final int delta) throws ArithmeticException {
+            final int streamId, final AtomicInteger window, final int delta) {
         final int newSize = updateWindow(window, delta);
         if (streamListener != null) {
             streamListener.onOutputFlowControl(this, streamId, delta, newSize);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -414,7 +414,7 @@ public final class ContentType implements Serializable {
         return parse(s, false);
     }
 
-    private static ContentType parse(final CharSequence s, final boolean strict) throws UnsupportedCharsetException {
+    private static ContentType parse(final CharSequence s, final boolean strict) {
         if (TextUtils.isBlank(s)) {
             return null;
         }


### PR DESCRIPTION
Because that is a "runtime" exception and we don't need to declare it.