### PR TITLE
BasicHttpRequest getUri() not reflecting setUri(); fragment not taken into account in setUri()

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
@@ -287,7 +287,12 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
         if (query != null) {
             buf.append('?').append(query);
         }
+        final String fragment = requestUri.getRawFragment();
+        if (fragment != null) {
+            buf.append('#').append(fragment);
+        }
         this.path = buf.toString();
+        this.requestUri = null;
     }
 
     private void assembleRequestUri(final StringBuilder buf) {


### PR DESCRIPTION
Fix BasicHttpRequest getUri() not reflecting setUri() #1; fix fragment not taken into account in setUri() #2