### PR TITLE
HTTPCLIENT-2185 Add support for IDNA 2008 (RFC 5891)

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
@@ -72,10 +72,11 @@ public final class Host implements NamedEndpoint, Serializable {
             if (!InetAddressUtils.isIPv6Address(hostName)) {
                 throw URISupport.createException(s, cursor, "Expected an IPv6 address");
             }
-        } else if (!TextUtils.isAllASCII(s)) {
-            hostName = IDN.toASCII(tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS));
         } else {
-            hostName = tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS);
+            // If the hostName contains non-ASCII characters, IDNA processing is required
+            hostName = TextUtils.isAllASCII(s) ?
+                    tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS) :
+                    IDN.toASCII(tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS));
         }
         String portText = null;
         if (!cursor.atEnd() && s.charAt(cursor.getPos()) == ':') {

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
@@ -29,7 +29,6 @@ package org.apache.hc.core5.net;
 import java.io.Serializable;
 import java.net.IDN;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -75,8 +74,7 @@ public final class Host implements NamedEndpoint, Serializable {
             }
         } else if (!TextUtils.isAllASCII(s)) {
             hostName = IDN.toASCII(tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS));
-        }
-        else {
+        } else {
             hostName = tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS);
         }
         String portText = null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
@@ -27,7 +27,9 @@
 package org.apache.hc.core5.net;
 
 import java.io.Serializable;
+import java.net.IDN;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -71,7 +73,10 @@ public final class Host implements NamedEndpoint, Serializable {
             if (!InetAddressUtils.isIPv6Address(hostName)) {
                 throw URISupport.createException(s, cursor, "Expected an IPv6 address");
             }
-        } else {
+        }  else if (!StandardCharsets.US_ASCII.newEncoder().canEncode(s.toString())){
+            hostName = IDN.toASCII(tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS));
+        }
+        else {
             hostName = tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS);
         }
         String portText = null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
@@ -73,7 +73,7 @@ public final class Host implements NamedEndpoint, Serializable {
             if (!InetAddressUtils.isIPv6Address(hostName)) {
                 throw URISupport.createException(s, cursor, "Expected an IPv6 address");
             }
-        }  else if (!StandardCharsets.US_ASCII.newEncoder().canEncode(s.toString())){
+        } else if (!TextUtils.isAllASCII(s)) {
             hostName = IDN.toASCII(tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS));
         }
         else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -141,4 +141,22 @@ public final class TextUtils {
         return s.toLowerCase(Locale.ROOT);
     }
 
+    /**
+     * check if a CharSequence only contains US-ASCII code point from {@link java.net.IDN}
+     * @param input which check CharSequence for US-ASCII
+     * @return input all is ASCII
+     * @since 5.2
+     * */
+    public static boolean isAllASCII(CharSequence input) {
+        boolean isASCII = true;
+        for (int i = 0; i < input.length(); i++) {
+            int c = input.charAt(i);
+            if (c > 0x7F) {
+                isASCII = false;
+                break;
+            }
+        }
+        return isASCII;
+    }
+
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -146,11 +146,11 @@ public final class TextUtils {
      * @param input which check CharSequence for US-ASCII
      * @return input all is ASCII
      * @since 5.2
-     * */
-    public static boolean isAllASCII(CharSequence input) {
+     */
+    public static boolean isAllASCII(final CharSequence input) {
         boolean isASCII = true;
         for (int i = 0; i < input.length(); i++) {
-            int c = input.charAt(i);
+            final int c = input.charAt(i);
             if (c > 0x7F) {
                 isASCII = false;
                 break;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
@@ -237,4 +237,22 @@ public class TestBasicMessageBuilders {
                 new BasicHeader("h1", "v1"), new BasicHeader("h1", "v2"), new BasicHeader("h2", "v2")));
     }
 
+    @Test
+    public void testIDNHost() throws Exception {
+        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://датаком.мон/test"));
+        request.addHeader("h1", "v1");
+        request.addHeader("h1", "v2");
+        request.addHeader("h2", "v2");
+        request.setVersion(HttpVersion.HTTP_2);
+        final BasicRequestBuilder builder = BasicRequestBuilder.copy(request);
+        Assertions.assertEquals("GET", builder.getMethod());
+        Assertions.assertEquals("http", builder.getScheme());
+//        Assertions.assertEquals(new URIAuthority("датаком.мон"), builder.getAuthority());
+        Assertions.assertEquals(new URIAuthority("xn--80aak0aklz.xn--l1acc"), builder.getAuthority());
+        Assertions.assertEquals("/test",builder.getPath());
+        Assertions.assertEquals(HttpVersion.HTTP_2, builder.getVersion());
+        assertThat(builder.getHeaders(), HeadersMatcher.same(
+                new BasicHeader("h1", "v1"), new BasicHeader("h1", "v2"), new BasicHeader("h2", "v2")));
+    }
+
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
@@ -239,7 +239,7 @@ public class TestBasicMessageBuilders {
 
     @Test
     public void testIDNHost() throws Exception {
-        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://датаком.мон/test"));
+        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://www.датаком.мон/test"));
         request.addHeader("h1", "v1");
         request.addHeader("h1", "v2");
         request.addHeader("h2", "v2");
@@ -247,8 +247,7 @@ public class TestBasicMessageBuilders {
         final BasicRequestBuilder builder = BasicRequestBuilder.copy(request);
         Assertions.assertEquals("GET", builder.getMethod());
         Assertions.assertEquals("http", builder.getScheme());
-//        Assertions.assertEquals(new URIAuthority("датаком.мон"), builder.getAuthority());
-        Assertions.assertEquals(new URIAuthority("xn--80aak0aklz.xn--l1acc"), builder.getAuthority());
+        Assertions.assertEquals(new URIAuthority("www.xn--80aak0aklz.xn--l1acc"), builder.getAuthority());
         Assertions.assertEquals("/test",builder.getPath());
         Assertions.assertEquals(HttpVersion.HTTP_2, builder.getVersion());
         assertThat(builder.getHeaders(), HeadersMatcher.same(


### PR DESCRIPTION
support IDNA 2008 (RFC 5896)  for [Add support for IDNA 2008 (RFC 5891)](https://issues.apache.org/jira/browse/HTTPCLIENT-2185?jql=project%20in%20(HTTPCLIENT%2C%20HTTPCORE)%20AND%20status%20%3D%20Open%20AND%20labels%20%3D%20volunteers-wanted%20AND%20assignee%20in%20(EMPTY))