### PR TITLE
Add content lenght header even if the body is empty

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -125,7 +125,9 @@ public class RequestContent implements HttpRequestInterceptor {
             MessageSupport.addContentTypeHeader(request, entity);
             MessageSupport.addContentEncodingHeader(request, entity);
         } else {
-            request.addHeader(HttpHeaders.CONTENT_LENGTH, "0");
+            if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method)) {
+                request.addHeader(HttpHeaders.CONTENT_LENGTH, "0");
+            }
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -125,7 +125,7 @@ public class RequestContent implements HttpRequestInterceptor {
             MessageSupport.addContentTypeHeader(request, entity);
             MessageSupport.addContentEncodingHeader(request, entity);
         } else {
-            if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method)) {
+            if (Method.POST.isSame(method) || Method.PUT.isSame(method) || Method.PATCH.isSame(method)) {
                 request.addHeader(HttpHeaders.CONTENT_LENGTH, "0");
             }
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -125,7 +125,7 @@ public class RequestContent implements HttpRequestInterceptor {
             MessageSupport.addContentTypeHeader(request, entity);
             MessageSupport.addContentEncodingHeader(request, entity);
         } else {
-            if (Method.POST.isSame(method) || Method.PUT.isSame(method) || Method.PATCH.isSame(method)) {
+            if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method)) {
                 request.addHeader(HttpHeaders.CONTENT_LENGTH, "0");
             }
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -124,6 +124,8 @@ public class RequestContent implements HttpRequestInterceptor {
             }
             MessageSupport.addContentTypeHeader(request, entity);
             MessageSupport.addContentEncodingHeader(request, entity);
+        } else {
+            request.addHeader(HttpHeaders.CONTENT_LENGTH, "0");
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -127,8 +127,7 @@ public class TestStandardInterceptors {
 
         final HttpRequestInterceptor interceptor = RequestContent.INSTANCE;
         interceptor.process(request, request.getEntity(), context);
-        final Header header = request.getFirstHeader(HttpHeaders.CONTENT_LENGTH);
-        Assertions.assertNull(header);
+        Assertions.assertNotNull(request.getFirstHeader(HttpHeaders.CONTENT_LENGTH));
         Assertions.assertNull(request.getFirstHeader(HttpHeaders.TRANSFER_ENCODING));
    }
 
@@ -240,7 +239,8 @@ public class TestStandardInterceptors {
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         final HttpRequestInterceptor interceptor = RequestContent.INSTANCE;
         interceptor.process(request, request.getEntity(), context);
-        Assertions.assertEquals(0, request.getHeaders().length);
+        Assertions.assertEquals(1, request.getHeaders().length);
+        Assertions.assertNotNull(request.getFirstHeader(HttpHeaders.CONTENT_LENGTH));
     }
 
     @Test


### PR DESCRIPTION
For strict servers which reject requests without content length header.