### PR TITLE
Replace lambdas with method references.

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,20 +1,35 @@
 Release 5.2.1
 ------------------
 
-This is the second GA release in the 5.2 release series.
+This is a maintenance release that corrects several minor defects discovered since release 5.2
+and fixes SOCKS proxy protocol support in the async transport.
 
-Please note that 5.2 upgrades the minimal JRE level to version 8 (8u251 is required).
 
 Change Log
 -------------------
 
-* Add org.apache.hc.core5.http.protocol.HttpCoreContext.toString().
+* HTTPCLIENT-2248: Fixed broken TLS over SOCKS.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* I/O reactor connect process redesign.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* SOCKS protocol handling: Delegate resolution of unknown hostnames to the SOCKS proxy.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* I/O reactor to validate remote endpoint address at the last moment immediately before connect.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* Bug fix: I/O reactor must handle all runtime exceptions when connecting to remote endpoints.
+  Contributed by Oleg Kalnichevski <olegk at apache.org>
+
+* Added org.apache.hc.core5.http.protocol.HttpCoreContext#toString().
   Contributed by Gary Gregory <ggregory at apache.org>
 
 * Examples should log exceptions instead of swallowing them.
   Contributed by Gary Gregory <ggregory at apache.org>
 
-* Fix HTTPCORE-729: NullPointerException at org.apache.hc.core5.http.impl.nio.ServerHttp1IOEventHandlerFactory.createHandler()
+* HTTPCORE-729: NPE in ServerHttp1IOEventHandlerFactory due to a missing null check
   Contributed by Oleg Kalnichevski <olegk at apache.org>
 
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,16 @@
+Release 5.2.2
+------------------
+
+This is a maintenance release that corrects several minor defects discovered since release 5.2.1.
+
+
+Change Log
+-------------------
+
+* Do not duplicate the HttpMessage instance variable slot in subclasses of AbstractMessageWrapper.
+  Contributed by Gary Gregory <ggregory at apache.org>
+
+
 Release 5.2.1
 ------------------
 

--- a/httpcore5-h2/pom.xml
+++ b/httpcore5-h2/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.core5</groupId>
     <artifactId>httpcore5-parent</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>httpcore5-h2</artifactId>
   <name>Apache HttpComponents Core HTTP/2</name>

--- a/httpcore5-reactive/pom.xml
+++ b/httpcore5-reactive/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>httpcore5-parent</artifactId>
     <groupId>org.apache.httpcomponents.core5</groupId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/examples/ReactiveFullDuplexServerExample.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/examples/ReactiveFullDuplexServerExample.java
@@ -68,7 +68,7 @@ public class ReactiveFullDuplexServerExample {
             .build();
 
         final HttpAsyncServer server = AsyncServerBootstrap.bootstrap()
-            .setExceptionCallback(e -> e.printStackTrace())
+            .setExceptionCallback(Throwable::printStackTrace)
             .setIOReactorConfig(config)
             .setStreamListener(new Http1StreamListener() {
                 @Override

--- a/httpcore5-testing/pom.xml
+++ b/httpcore5-testing/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.core5</groupId>
     <artifactId>httpcore5-parent</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>httpcore5-testing</artifactId>
   <name>Apache HttpComponents Core Integration Tests</name>

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFramework.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFramework.java
@@ -85,7 +85,7 @@ public class TestTestingFramework {
     @Test
     public void runTestsWithoutSettingAdapterThrows() throws Exception {
         final TestingFramework framework = newWebServerTestingFramework();
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class TestTestingFramework {
         final ClientTestingAdapter adapter = null;
 
         final TestingFramework framework = newWebServerTestingFramework(adapter);
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class TestTestingFramework {
 
         final TestingFramework framework = newWebServerTestingFramework(adapter);
         framework.setAdapter(adapter);
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -235,7 +235,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     private Map<String, Object> alreadyCheckedResponse() {
@@ -294,7 +294,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -325,7 +325,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -383,7 +383,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -419,7 +419,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     private Object deepcopy(final Object obj) {
@@ -456,8 +456,7 @@ public class TestTestingFramework {
 
         framework.addTest(test);
 
-        final TestingFrameworkException exception = Assertions.assertThrows(TestingFrameworkException.class, () ->
-                framework.runTests());
+        final TestingFrameworkException exception = Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
         // make sure the HTTP Client name is in the message.
         final String message = exception.getMessage();
         final ClientPOJOAdapter pojoAdapter = adapter.getClientPOJOAdapter();
@@ -539,7 +538,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -564,7 +563,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -589,7 +588,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -614,7 +613,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -638,7 +637,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -662,7 +661,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -686,7 +685,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test
@@ -714,7 +713,7 @@ public class TestTestingFramework {
 
         framework.addTest();
 
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
+        Assertions.assertThrows(TestingFrameworkException.class, framework::runTests);
     }
 
     @Test

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFrameworkRequestHandler.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFrameworkRequestHandler.java
@@ -65,7 +65,7 @@ public class TestTestingFrameworkRequestHandler {
 
         handler.handle(null, null, null);
         final TestingFrameworkException exception = Assertions.assertThrows(TestingFrameworkException.class,
-                () -> handler.assertNothingThrown());
+                handler::assertNothingThrown);
         Assertions.assertEquals(errorMessage, exception.getMessage(), "Unexpected message");
         // a second call should not throw
         handler.assertNothingThrown();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TestDefaultListeningIOReactor.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TestDefaultListeningIOReactor.java
@@ -108,7 +108,7 @@ public class TestDefaultListeningIOReactor {
         final int port = ((InetSocketAddress) endpoint1.getAddress()).getPort();
 
         final Future<ListenerEndpoint> future2 = ioReactor.listen(new InetSocketAddress(port));
-        Assertions.assertThrows(ExecutionException.class, () -> future2.get());
+        Assertions.assertThrows(ExecutionException.class, future2::get);
         ioReactor.close(CloseMode.GRACEFUL);
         ioReactor.awaitShutdown(TimeValue.ofSeconds(5));
 

--- a/httpcore5/pom.xml
+++ b/httpcore5/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.core5</groupId>
     <artifactId>httpcore5-parent</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>httpcore5</artifactId>
   <name>Apache HttpComponents Core HTTP/1.1</name>

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/AbstractMessageWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/AbstractMessageWrapper.java
@@ -37,12 +37,14 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * Abstract {@link HttpMessage} wrapper.
+ *
+ * @param <T> A {@link HttpMessage} type.
  */
-public abstract class AbstractMessageWrapper implements HttpMessage {
+public abstract class AbstractMessageWrapper<T extends HttpMessage> implements HttpMessage {
 
-    private final HttpMessage message;
+    private final T message;
 
-    public AbstractMessageWrapper(final HttpMessage message) {
+    public AbstractMessageWrapper(final T message) {
         this.message = Args.notNull(message, "Message");
     }
 
@@ -119,6 +121,10 @@ public abstract class AbstractMessageWrapper implements HttpMessage {
     @Override
     public Header getLastHeader(final String name) {
         return message.getLastHeader(name);
+    }
+
+    T getMessage() {
+        return message;
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/HttpRequestWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/HttpRequestWrapper.java
@@ -34,65 +34,64 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.net.URIAuthority;
 
 /**
+ * Wraps an {@link HttpRequest}.
+ *
  * {@link HttpRequest} wrapper.
  */
-public class HttpRequestWrapper extends AbstractMessageWrapper implements HttpRequest {
-
-    private final HttpRequest message;
+public class HttpRequestWrapper extends AbstractMessageWrapper<HttpRequest> implements HttpRequest {
 
     public HttpRequestWrapper(final HttpRequest message) {
         super(message);
-        this.message = message;
     }
 
     @Override
     public String getMethod() {
-        return message.getMethod();
+        return getMessage().getMethod();
     }
 
     @Override
     public String getPath() {
-        return message.getPath();
+        return getMessage().getPath();
     }
 
     @Override
     public void setPath(final String path) {
-        message.setPath(path);
+        getMessage().setPath(path);
     }
 
     @Override
     public String getScheme() {
-        return message.getScheme();
+        return getMessage().getScheme();
     }
 
     @Override
     public void setScheme(final String scheme) {
-        message.setScheme(scheme);
+        getMessage().setScheme(scheme);
     }
 
     @Override
     public URIAuthority getAuthority() {
-        return message.getAuthority();
+        return getMessage().getAuthority();
     }
 
     @Override
     public void setAuthority(final URIAuthority authority) {
-        message.setAuthority(authority);
+        getMessage().setAuthority(authority);
     }
 
     @Override
     public String getRequestUri() {
-        return message.getRequestUri();
+        return getMessage().getRequestUri();
     }
 
     @Override
     public URI getUri() throws URISyntaxException {
-        return message.getUri();
+        return getMessage().getUri();
     }
 
     @Override
     public void setUri(final URI requestUri) {
-        message.setUri(requestUri);
+        getMessage().setUri(requestUri);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/HttpResponseWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/HttpResponseWrapper.java
@@ -32,45 +32,44 @@ import java.util.Locale;
 import org.apache.hc.core5.http.HttpResponse;
 
 /**
+ * Wraps an {@link HttpResponse}.
+ *
  * {@link HttpResponse} wrapper.
  */
-public class HttpResponseWrapper extends AbstractMessageWrapper implements HttpResponse {
-
-    private final HttpResponse message;
+public class HttpResponseWrapper extends AbstractMessageWrapper<HttpResponse> implements HttpResponse {
 
     public HttpResponseWrapper(final HttpResponse message) {
         super(message);
-        this.message = message;
     }
 
     @Override
     public int getCode() {
-        return message.getCode();
+        return getMessage().getCode();
     }
 
     @Override
     public void setCode(final int code) {
-        message.setCode(code);
+        getMessage().setCode(code);
     }
 
     @Override
     public String getReasonPhrase() {
-        return message.getReasonPhrase();
+        return getMessage().getReasonPhrase();
     }
 
     @Override
     public void setReasonPhrase(final String reason) {
-        message.setReasonPhrase(reason);
+        getMessage().setReasonPhrase(reason);
     }
 
     @Override
     public Locale getLocale() {
-        return message.getLocale();
+        return getMessage().getLocale();
     }
 
     @Override
     public void setLocale(final Locale loc) {
-        message.setLocale(loc);
+        getMessage().setLocale(loc);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/BasicAsyncEntityProducer.java
@@ -147,6 +147,7 @@ public class BasicAsyncEntityProducer implements AsyncEntityProducer {
     @Override
     public void releaseResources() {
         bytebuf.clear();
+        bytebuf.limit(length);
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFileServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFileServerExample.java
@@ -86,7 +86,7 @@ public class AsyncFileServerExample {
                 .build();
 
         final HttpAsyncServer server = AsyncServerBootstrap.bootstrap()
-                .setExceptionCallback(e -> e.printStackTrace())
+                .setExceptionCallback(Throwable::printStackTrace)
                 .setIOReactorConfig(config)
                 .register("*", new AsyncServerRequestHandler<Message<HttpRequest, Void>>() {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFullDuplexServerExample.java
@@ -75,7 +75,7 @@ public class AsyncFullDuplexServerExample {
                 .build();
 
         final HttpAsyncServer server = AsyncServerBootstrap.bootstrap()
-                .setExceptionCallback(e -> e.printStackTrace())
+                .setExceptionCallback(Throwable::printStackTrace)
                 .setIOReactorConfig(config)
                 .setStreamListener(new Http1StreamListener() {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncReverseProxyExample.java
@@ -162,7 +162,7 @@ public class AsyncReverseProxyExample {
                 .create();
 
         final HttpAsyncServer server = AsyncServerBootstrap.bootstrap()
-                .setExceptionCallback(e -> e.printStackTrace())
+                .setExceptionCallback(Throwable::printStackTrace)
                 .setIOReactorConfig(config)
                 .setStreamListener(new Http1StreamListener() {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncServerFilterExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncServerFilterExample.java
@@ -76,7 +76,7 @@ public class AsyncServerFilterExample {
                 .build();
 
         final HttpAsyncServer server = AsyncServerBootstrap.bootstrap()
-                .setExceptionCallback(e -> e.printStackTrace())
+                .setExceptionCallback(Throwable::printStackTrace)
                 .setIOReactorConfig(config)
 
                 // Replace standard expect-continue handling with a custom auth filter

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
@@ -147,7 +147,7 @@ public class TestChunkCoding {
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         in.close();
         in.close();
-        Assertions.assertThrows(StreamClosedException.class, () -> in.read());
+        Assertions.assertThrows(StreamClosedException.class, in::read);
         final byte[] tmp = new byte[10];
         Assertions.assertThrows(StreamClosedException.class, () -> in.read(tmp));
         Assertions.assertThrows(StreamClosedException.class, () -> in.read(tmp, 0, tmp.length));
@@ -162,8 +162,8 @@ public class TestChunkCoding {
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] tmp = new byte[5];
         Assertions.assertEquals(5, in.read(tmp));
-        Assertions.assertThrows(ConnectionClosedException.class, () -> in.read());
-        Assertions.assertThrows(ConnectionClosedException.class, () -> in.close());
+        Assertions.assertThrows(ConnectionClosedException.class, in::read);
+        Assertions.assertThrows(ConnectionClosedException.class, in::close);
     }
 
     // Truncated stream (missing closing CRLF)
@@ -175,7 +175,7 @@ public class TestChunkCoding {
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
         final byte[] tmp = new byte[5];
         Assertions.assertEquals(5, in.read(tmp));
-        Assertions.assertThrows(MalformedChunkCodingException.class, () -> in.read());
+        Assertions.assertThrows(MalformedChunkCodingException.class, in::read);
         in.close();
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
@@ -131,8 +131,8 @@ public class TestContentLengthInputStream {
         final int byteRead = in.read(tmp);
         Assertions.assertEquals(16, byteRead);
         Assertions.assertThrows(ConnectionClosedException.class, () -> in.read(tmp));
-        Assertions.assertThrows(ConnectionClosedException.class, () -> in.read());
-        Assertions.assertThrows(ConnectionClosedException.class, () -> in.close());
+        Assertions.assertThrows(ConnectionClosedException.class, in::read);
+        Assertions.assertThrows(ConnectionClosedException.class, in::close);
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestIdentityInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestIdentityInputStream.java
@@ -71,7 +71,7 @@ public class TestIdentityInputStream {
         Assertions.assertEquals(0, in.available());
         final byte[] tmp = new byte[2];
         Assertions.assertThrows(StreamClosedException.class, () -> in.read(tmp, 0, tmp.length));
-        Assertions.assertThrows(StreamClosedException.class, () -> in.read());
+        Assertions.assertThrows(StreamClosedException.class, in::read);
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkEncoder.java
@@ -193,7 +193,7 @@ public class TestChunkEncoder {
         encoder.complete();
 
         Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(CodecTestUtils.wrap("more stuff")));
-        Assertions.assertThrows(IllegalStateException.class, () -> encoder.complete());
+        Assertions.assertThrows(IllegalStateException.class, encoder::complete);
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderElementIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderElementIterator.java
@@ -59,10 +59,10 @@ public class TestBasicHeaderElementIterator {
         Assertions.assertEquals("value1", elem.getName(), "The two header values must be equal");
 
         Assertions.assertFalse(hei.hasNext());
-        Assertions.assertThrows(NoSuchElementException.class, () -> hei.next());
+        Assertions.assertThrows(NoSuchElementException.class, hei::next);
 
         Assertions.assertFalse(hei.hasNext());
-        Assertions.assertThrows(NoSuchElementException.class, () -> hei.next());
+        Assertions.assertThrows(NoSuchElementException.class, hei::next);
     }
 
     @Test
@@ -100,9 +100,9 @@ public class TestBasicHeaderElementIterator {
                 new BasicHeaderIterator(headers, "Name"));
 
         Assertions.assertFalse(hei.hasNext());
-        Assertions.assertThrows(NoSuchElementException.class, () -> hei.next());
+        Assertions.assertThrows(NoSuchElementException.class, hei::next);
         Assertions.assertFalse(hei.hasNext());
-        Assertions.assertThrows(NoSuchElementException.class, () -> hei.next());
+        Assertions.assertThrows(NoSuchElementException.class, hei::next);
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderIterator.java
@@ -222,7 +222,7 @@ public class TestBasicHeaderIterator {
         Assertions.assertFalse(hit.hasNext());
 
         // but this is
-        Assertions.assertThrows(NoSuchElementException.class, () -> hit.next());
+        Assertions.assertThrows(NoSuchElementException.class, hit::next);
     }
 
     @Test
@@ -250,6 +250,6 @@ public class TestBasicHeaderIterator {
 
         final Iterator<Header> hit2 = new BasicHeaderIterator(headers, null);
         Assertions.assertTrue(hit2.hasNext());
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> hit2.remove());
+        Assertions.assertThrows(UnsupportedOperationException.class, hit2::remove);
     }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicTokenIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicTokenIterator.java
@@ -191,8 +191,8 @@ public class TestBasicTokenIterator {
         final Iterator<Header> hit = new BasicHeaderIterator(headers, null);
         final Iterator<String>  ti  = new BasicTokenIterator(hit);
 
-        Assertions.assertThrows(NoSuchElementException.class, () -> ti.next());
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> ti.remove());
+        Assertions.assertThrows(NoSuchElementException.class, ti::next);
+        Assertions.assertThrows(UnsupportedOperationException.class, ti::remove);
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestBasicAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestBasicAsyncEntityProducer.java
@@ -99,4 +99,18 @@ public class TestBasicAsyncEntityProducer {
         }
     }
 
+    @Test
+    public void testTextContentRepeatableUTF() throws Exception {
+        final String content = "<testtag></testtag>";
+        final AsyncEntityProducer producer = new BasicAsyncEntityProducer(content, ContentType.TEXT_XML);
+        for (int i = 0; i < 3; i++) {
+            final WritableByteChannelMock byteChannel = new WritableByteChannelMock(1024);
+            final DataStreamChannel streamChannel = new BasicDataStreamChannel(byteChannel);
+            producer.produce(streamChannel);
+            Assertions.assertFalse(byteChannel.isOpen());
+            Assertions.assertEquals(content, byteChannel.dump(StandardCharsets.UTF_8));
+            producer.releaseResources();
+        }
+    }
+
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
@@ -542,8 +542,7 @@ public class TestStrictConnPool {
         // Attempt to get a connection while lock is held
         final Future<PoolEntry<String, HttpConnection>> future2 = pool.lease("somehost", null, Timeout.ofMilliseconds(10), null);
 
-        final ExecutionException executionException = Assertions.assertThrows(ExecutionException.class, () ->
-                future2.get());
+        final ExecutionException executionException = Assertions.assertThrows(ExecutionException.class, future2::get);
         Assertions.assertTrue(executionException.getCause() instanceof DeadlineTimeoutException);
         holdInternalLock.interrupt(); // Cleanup
     }
@@ -562,7 +561,7 @@ public class TestStrictConnPool {
         final Future<PoolEntry<String, HttpConnection>> future2 = pool.lease("somehost", null, Timeout.ofMilliseconds(10), null);
 
         Assertions.assertTrue(Thread.interrupted());
-        Assertions.assertThrows(CancellationException.class, () -> future2.get());
+        Assertions.assertThrows(CancellationException.class, future2::get);
         holdInternalLock.interrupt(); // Cleanup
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <log4j.version>2.19.0</log4j.version>
     <rxjava.version>2.2.21</rxjava.version>
     <rxjava3.version>3.1.5</rxjava3.version>
-    <api.comparison.version>5.1</api.comparison.version>
+    <api.comparison.version>5.2</api.comparison.version>
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters,java.nio.ByteBuffer,java.nio.CharBuffer</hc.animal-sniffer.signature.ignores>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.httpcomponents.core5</groupId>
   <artifactId>httpcore5-parent</artifactId>
   <name>Apache HttpComponents Core Parent</name>
-  <version>5.2.1-SNAPSHOT</version>
+  <version>5.2.2-SNAPSHOT</version>
   <description>Apache HttpComponents Core is a library of components for building HTTP enabled services</description>
   <url>https://hc.apache.org/httpcomponents-core-5.2.x/${project.version}/</url>
   <inceptionYear>2005</inceptionYear>
@@ -48,7 +48,7 @@
     <connection>scm:git:https://gitbox.apache.org/repos/asf/httpcomponents-core.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/httpcomponents-core.git</developerConnection>
     <url>https://github.com/apache/httpcomponents-core/tree/${project.scm.tag}</url>
-    <tag>5.2.1-SNAPSHOT</tag>
+    <tag>5.2.2-SNAPSHOT</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Method references are more clear and readable compared to. Of course this  could be a matter of taste.