### PR TITLE
(test) Add test for BasicFuture.failed and ComplexFuture.failed

### DIFF
--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
@@ -97,9 +97,9 @@ public class TestComplexFuture {
     }
 
     @Test
-    public void testFailedAndFailed() {
+    public void testCanceledAndFailed() {
         final ComplexFuture<Object> future = new ComplexFuture<>(null);
-        future.cancel();
+        assertThat(future.cancel(), CoreMatchers.is(true));
         assertThat(future.failed(new Exception()), CoreMatchers.is(false));
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
@@ -96,4 +96,11 @@ public class TestComplexFuture {
         assertThat(dependency2.isCancelled(), CoreMatchers.is(true));
     }
 
+    @Test
+    public void testFailedAndFailed() {
+        final ComplexFuture<Object> future = new ComplexFuture<>(null);
+        future.cancel();
+        assertThat(future.failed(new Exception()), CoreMatchers.is(false));
+    }
+
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `future.failed(new java.lang.Exception())` is false when `failed` is called with the parameter `exception = new java.lang.Exception()`.
This tests the methods [`BasicFuture.failed`](https://github.com/apache/httpcomponents-core/blob/ece5876b65fad1a5ea0bf7985abc1b9aba1e08ac/httpcore5/src/main/java/org/apache/hc/core5/concurrent/BasicFuture.java#L128) and [`ComplexFuture.failed`](https://github.com/apache/httpcomponents-core/blob/ece5876b65fad1a5ea0bf7985abc1b9aba1e08ac/httpcore5/src/main/java/org/apache/hc/core5/concurrent/ComplexFuture.java#L78).
This test is based on the test [`testCancelled`](https://github.com/apache/httpcomponents-core/blob/ece5876b65fad1a5ea0bf7985abc1b9aba1e08ac/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java#L40).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))