### PR TITLE
Use either US-ASCII or UTF-8 encoding for text where approriate

### DIFF
--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2GreetingServer.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2GreetingServer.java
@@ -76,7 +76,7 @@ import org.apache.hc.core5.util.TimeValue;
  * Date: Sat, 25 May 2019 03:44:49 GMT
  * Server: Apache-HttpCore/5.0-beta8-SNAPSHOT (Java/1.8.0_202)
  * Transfer-Encoding: chunked
- * Content-Type: text/plain; charset=ISO-8859-1
+ * Content-Type: text/plain; charset=UTF-8
  *
  * Hello bob
  * }</pre>

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicIntegrationTest.java
@@ -442,7 +442,7 @@ public abstract class ClassicIntegrationTest {
 
         public RepeatingEntity(final String content, final Charset charset, final int n, final boolean chunked) {
             super(ContentType.TEXT_PLAIN.withCharset(charset), null, chunked);
-            final Charset cs = charset != null ? charset : StandardCharsets.US_ASCII;
+            final Charset cs = charset != null ? charset : StandardCharsets.UTF_8;
             this.raw = content.getBytes(cs);
             this.n = n;
         }
@@ -531,7 +531,7 @@ public abstract class ClassicIntegrationTest {
             if (entity != null) {
                 final String line = EntityUtils.toString(entity);
                 final ContentType contentType = ContentType.parse(entity.getContentType());
-                final Charset charset = ContentType.getCharset(contentType, StandardCharsets.ISO_8859_1);
+                final Charset charset = ContentType.getCharset(contentType, StandardCharsets.UTF_8);
                 response.setEntity(new RepeatingEntity(line, charset, n, n % 2 == 0));
             }
         });
@@ -553,7 +553,7 @@ public abstract class ClassicIntegrationTest {
                     Assertions.assertNotNull(entity);
                     final InputStream inStream = entity.getContent();
                     final ContentType contentType = ContentType.parse(entity.getContentType());
-                    final Charset charset = ContentType.getCharset(contentType, StandardCharsets.ISO_8859_1);
+                    final Charset charset = ContentType.getCharset(contentType, StandardCharsets.UTF_8);
                     Assertions.assertNotNull(inStream);
                     final BufferedReader reader = new BufferedReader(new InputStreamReader(inStream, charset));
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -153,7 +153,7 @@ public final class ContentType implements Serializable {
             "multipart/related", StandardCharsets.ISO_8859_1);
 
     public static final ContentType TEXT_HTML = create(
-            "text/html", StandardCharsets.ISO_8859_1);
+            "text/html", StandardCharsets.UTF_8);
 
     /**
      * Public constant media type for {@code text/markdown}.
@@ -163,7 +163,7 @@ public final class ContentType implements Serializable {
             "text/markdown", StandardCharsets.UTF_8);
 
     public static final ContentType TEXT_PLAIN = create(
-            "text/plain", StandardCharsets.ISO_8859_1);
+            "text/plain", StandardCharsets.UTF_8);
     public static final ContentType TEXT_XML = create(
             "text/xml", StandardCharsets.UTF_8);
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/CharCodingConfig.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/CharCodingConfig.java
@@ -45,6 +45,8 @@ public class CharCodingConfig {
 
     public static final CharCodingConfig DEFAULT = new Builder().build();
 
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.US_ASCII;
+
     private final Charset charset;
     private final CodingErrorAction malformedInputAction;
     private final CodingErrorAction unmappableInputAction;
@@ -110,7 +112,7 @@ public class CharCodingConfig {
         public Builder setMalformedInputAction(final CodingErrorAction malformedInputAction) {
             this.malformedInputAction = malformedInputAction;
             if (malformedInputAction != null && this.charset == null) {
-                this.charset = StandardCharsets.US_ASCII;
+                this.charset = DEFAULT_CHARSET;
             }
             return this;
         }
@@ -118,7 +120,7 @@ public class CharCodingConfig {
         public Builder setUnmappableInputAction(final CodingErrorAction unmappableInputAction) {
             this.unmappableInputAction = unmappableInputAction;
             if (unmappableInputAction != null && this.charset == null) {
-                this.charset = StandardCharsets.US_ASCII;
+                this.charset = DEFAULT_CHARSET;
             }
             return this;
         }
@@ -126,7 +128,7 @@ public class CharCodingConfig {
         public CharCodingConfig build() {
             Charset charsetCopy = charset;
             if (charsetCopy == null && (malformedInputAction != null || unmappableInputAction != null)) {
-                charsetCopy = StandardCharsets.US_ASCII;
+                charsetCopy = DEFAULT_CHARSET;
             }
             return new CharCodingConfig(charsetCopy, malformedInputAction, unmappableInputAction);
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EntityUtils.java
@@ -59,7 +59,7 @@ public final class EntityUtils {
 
     // TODO Consider using a sane value, but what is sane? 1 GB? 100 MB? 10 MB?
     private static final int DEFAULT_ENTITY_RETURN_MAX_LENGTH = Integer.MAX_VALUE;
-    private static final Charset DEFAULT_CHARSET = StandardCharsets.ISO_8859_1;
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     private static final int DEFAULT_CHAR_BUFFER_SIZE = 1024;
     private static final int DEFAULT_BYTE_BUFFER_SIZE = 4096;
 
@@ -226,7 +226,7 @@ public final class EntityUtils {
     /**
      * Gets the entity content as a String, using the provided default character set
      * if none is found in the entity.
-     * If defaultCharset is null, the default "ISO-8859-1" is used.
+     * If defaultCharset is null, the default "UTF-8" is used.
      *
      * @param entity must not be null
      * @param defaultCharset character set to be applied if none found in the entity,
@@ -247,7 +247,7 @@ public final class EntityUtils {
     /**
      * Gets the entity content as a String, using the provided default character set
      * if none is found in the entity.
-     * If defaultCharset is null, the default "ISO-8859-1" is used.
+     * If defaultCharset is null, the default "UTF-8" is used.
      *
      * @param entity must not be null
      * @param defaultCharset character set to be applied if none found in the entity,
@@ -286,7 +286,7 @@ public final class EntityUtils {
     /**
      * Gets the entity content as a String, using the provided default character set
      * if none is found in the entity.
-     * If defaultCharset is null, the default "ISO-8859-1" is used.
+     * If defaultCharset is null, the default "UTF-8" is used.
      *
      * @param entity must not be null
      * @param defaultCharset character set to be applied if none found in the entity
@@ -306,7 +306,7 @@ public final class EntityUtils {
     /**
      * Gets the entity content as a String, using the provided default character set
      * if none is found in the entity.
-     * If defaultCharset is null, the default "ISO-8859-1" is used.
+     * If defaultCharset is null, the default "UTF-8" is used.
      *
      * @param entity must not be null
      * @param defaultCharset character set to be applied if none found in the entity
@@ -328,7 +328,7 @@ public final class EntityUtils {
     /**
      * Reads the contents of an entity and return it as a String.
      * The content is converted using the character set from the entity (if any),
-     * failing that, "ISO-8859-1" is used.
+     * failing that, "UTF-8" is used.
      *
      * @param entity the entity to convert to a string; must not be null
      * @return String containing the content.
@@ -345,7 +345,7 @@ public final class EntityUtils {
     /**
      * Reads the contents of an entity and return it as a String.
      * The content is converted using the character set from the entity (if any),
-     * failing that, "ISO-8859-1" is used.
+     * failing that, "UTF-8" is used.
      *
      * @param entity the entity to convert to a string; must not be null
      * @param maxResultLength

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/StringEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/StringEntity.java
@@ -62,7 +62,7 @@ public class StringEntity extends AbstractHttpEntity {
             final String string, final ContentType contentType, final String contentEncoding, final boolean chunked) {
         super(contentType, contentEncoding, chunked);
         Args.notNull(string, "Source string");
-        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.ISO_8859_1);
+        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.UTF_8);
         this.content = string.getBytes(charset);
     }
 
@@ -80,7 +80,7 @@ public class StringEntity extends AbstractHttpEntity {
      *
      * @param string content to be used. Not {@code null}.
      * @param charset character set to be used. May be {@code null}, in which case the default
-     *   is {@link StandardCharsets#ISO_8859_1} is assumed
+     *   is {@link StandardCharsets#UTF_8} is assumed
      *
      * @since 4.2
      */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharAsyncEntityProducer.java
@@ -70,7 +70,7 @@ public abstract class AbstractCharAsyncEntityProducer implements AsyncEntityProd
         this.fragmentSizeHint = fragmentSizeHint >= 0 ? fragmentSizeHint : 0;
         this.bytebuf = ByteBuffer.allocate(bufferSize);
         this.contentType = contentType;
-        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.US_ASCII);
+        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.UTF_8);
         this.charsetEncoder = charset.newEncoder();
         this.state = State.ACTIVE;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharDataConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharDataConsumer.java
@@ -116,7 +116,7 @@ public abstract class AbstractCharDataConsumer implements AsyncDataConsumer {
                 charset = charCodingConfig.getCharset();
             }
             if (charset == null) {
-                charset = StandardCharsets.US_ASCII;
+                charset = StandardCharsets.UTF_8;
             }
             charsetDecoder = charset.newDecoder();
             if (charCodingConfig.getMalformedInputAction() != null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
@@ -73,7 +73,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     public BasicAsyncEntityProducer(final CharSequence content, final ContentType contentType, final boolean chunked) {
         Args.notNull(content, "Content");
         this.contentType = contentType;
-        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.US_ASCII);
+        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.UTF_8);
         this.bytebuf = charset.encode(CharBuffer.wrap(content));
         this.length = this.bytebuf.remaining();
         this.chunked = chunked;

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/SocksProxyProtocolHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/SocksProxyProtocolHandler.java
@@ -136,6 +136,8 @@ final class SocksProxyProtocolHandler implements IOEventHandler {
         if (cred == null) {
             return new byte[] {};
         }
+        // These will remain with ISO-8859-1 since the RFC does not mention any string
+        // to octet encoding. So neither one is wrong or right.
         final byte[] bytes = cred.getBytes(StandardCharsets.ISO_8859_1);
         if (bytes.length >= 255) {
             throw new IOException("SOCKS username / password are too long");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
@@ -56,7 +56,7 @@ public class TestChunkCoding {
     @Test
     public void testChunkedInputStreamLargeBuffer() throws IOException {
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] buffer = new byte[300];
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -69,7 +69,7 @@ public class TestChunkCoding {
 
         in.close();
 
-        final String result = new String(out.toByteArray(), StandardCharsets.ISO_8859_1);
+        final String result = new String(out.toByteArray(), StandardCharsets.US_ASCII);
         Assertions.assertEquals(result, CHUNKED_RESULT);
 
         final Header[] footers = in.getFooters();
@@ -85,7 +85,7 @@ public class TestChunkCoding {
     @Test
     public void testChunkedInputStreamSmallBuffer() throws IOException {
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
 
         final byte[] buffer = new byte[7];
@@ -113,7 +113,7 @@ public class TestChunkCoding {
     public void testChunkedInputStreamOneByteRead() throws IOException {
         final String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         int ch;
         int i = '0';
@@ -131,7 +131,7 @@ public class TestChunkCoding {
     public void testAvailable() throws IOException {
         final String s = "5\r\n12345\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         Assertions.assertEquals(0, in.available());
         in.read();
@@ -143,7 +143,7 @@ public class TestChunkCoding {
     public void testChunkedInputStreamClose() throws IOException {
         final String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         in.close();
         in.close();
@@ -158,7 +158,7 @@ public class TestChunkCoding {
     public void testChunkedInputStreamNoClosingChunk() throws IOException {
         final String s = "5\r\n01234\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] tmp = new byte[5];
         Assertions.assertEquals(5, in.read(tmp));
@@ -171,7 +171,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamTruncatedCRLF() throws IOException {
         final String s = "5\r\n01234";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] tmp = new byte[5];
         Assertions.assertEquals(5, in.read(tmp));
@@ -184,7 +184,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamMissingCRLF() throws IOException {
         final String s = "5\r\n012345\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] buffer = new byte[300];
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -202,7 +202,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamMissingLF() throws IOException {
         final String s = "5\r01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         Assertions.assertThrows(MalformedChunkCodingException.class, in::read);
         in.close();
@@ -213,7 +213,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamInvalidSize() throws IOException {
         final String s = "whatever\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         Assertions.assertThrows(MalformedChunkCodingException.class, in::read);
         in.close();
@@ -224,7 +224,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamNegativeSize() throws IOException {
         final String s = "-5\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         Assertions.assertThrows(MalformedChunkCodingException.class, in::read);
         in.close();
@@ -235,7 +235,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamTruncatedChunk() throws IOException {
         final String s = "3\r\n12";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] buffer = new byte[300];
         Assertions.assertEquals(2, in.read(buffer));
@@ -248,7 +248,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamInvalidFooter() throws IOException {
         final String s = "1\r\n0\r\n0\r\nstuff\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         in.read();
         Assertions.assertThrows(MalformedChunkCodingException.class, in::read);
@@ -259,7 +259,7 @@ public class TestChunkCoding {
     public void testCorruptChunkedInputStreamClose() throws IOException {
         final String s = "whatever\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         try (final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream)) {
             Assertions.assertThrows(MalformedChunkCodingException.class, in::read);
         }
@@ -269,7 +269,7 @@ public class TestChunkCoding {
     public void testEmptyChunkedInputStream() throws IOException {
         final String s = "0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] buffer = new byte[300];
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -286,13 +286,13 @@ public class TestChunkCoding {
         final String s = "5; and some very looooong commend\r\n12345\r\n0\r\n";
         final SessionInputBuffer inBuffer1 = new SessionInputBufferImpl(16);
         final byte[] buffer = new byte[300];
-        final ByteArrayInputStream inputStream1 = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream1 = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         try (final ChunkedInputStream in1 = new ChunkedInputStream(inBuffer1, inputStream1)) {
             Assertions.assertEquals(5, in1.read(buffer));
         }
 
         final SessionInputBuffer inBuffer2 = new SessionInputBufferImpl(16, 10);
-        final ByteArrayInputStream inputStream2 = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream2 = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in2 = new ChunkedInputStream(inBuffer2, inputStream2);
         Assertions.assertThrows(MessageConstraintException.class, () -> in2.read(buffer));
     }
@@ -314,7 +314,7 @@ public class TestChunkCoding {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final ChunkedOutputStream out = new ChunkedOutputStream(outbuffer, outputStream, 2048);
-        out.write(input.getBytes(StandardCharsets.ISO_8859_1));
+        out.write(input.getBytes(StandardCharsets.US_ASCII));
         out.flush();
         out.close();
         out.close();
@@ -329,7 +329,7 @@ public class TestChunkCoding {
             result.write(d, 0, len);
         }
 
-        final String output = new String(result.toByteArray(), StandardCharsets.ISO_8859_1);
+        final String output = new String(result.toByteArray(), StandardCharsets.US_ASCII);
         Assertions.assertEquals(input, output);
         in.close();
     }
@@ -396,7 +396,7 @@ public class TestChunkCoding {
     public void testResumeOnSocketTimeoutInData() throws IOException {
         final String s = "5\r\n01234\r\n5\r\n5\0006789\r\na\r\n0123\000456789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final TimeoutByteArrayInputStream inputStream = new TimeoutByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final TimeoutByteArrayInputStream inputStream = new TimeoutByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
 
         final byte[] tmp = new byte[3];
@@ -424,7 +424,7 @@ public class TestChunkCoding {
     public void testResumeOnSocketTimeoutInChunk() throws IOException {
         final String s = "5\000\r\000\n\00001234\r\n\0005\r\n56789\r\na\r\n0123456789\r\n\0000\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
-        final TimeoutByteArrayInputStream inputStream = new TimeoutByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final TimeoutByteArrayInputStream inputStream = new TimeoutByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
 
         final byte[] tmp = new byte[3];
@@ -454,7 +454,7 @@ public class TestChunkCoding {
 
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("1234567890abcdef\r\n01234567".getBytes(
-                StandardCharsets.ISO_8859_1));
+                StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -462,7 +462,7 @@ public class TestChunkCoding {
             out.write(in.read());
         }
 
-        final String result = new String(out.toByteArray(), StandardCharsets.ISO_8859_1);
+        final String result = new String(out.toByteArray(), StandardCharsets.US_ASCII);
         Assertions.assertEquals("01234567", result);
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
@@ -44,7 +44,7 @@ public class TestContentLengthInputStream {
     @Test
     public void testBasics() throws IOException {
         final String s = "1234567890123456";
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final InputStream in = new ContentLengthInputStream(inBuffer, inputStream, 10L);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -55,7 +55,7 @@ public class TestContentLengthInputStream {
         len = in.read(buffer);
         outputStream.write(buffer, 0, len);
 
-        final String result = new String(outputStream.toByteArray(), StandardCharsets.ISO_8859_1);
+        final String result = new String(outputStream.toByteArray(), StandardCharsets.US_ASCII);
         Assertions.assertEquals(result, "1234567890");
         in.close();
     }
@@ -109,7 +109,7 @@ public class TestContentLengthInputStream {
     @Test
     public void testClose() throws IOException {
         final String s = "1234567890123456-";
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final InputStream in = new ContentLengthInputStream(inBuffer, inputStream, 16L);
         in.close();
@@ -124,7 +124,7 @@ public class TestContentLengthInputStream {
     @Test
     public void testTruncatedContent() throws IOException {
         final String s = "1234567890123456";
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1));
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final InputStream in = new ContentLengthInputStream(inBuffer, inputStream, 32L);
         final byte[] tmp = new byte[32];

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestSessionInOutBuffers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestSessionInOutBuffers.java
@@ -559,7 +559,7 @@ public class TestSessionInOutBuffers {
     public void testNonAsciiReadWriteLine() throws Exception {
         final String s1 = constructString(SWISS_GERMAN_HELLO);
 
-        final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16, StandardCharsets.ISO_8859_1.newEncoder());
+        final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16, StandardCharsets.UTF_8.newEncoder());
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         final CharArrayBuffer chbuffer = new CharArrayBuffer(16);
@@ -572,10 +572,10 @@ public class TestSessionInOutBuffers {
         outbuffer.writeLine(chbuffer, outputStream);
         outbuffer.flush(outputStream);
         final long bytesWritten = outbuffer.getMetrics().getBytesTransferred();
-        final long expected = ((s1.getBytes(StandardCharsets.ISO_8859_1).length + 2)) * 10 + 2;
+        final long expected = ((s1.getBytes(StandardCharsets.UTF_8).length + 2)) * 10 + 2;
         Assertions.assertEquals(expected, bytesWritten);
 
-        final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16, StandardCharsets.ISO_8859_1.newDecoder());
+        final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16, StandardCharsets.UTF_8.newDecoder());
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
 
         for (int i = 0; i < 10; i++) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -61,16 +61,16 @@ public class TestEntityUtils {
 
     @Test
     public void testMaxIntContentToByteArray() throws Exception {
-        final byte[] content = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] content = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(content),
-                Integer.MAX_VALUE + 100L, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.ISO_8859_1));
+                Integer.MAX_VALUE + 100L, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 EntityUtils.toByteArray(entity));
     }
 
     @Test
     public void testUnknownLengthContentToByteArray() throws Exception {
-        final byte[] bytes = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), -1, null);
         final byte[] bytes2 = EntityUtils.toByteArray(entity);
         Assertions.assertNotNull(bytes2);
@@ -82,7 +82,7 @@ public class TestEntityUtils {
 
     @Test
     public void testKnownLengthContentToByteArray() throws Exception {
-        final byte[] bytes = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), bytes.length, null);
         final byte[] bytes2 = EntityUtils.toByteArray(entity);
         Assertions.assertNotNull(bytes2);
@@ -99,27 +99,27 @@ public class TestEntityUtils {
 
     @Test
     public void testMaxIntContentToString() throws Exception {
-        final byte[] content = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] content = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(content),
-                Integer.MAX_VALUE + 100L, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.ISO_8859_1));
+                Integer.MAX_VALUE + 100L, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
         Assertions.assertThrows(IllegalArgumentException.class, () ->
-                EntityUtils.toString(entity));
+                EntityUtils.toString(entity, "US-ASCII"));
     }
 
     @Test
     public void testUnknownLengthContentToString() throws Exception {
-        final byte[] bytes = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), -1, null);
-        final String s = EntityUtils.toString(entity, "ISO-8859-1");
+        final String s = EntityUtils.toString(entity, "US-ASCII");
         Assertions.assertEquals("Message content", s);
     }
 
     @Test
     public void testKnownLengthContentToString() throws Exception {
-        final byte[] bytes = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), bytes.length,
-                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.ISO_8859_1));
-        final String s = EntityUtils.toString(entity, StandardCharsets.ISO_8859_1);
+                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
+        final String s = EntityUtils.toString(entity, StandardCharsets.US_ASCII);
         Assertions.assertEquals("Message content", s);
     }
 
@@ -145,7 +145,7 @@ public class TestEntityUtils {
     @Test
     public void testNoCharsetContentToString() throws Exception {
         final String content = constructString(SWISS_GERMAN_HELLO);
-        final byte[] bytes = content.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), ContentType.TEXT_PLAIN);
         final String s = EntityUtils.toString(entity);
     }
@@ -241,7 +241,7 @@ public class TestEntityUtils {
 
     @Test
     public void testByteArrayMaxResultLength() throws IOException {
-        final byte[] allBytes = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] allBytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final Map<Integer, byte[]> testCases = new HashMap<>();
         testCases.put(0, new byte[]{});
         testCases.put(2, Arrays.copyOfRange(allBytes, 0, 2));
@@ -288,7 +288,7 @@ public class TestEntityUtils {
     @Test
     public void testStringMaxResultLength() throws IOException, ParseException {
         final String allMessage = "Message content";
-        final byte[] allBytes = allMessage.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] allBytes = allMessage.getBytes(StandardCharsets.US_ASCII);
         final Map<Integer, String> testCases = new HashMap<>();
         testCases.put(7, allMessage.substring(0, 7));
         testCases.put(allMessage.length(), allMessage);
@@ -296,7 +296,7 @@ public class TestEntityUtils {
 
         for (final Map.Entry<Integer, String> tc : testCases.entrySet()) {
             final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(allBytes), allBytes.length, null);
-            final String string = EntityUtils.toString(entity, StandardCharsets.ISO_8859_1, tc.getKey());
+            final String string = EntityUtils.toString(entity, StandardCharsets.US_ASCII, tc.getKey());
             final String expectedString = tc.getValue();
             Assertions.assertNotNull(string);
             Assertions.assertEquals(expectedString, string);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
@@ -63,7 +63,7 @@ public class TestHttpEntityWrapper {
     @Test
     public void testWriteTo() throws Exception {
         final String s = "Message content";
-        final byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = s.getBytes(StandardCharsets.US_ASCII);
         final StringEntity entity = new StringEntity(s);
         try (final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity)) {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestInputStreamEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestInputStreamEntity.java
@@ -44,7 +44,7 @@ public class TestInputStreamEntity {
 
     @Test
     public void testBasics() throws Exception {
-        final byte[] bytes = "Message content".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final InputStreamEntity entity = new InputStreamEntity(new ByteArrayInputStream(bytes), bytes.length, null);
 
         Assertions.assertEquals(bytes.length, entity.getContentLength());
@@ -69,17 +69,17 @@ public class TestInputStreamEntity {
     @Test
     public void testWriteTo() throws Exception {
         final String message = "Message content";
-        final byte[] bytes = message.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = message.getBytes(StandardCharsets.US_ASCII);
         final InputStream inStream = new ByteArrayInputStream(bytes);
         try (final InputStreamEntity entity = new InputStreamEntity(inStream, bytes.length,
-                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.ISO_8859_1))) {
+                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII))) {
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             entity.writeTo(out);
             final byte[] writtenBytes = out.toByteArray();
             Assertions.assertNotNull(writtenBytes);
             Assertions.assertEquals(bytes.length, writtenBytes.length);
 
-            final String s = new String(writtenBytes, StandardCharsets.ISO_8859_1.name());
+            final String s = new String(writtenBytes, StandardCharsets.US_ASCII.name());
             Assertions.assertEquals(message, s);
         }
     }
@@ -87,11 +87,11 @@ public class TestInputStreamEntity {
     @Test
     public void testWriteToPartialContent() throws Exception {
         final String message = "Message content";
-        final byte[] bytes = message.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = message.getBytes(StandardCharsets.US_ASCII);
         final InputStream inStream = new ByteArrayInputStream(bytes);
         final int contentLength = 7;
         try (final InputStreamEntity entity = new InputStreamEntity(inStream, contentLength,
-                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.ISO_8859_1))) {
+                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII))) {
 
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             entity.writeTo(out);
@@ -99,7 +99,7 @@ public class TestInputStreamEntity {
             Assertions.assertNotNull(writtenBytes);
             Assertions.assertEquals(contentLength, writtenBytes.length);
 
-            final String s = new String(writtenBytes, StandardCharsets.ISO_8859_1.name());
+            final String s = new String(writtenBytes, StandardCharsets.US_ASCII.name());
             Assertions.assertEquals(message.substring(0, contentLength), s);
         }
     }
@@ -107,9 +107,9 @@ public class TestInputStreamEntity {
     @Test
     public void testWriteToUnknownLength() throws Exception {
         final String message = "Message content";
-        final byte[] bytes = message.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = message.getBytes(StandardCharsets.US_ASCII);
         final InputStreamEntity entity = new InputStreamEntity(new ByteArrayInputStream(bytes),
-                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.ISO_8859_1));
+                ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         entity.writeTo(out);
@@ -117,7 +117,7 @@ public class TestInputStreamEntity {
         Assertions.assertNotNull(writtenBytes);
         Assertions.assertEquals(bytes.length, writtenBytes.length);
 
-        final String s = new String(writtenBytes, StandardCharsets.ISO_8859_1.name());
+        final String s = new String(writtenBytes, StandardCharsets.US_ASCII.name());
         Assertions.assertEquals(message, s);
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestStringEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestStringEntity.java
@@ -45,7 +45,7 @@ public class TestStringEntity {
         final String s = "Message content";
         try (final StringEntity httpentity = new StringEntity(s, ContentType.TEXT_PLAIN)) {
 
-            final byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
+            final byte[] bytes = s.getBytes(StandardCharsets.US_ASCII);
             Assertions.assertEquals(bytes.length, httpentity.getContentLength());
             Assertions.assertNotNull(httpentity.getContent());
             Assertions.assertTrue(httpentity.isRepeatable());
@@ -66,7 +66,7 @@ public class TestStringEntity {
         httpentity = new StringEntity(s, StandardCharsets.US_ASCII);
         Assertions.assertEquals("text/plain; charset=US-ASCII", httpentity.getContentType());
         httpentity = new StringEntity(s);
-        Assertions.assertEquals("text/plain; charset=ISO-8859-1", httpentity.getContentType());
+        Assertions.assertEquals("text/plain; charset=UTF-8", httpentity.getContentType());
     }
 
     private static String constructString(final int [] unicodeChars) {
@@ -99,7 +99,7 @@ public class TestStringEntity {
     @Test
     public void testWriteTo() throws Exception {
         final String s = "Message content";
-        final byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         try (final StringEntity httpentity = new StringEntity(s)) {
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
Previously, text-based content was many times encoded with ISO-8859-1. This has gradually fallen out of use in the past 10 to 15 years. Use US-ASCII where a 7-bit encoding scheme is required for everything related to text encoding use UTF-8.

This is just a draft to move to UTF-8. May contain incorrect changes. Intended for 5.3+ only.