### PR TITLE
Consider empty buffered input in appBufferStatus to close the SSLIOSession.

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -392,7 +392,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         }
         if (this.status == CLOSING && this.sslEngine.isOutboundDone()
                 && (this.endOfStream || this.sslEngine.isInboundDone())
-                && (this.terminated || (!this.inPlain.hasData() && this.appBufferStatus != null && this.appBufferStatus.hasBufferedInput()))) {
+                && (this.terminated || (!this.inPlain.hasData() && this.appBufferStatus != null && !this.appBufferStatus.hasBufferedInput()))) {
             this.status = CLOSED;
         }
         // Abnormal session termination

--- a/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -392,7 +392,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         }
         if (this.status == CLOSING && this.sslEngine.isOutboundDone()
                 && (this.endOfStream || this.sslEngine.isInboundDone())
-                && (this.terminated || (!this.inPlain.hasData() && this.appBufferStatus != null && !this.appBufferStatus.hasBufferedInput()))) {
+                && (this.terminated || (!this.inPlain.hasData() && (this.appBufferStatus == null || !this.appBufferStatus.hasBufferedInput())))) {
             this.status = CLOSED;
         }
         // Abnormal session termination


### PR DESCRIPTION
Update the logic back to consider empty buffered input in appBufferStatus before closing the SSLIOSession. 

This was the condition considered before this commit https://github.com/apache/httpcomponents-core/commit/211c21f86f27c8cc786a621fef2e1fdf3dc6b126#diff-b31898263b1708b34dde2568e52e870fa623a6d4be99ce247a7f6dc61f03ed7fR395