### PR TITLE
Logs improvements:

### DIFF
--- a/httpcore5-h2/pom.xml
+++ b/httpcore5-h2/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/httpcore5-testing/pom.xml
+++ b/httpcore5-testing/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/httpcore5/pom.xml
+++ b/httpcore5/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
     <hamcrest.version>2.2</hamcrest.version>
     <junit.migrationsupport.version>5.0.0</junit.migrationsupport.version>
     <mockito.version>4.0.0</mockito.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <log4j.version>2.16.0</log4j.version>
+    <slf4j.version>1.7.32</slf4j.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <rxjava.version>2.2.21</rxjava.version>
     <api.comparison.version>5.1</api.comparison.version>
     <japicmp.version>0.15.4</japicmp.version>
@@ -138,12 +138,12 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j.version}</version>
+        <version>${log4j2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j.version}</version>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
* Use just log4j-api.
* Rename libs to log4j2.
* Bump version slf4j 1.7.32.