### PR TITLE
Check if a given protocol is secure and  enabled.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ssl/TLS.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ssl/TLS.java
@@ -83,8 +83,8 @@ public enum TLS {
             return null;
         }
         final List<String> enabledProtocols = new ArrayList<>();
-        for (final String protocol: protocols) {
-            if (!protocol.startsWith("SSL") && !protocol.equals(V_1_0.id) && !protocol.equals(V_1_1.id)) {
+        for (final String protocol : protocols) {
+            if (isSecure(protocol)) {
                 enabledProtocols.add(protocol);
             }
         }
@@ -92,6 +92,17 @@ public enum TLS {
             enabledProtocols.add(V_1_2.id);
         }
         return enabledProtocols.toArray(new String[0]);
+    }
+
+    /**
+     * Check if a given protocol is considered secure and is enabled by default.
+     *
+     * @return {@code true} if the given protocol is secure and enabled, otherwise return {@code
+     * false}.
+     * @since 5.2
+     */
+    public static boolean isSecure(final String protocol) {
+        return !protocol.startsWith("SSL") && !protocol.equals(V_1_0.id) && !protocol.equals(V_1_1.id);
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/ssl/TLSTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/ssl/TLSTest.java
@@ -1,0 +1,89 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TLSTest {
+
+
+    @Test
+    void isSame() throws ParseException {
+        assertTrue(TLS.V_1_0.isSame(TLS.parse("TLSv1")));
+    }
+
+    @Test
+    void isComparable() throws ParseException {
+        assertTrue(TLS.V_1_0.isComparable(TLS.parse("TLSv1")));
+    }
+
+    @Test
+    void greaterEquals() throws ParseException {
+        assertTrue(TLS.V_1_3.greaterEquals(TLS.parse("TLSv1")));
+    }
+
+    @Test
+    void lessEquals() throws ParseException {
+        assertTrue(TLS.V_1_0.lessEquals(TLS.parse("TLSv1.3")));
+    }
+
+    @Test
+    void parse() throws ParseException {
+        assertTrue(TLS.V_1_0.lessEquals(TLS.parse("TLSv1.3")));
+    }
+
+    @Test
+    void parseNull() throws ParseException {
+        assertNull(TLS.parse(null));
+    }
+
+    @Test
+    void excludeWeakNull() {
+        assertNull((TLS.excludeWeak(null)));
+    }
+
+    @Test
+    void excludeWeak() {
+        final String[] mixProtocol = {
+                "SSL 2.0",
+                "TLS 1.3",
+                "SSL 3.0",
+                "TLS 1.2",
+                "TLS 1.1"
+        };
+        final String[] strongProtocols = TLS.excludeWeak(mixProtocol);
+        for (final String protocol : strongProtocols) {
+            Assertions.assertTrue(TLS.isSecure(protocol));
+        }
+    }
+}


### PR DESCRIPTION
Creating the unit tests for the enum `TLS` I realized that was not possible to check if the method `TLS.excludeWeak` it worked as expected and excluded the disabled protocols, without having to manually check one by one.

Now it's possible to check if a given protocol its enabled.