### PR TITLE
Bumping versions of slf4j and log4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
     <hamcrest.version>2.2</hamcrest.version>
     <junit.migrationsupport.version>5.0.0</junit.migrationsupport.version>
     <mockito.version>4.4.0</mockito.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <log4j.version>2.17.1</log4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <log4j.version>2.17.2</log4j.version>
     <rxjava.version>2.2.21</rxjava.version>
     <rxjava3.version>3.1.3</rxjava3.version>
     <api.comparison.version>5.1</api.comparison.version>


### PR DESCRIPTION
SLF4J v1.7.25 verson is from March 2017 and it would be nice to keep up with more recent versions, just to be save.
Bumping to latest log4j binding as well.