### PR TITLE
HTTPCORE-713 - Optimize InetAddressUtils#isIPv6*Address checks 

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
@@ -101,6 +101,17 @@ public class InetAddressUtils {
         return IPV4_MAPPED_IPV6_PATTERN.matcher(input).matches();
     }
 
+    static boolean hasValidIPv6ColonCount(final String input) {
+        int colonCount = 0;
+        for (int i = 0; i < input.length(); i++) {
+            if (input.charAt(i) == COLON_CHAR) {
+                colonCount++;
+            }
+        }
+        // IPv6 address must have at least 2 colons and not more than 7 (i.e. 8 fields)
+        return colonCount >= 2 && colonCount <= MAX_COLON_COUNT;
+    }
+
     /**
      * Checks whether the parameter is a valid standard (non-compressed) IPv6 address
      *
@@ -108,7 +119,7 @@ public class InetAddressUtils {
      * @return true if the input parameter is a valid standard (non-compressed) IPv6 address
      */
     public static boolean isIPv6StdAddress(final String input) {
-        return IPV6_STD_PATTERN.matcher(input).matches();
+        return hasValidIPv6ColonCount(input) && IPV6_STD_PATTERN.matcher(input).matches();
     }
 
     /**
@@ -118,13 +129,7 @@ public class InetAddressUtils {
      * @return true if the input parameter is a valid compressed IPv6 address
      */
     public static boolean isIPv6HexCompressedAddress(final String input) {
-        int colonCount = 0;
-        for(int i = 0; i < input.length(); i++) {
-            if (input.charAt(i) == COLON_CHAR) {
-                colonCount++;
-            }
-        }
-        return  colonCount <= MAX_COLON_COUNT && IPV6_HEX_COMPRESSED_PATTERN.matcher(input).matches();
+        return hasValidIPv6ColonCount(input) && IPV6_HEX_COMPRESSED_PATTERN.matcher(input).matches();
     }
 
     /**

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
@@ -57,11 +57,22 @@ public class TestInetAddressUtils {
         Assertions.assertTrue(InetAddressUtils.isIPv6StdAddress("2001:db8:0:0:0:0:1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6StdAddress("0:0:0:0:0:0:0:0"));
         Assertions.assertTrue(InetAddressUtils.isIPv6StdAddress("0:0:0:0:0:0:0:1"));
+
         Assertions.assertTrue(InetAddressUtils.isIPv6HexCompressedAddress("2001:0db8:0:0::1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6HexCompressedAddress("2001:0db8::1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6HexCompressedAddress("2001:db8::1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6HexCompressedAddress("::1"));
         Assertions.assertTrue(InetAddressUtils.isIPv6HexCompressedAddress("::")); // http://tools.ietf.org/html/rfc4291#section-2.2
+
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("2001:0db8:0000:0000:0000:0000:1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("2001:db8:0:0:0:0:1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("0:0:0:0:0:0:0:0"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("0:0:0:0:0:0:0:1"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("2001:0db8:0:0::1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("2001:0db8::1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("2001:db8::1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("::1"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("::")); // http://tools.ietf.org/html/rfc4291#section-2.2
     }
 
     @Test
@@ -71,6 +82,7 @@ public class TestInetAddressUtils {
         Assertions.assertFalse(InetAddressUtils.isIPv6StdAddress("0:0:0:0:0:0:0:0:0")); // Too many
         Assertions.assertFalse(InetAddressUtils.isIPv6StdAddress("0:0:0:0:0:0:0")); // Too few
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress(":1"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address(":1"));
         Assertions.assertFalse(InetAddressUtils.isIPv6Address("2001:0db8::0000::57ab")); // Cannot have two contractions
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress("1:2:3:4:5:6:7::9")); // too many fields before ::
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress("1::3:4:5:6:7:8:9")); // too many fields after ::
@@ -133,6 +145,27 @@ public class TestInetAddressUtils {
     public void testInvalidIPv6AddressIncorrectGroupCount() {
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress("1:2::4:5:6:7:8:9")); // too many fields in total
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress("1:2:3:4:5:6::8:9")); // too many fields in total
+    }
+
+    @Test
+    public void testHasValidIPv6ColonCount() {
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount(""));
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount(":"));
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount("127.0.0.1"));
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount(":0"));
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount("0:"));
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount("1:2:3:4:5:6:7:8:"));
+        Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount("1:2:3:4:5:6:7:8:9"));
+
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("2001:0db8:0000:0000:0000:0000:1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("2001:db8:0:0:0:0:1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("0:0:0:0:0:0:0:0"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("0:0:0:0:0:0:0:1"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("2001:0db8:0:0::1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("2001:0db8::1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("2001:db8::1428:57ab"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("::1"));
+        Assertions.assertTrue(InetAddressUtils.hasValidIPv6ColonCount("::")); // http://tools.ietf.org/html/rfc4291#section-2.2
     }
 
     @Test


### PR DESCRIPTION
Check input colon count before performing IPv6 regex validation.

`org.apache.hc.core5.net.InetAddressUtils.isIPv6Address` is used when constructing the `host` header for requests, and currently allocates a regex matcher when checking if the provided address is an IPv6 address. This is generates excess garbage and CPU cycles, especially in environments with mostly IPv4 addresses. By checking the colon count first, we see a 50x improvement checking `InetAddressUtils.isIPv6Address` for an IPv4 address.


The specific call backtrace seen looks like:
```
void java.util.regex.Matcher.<init>(Pattern, CharSequence)
   Matcher java.util.regex.Pattern.matcher(CharSequence)
   boolean org.apache.hc.core5.net.InetAddressUtils.isIPv6HexCompressedAddress(String)
      boolean org.apache.hc.core5.net.InetAddressUtils.isIPv6Address(String)
      void org.apache.hc.core5.net.Host.format(StringBuilder, NamedEndpoint)
      void org.apache.hc.core5.net.URIAuthority.format(StringBuilder, URIAuthority)
         String org.apache.hc.core5.net.URIAuthority.format(URIAuthority)
         String org.apache.hc.core5.net.URIAuthority.toString()
         String java.util.Objects.toString(Object, String)
         void org.apache.hc.core5.http.message.BasicHeader.<init>(String, Object, boolean)
         void org.apache.hc.core5.http.message.BasicHeader.<init>(String, Object)
         void org.apache.hc.core5.http.message.BasicHttpRequest.addHeader(String, Object)
         void org.apache.hc.core5.http.protocol.RequestTargetHost.process(HttpRequest, EntityDetails, HttpContext)
         void org.apache.hc.core5.http.protocol.DefaultHttpProcessor.process(HttpRequest, EntityDetails, HttpContext)
         ClassicHttpResponse org.apache.hc.client5.http.impl.classic.ProtocolExec.execute(ClassicHttpRequest, ExecChain$Scope, ExecChain)
         ClassicHttpResponse org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ClassicHttpRequest, ExecChain$Scope)
         ClassicHttpResponse org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ClassicHttpRequest, ExecChain$Scope)
         ClassicHttpResponse org.apache.hc.client5.http.impl.classic.RedirectExec.execute(ClassicHttpRequest, ExecChain$Scope, ExecChain)
         ClassicHttpResponse org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ClassicHttpRequest, ExecChain$Scope)
         CloseableHttpResponse org.apache.hc.client5.http.impl.classic.InternalHttpClient.doExecute(HttpHost, ClassicHttpRequest, HttpContext)
         CloseableHttpResponse org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(ClassicHttpRequest, HttpContext)
         CloseableHttpResponse org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(ClassicHttpRequest)
```

I wrote some [Ipv6FormatBenchmarks](https://github.com/schlosna/httpclient-format-performance/blob/develop/src/jmh/java/com/github/schlosna/Ipv6FormatBenchmarks.java) showing original and improved:

From `JDK 11.0.13, OpenJDK 64-Bit Server VM, 11.0.13+8-LTS` on `Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz`:
```
Benchmark                                                              (address)  Mode  Cnt    Score   Error   Units
Ipv6FormatBenchmarks.isIPv6Address_original                            127.0.0.1  avgt    2  395.333           ns/op
Ipv6FormatBenchmarks.isIPv6Address_original:·gc.alloc.rate.norm        127.0.0.1  avgt    2  440.000            B/op
Ipv6FormatBenchmarks.isIPv6Address_original                      0:0:0:0:0:0:0:1  avgt    2  425.793           ns/op
Ipv6FormatBenchmarks.isIPv6Address_original:·gc.alloc.rate.norm  0:0:0:0:0:0:0:1  avgt    2  208.000            B/op
Ipv6FormatBenchmarks.isIPv6Address_improved                            127.0.0.1  avgt    2   15.780           ns/op
Ipv6FormatBenchmarks.isIPv6Address_improved:·gc.alloc.rate.norm        127.0.0.1  avgt    2   ≈ 10⁻⁶            B/op
Ipv6FormatBenchmarks.isIPv6Address_improved                      0:0:0:0:0:0:0:1  avgt    2  430.078           ns/op
Ipv6FormatBenchmarks.isIPv6Address_improved:·gc.alloc.rate.norm  0:0:0:0:0:0:0:1  avgt    2  208.000            B/op
```


Seen in JFR profiles before changes:
![image](https://user-images.githubusercontent.com/54594/166573589-2c814d53-9639-4b14-82d0-9238f285be0b.png)

![image](https://user-images.githubusercontent.com/54594/166573845-b556e2ad-6b26-48d2-a2ee-2a01e4316c8b.png)
