### PR TITLE
Upgrade to RxJava3

### DIFF
--- a/httpcore5-reactive/pom.xml
+++ b/httpcore5-reactive/pom.xml
@@ -55,9 +55,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.reactivex.rxjava2</groupId>
+      <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
-      <version>${rxjava.version}</version>
+      <version>${rxjava3.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
@@ -35,10 +35,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.Flowable;
-import io.reactivex.Notification;
-import io.reactivex.Observable;
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Notification;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import org.apache.hc.core5.http.HttpStreamResetException;
 import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.junit.jupiter.api.Assertions;

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataProducer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataProducer.java
@@ -34,7 +34,7 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 
 public class TestReactiveDataProducer {
     @Test

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveEntityProducer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveEntityProducer.java
@@ -35,7 +35,7 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 
 public class TestReactiveEntityProducer {
 

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/examples/ReactiveFullDuplexClientExample.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/examples/ReactiveFullDuplexClientExample.java
@@ -54,8 +54,8 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.Timeout;
 import org.reactivestreams.Publisher;
 
-import io.reactivex.Flowable;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * Example of full-duplex HTTP/1.1 message exchanges using reactive streaming. This demo will stream randomly

--- a/httpcore5-testing/pom.xml
+++ b/httpcore5-testing/pom.xml
@@ -66,6 +66,11 @@
       <version>${rxjava.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>${rxjava3.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/reactive/Reactive3TestUtils.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/reactive/Reactive3TestUtils.java
@@ -27,6 +27,14 @@
 
 package org.apache.hc.core5.testing.reactive;
 
+import io.reactivex.rxjava3.core.Emitter;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.functions.Consumer;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.util.TextUtils;
+import org.reactivestreams.Publisher;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -34,21 +42,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.hc.core5.annotation.Internal;
-import org.apache.hc.core5.util.TextUtils;
-import org.reactivestreams.Publisher;
-
-import io.reactivex.Emitter;
-import io.reactivex.Flowable;
-import io.reactivex.Single;
-import io.reactivex.functions.Consumer;
-
-/**
- * @deprecated Use {@link Reactive3TestUtils} and RxJava3
- */
 @Internal
-@Deprecated
-public class ReactiveTestUtils {
+public class Reactive3TestUtils {
     /** The range from which to generate random data. */
     private final static byte[] RANGE = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
             .getBytes(StandardCharsets.US_ASCII);

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/reactive/ReactiveRandomProcessor.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/reactive/ReactiveRandomProcessor.java
@@ -51,7 +51,7 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.reactive.ReactiveRequestProcessor;
 import org.reactivestreams.Publisher;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 
 public class ReactiveRandomProcessor implements ReactiveRequestProcessor {
     public ReactiveRandomProcessor() {
@@ -100,7 +100,7 @@ public class ReactiveRandomProcessor implements ReactiveRequestProcessor {
             }
 
             final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_OK);
-            final Flowable<ByteBuffer> stream = ReactiveTestUtils.produceStream(n);
+            final Flowable<ByteBuffer> stream = Reactive3TestUtils.produceStream(n);
             final String hash = ReactiveTestUtils.getStreamHash(n);
             response.addHeader("response-hash-code", hash);
             final BasicEntityDetails basicEntityDetails = new BasicEntityDetails(n, ContentType.APPLICATION_OCTET_STREAM);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/ReactiveClientTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/ReactiveClientTest.java
@@ -69,7 +69,7 @@ import org.apache.hc.core5.testing.nio.LoggingH2StreamListener;
 import org.apache.hc.core5.testing.nio.LoggingHttp1StreamListener;
 import org.apache.hc.core5.testing.nio.LoggingIOSessionDecorator;
 import org.apache.hc.core5.testing.nio.LoggingIOSessionListener;
-import org.apache.hc.core5.testing.reactive.ReactiveTestUtils.StreamDescription;
+import org.apache.hc.core5.testing.reactive.Reactive3TestUtils.StreamDescription;
 import org.apache.hc.core5.util.TextUtils;
 import org.apache.hc.core5.util.Timeout;
 import org.hamcrest.CoreMatchers;
@@ -84,8 +84,8 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.reactivex.Flowable;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Observable;
 
 @RunWith(Parameterized.class)
 @EnableRuleMigrationSupport
@@ -211,7 +211,7 @@ public class ReactiveClientTest {
         final InetSocketAddress address = startClientAndServer();
         final long expectedLength = 6_554_200L;
         final AtomicReference<String> expectedHash = new AtomicReference<>();
-        final Flowable<ByteBuffer> stream = ReactiveTestUtils.produceStream(expectedLength, expectedHash);
+        final Flowable<ByteBuffer> stream = Reactive3TestUtils.produceStream(expectedLength, expectedHash);
         final ReactiveEntityProducer producer = new ReactiveEntityProducer(stream, -1, null, null);
         final BasicRequestProducer request = getRequestProducer(address, producer);
 
@@ -219,7 +219,7 @@ public class ReactiveClientTest {
         requester.execute(request, consumer, SOCKET_TIMEOUT, null);
         final Message<HttpResponse, Publisher<ByteBuffer>> response = consumer.getResponseFuture()
                 .get(RESULT_TIMEOUT.getDuration(), RESULT_TIMEOUT.getTimeUnit());
-        final StreamDescription desc = ReactiveTestUtils.consumeStream(response.getBody()).blockingGet();
+        final StreamDescription desc = Reactive3TestUtils.consumeStream(response.getBody()).blockingGet();
 
         Assertions.assertEquals(expectedLength, desc.length);
         Assertions.assertEquals(expectedHash.get(), TextUtils.toHexString(desc.md.digest()));
@@ -244,7 +244,7 @@ public class ReactiveClientTest {
             requester.execute(request, consumer, SOCKET_TIMEOUT, null);
             final Message<HttpResponse, Publisher<ByteBuffer>> response = consumer.getResponseFuture()
                 .get(RESULT_TIMEOUT.getDuration(), RESULT_TIMEOUT.getTimeUnit());
-            final StreamDescription desc = ReactiveTestUtils.consumeStream(response.getBody()).blockingGet();
+            final StreamDescription desc = Reactive3TestUtils.consumeStream(response.getBody()).blockingGet();
 
             Assertions.assertEquals(expectedLength, desc.length);
             Assertions.assertEquals(expectedHash.get(), TextUtils.toHexString(desc.md.digest()));

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>2.17.0</log4j.version>
     <rxjava.version>2.2.21</rxjava.version>
+    <rxjava3.version>3.1.3</rxjava3.version>
     <api.comparison.version>5.1</api.comparison.version>
     <japicmp.version>0.15.4</japicmp.version>
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters</hc.animal-sniffer.signature.ignores>


### PR DESCRIPTION
Since the `ReactiveTestUtils` API references symbols from RxJava2, I've
left it untouched for now so that japicmp doesn't yell at me.