### PR TITLE
Fix unrepeatable producers to return isRepeatable false

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiBinEntityProducer.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiBinEntityProducer.java
@@ -51,7 +51,7 @@ public class MultiBinEntityProducer extends AbstractBinAsyncEntityProducer {
 
     @Override
     public boolean isRepeatable() {
-        return true;
+        return false;
     }
 
     @Override

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiLineEntityProducer.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/MultiLineEntityProducer.java
@@ -57,7 +57,7 @@ public class MultiLineEntityProducer extends AbstractCharAsyncEntityProducer {
 
     @Override
     public boolean isRepeatable() {
-        return true;
+        return false;
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
@@ -90,7 +90,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
 
     @Override
     public boolean isRepeatable() {
-        return true;
+        return false;
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/StringAsyncEntityProducer.java
@@ -71,7 +71,7 @@ public class StringAsyncEntityProducer extends AbstractCharAsyncEntityProducer {
 
     @Override
     public boolean isRepeatable() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
These classes are returning true for `isRepeatable` but actually not repeatable.
They does not reset bytebuf pointer after producing, and some of them clear bytebuf on `releaseResources`, which make producer produce empty data on repeat.
