### PR TITLE
Make it possible to read chunked entities with maxResultLength

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
@@ -158,9 +158,10 @@ public final class EntityUtils {
             final ByteArrayBuffer buffer = new ByteArrayBuffer(Math.min(maxResultLength, contentLength));
             final byte[] tmp = new byte[DEFAULT_BYTE_BUFFER_SIZE];
             int l;
-            while ((l = inStream.read(tmp, 0, Math.min(DEFAULT_BYTE_BUFFER_SIZE, buffer.capacity() - buffer.length()))) > 0) {
+            while ((l = inStream.read(tmp)) != -1 && buffer.length() < maxResultLength) {
                 buffer.append(tmp, 0, l);
             }
+            buffer.setLength(Math.min(buffer.length(), maxResultLength));
             return buffer.toByteArray();
         }
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -262,6 +262,30 @@ public class TestEntityUtils {
     }
 
     @Test
+    public void testByteArrayMaxResultLengthWithNoContentLength() throws IOException {
+        byte b = 'b';
+        byte[] allBytes = new byte[5000];
+        Arrays.fill(allBytes, b);
+        final Map<Integer, byte[]> testCases = new HashMap<>();
+        testCases.put(0, new byte[]{});
+        testCases.put(2, Arrays.copyOfRange(allBytes, 0, 2));
+        testCases.put(allBytes.length, allBytes);
+        testCases.put(Integer.MAX_VALUE, allBytes);
+
+        for (final Map.Entry<Integer, byte[]> tc : testCases.entrySet()) {
+            final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(allBytes), null);
+
+            final byte[] bytes = EntityUtils.toByteArray(entity, tc.getKey());
+            final byte[] expectedBytes = tc.getValue();
+            Assertions.assertNotNull(bytes);
+            Assertions.assertEquals(expectedBytes.length, bytes.length);
+            for (int i = 0; i < expectedBytes.length; i++) {
+                Assertions.assertEquals(expectedBytes[i], bytes[i]);
+            }
+        }
+    }
+
+    @Test
     public void testStringMaxResultLength() throws IOException, ParseException {
         final String allMessage = "Message content";
         final byte[] allBytes = allMessage.getBytes(StandardCharsets.ISO_8859_1);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -263,8 +263,8 @@ public class TestEntityUtils {
 
     @Test
     public void testByteArrayMaxResultLengthWithNoContentLength() throws IOException {
-        byte b = 'b';
-        byte[] allBytes = new byte[5000];
+        final byte b = 'b';
+        final byte[] allBytes = new byte[5000];
         Arrays.fill(allBytes, b);
         final Map<Integer, byte[]> testCases = new HashMap<>();
         testCases.put(0, new byte[]{});

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>httpcomponents-parent</artifactId>
-    <version>12</version>
+    <version>13</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.httpcomponents.core5</groupId>
@@ -81,7 +81,6 @@
     <rxjava.version>2.2.21</rxjava.version>
     <rxjava3.version>3.1.5</rxjava3.version>
     <api.comparison.version>5.1</api.comparison.version>
-    <japicmp.version>0.15.7</japicmp.version>
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters</hc.animal-sniffer.signature.ignores>
   </properties>
 
@@ -199,7 +198,6 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>${japicmp.version}</version>
         <configuration>
           <oldVersion>
             <dependency>
@@ -291,7 +289,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${hc.javadoc.version}</version>
         <configuration>
           <quiet>true</quiet>
           <links>
@@ -330,7 +327,6 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>${japicmp.version}</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -356,16 +352,15 @@
             <excludes>
               <exclude>@org.apache.hc.core5.annotation.Internal</exclude>
             </excludes>
+            <ignoreMissingClasses>true</ignoreMissingClasses>
           </parameter>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>${hc.jxr.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>${hc.surefire.version}</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
This makes it possible to read more than 4096 bytes of a `HttpEntity` with `EntityUtils.toByteArray` when you provide a `maxResultLength`, even if the entity doesn't have a content-length set (for example chunked).

It now reads the stream in a simliar way as `toCharArrayBuffer`.