### PR TITLE
Replace new FileInputStream() and/or new FileOutputStream() expressions  with Files.newInputStream() and/or Files.newOutputStream() calls respectively.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/FileEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/FileEntity.java
@@ -28,9 +28,9 @@
 package org.apache.hc.core5.http.io.entity;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -69,7 +69,7 @@ public class FileEntity extends AbstractHttpEntity {
 
     @Override
     public final InputStream getContent() throws IOException {
-        return new FileInputStream(this.file);
+        return Files.newInputStream(this.file.toPath());
     }
 
     @Override

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/CodecTestUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/CodecTestUtils.java
@@ -28,10 +28,11 @@
 package org.apache.hc.core5.http.impl.nio;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 class CodecTestUtils {
 
@@ -49,8 +50,8 @@ class CodecTestUtils {
     }
 
     public static String readFromFile(final File file) throws Exception {
-        final FileInputStream filestream = new FileInputStream(file);
-        try (InputStreamReader reader = new InputStreamReader(filestream)) {
+        final InputStream inputStream = Files.newInputStream(file.toPath());
+        try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             final StringBuilder buffer = new StringBuilder();
             final char[] tmp = new char[2048];
             int l;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestFileEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestFileEntity.java
@@ -29,8 +29,9 @@ package org.apache.hc.core5.http.io.entity;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 
 import org.apache.hc.core5.http.ContentType;
 import org.junit.jupiter.api.Assertions;
@@ -68,7 +69,7 @@ public class TestFileEntity {
         final File tmpfile = File.createTempFile("testfile", ".txt");
         tmpfile.deleteOnExit();
 
-        final FileOutputStream outStream = new FileOutputStream(tmpfile);
+        final OutputStream outStream = Files.newOutputStream(tmpfile.toPath());
         outStream.write(0);
         outStream.write(1);
         outStream.write(2);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileAsyncEntityProducer.java
@@ -28,10 +28,10 @@
 package org.apache.hc.core5.http.nio.entity;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.WritableByteChannelMock;
@@ -50,7 +50,7 @@ public class TestFileAsyncEntityProducer {
     @BeforeEach
     public void setup() throws Exception {
         tempFile = File.createTempFile("testing", ".txt");
-        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.US_ASCII)) {
+        try (final Writer writer = new OutputStreamWriter(Files.newOutputStream(tempFile.toPath()), StandardCharsets.US_ASCII)) {
             writer.append("abcdef");
             writer.flush();
         }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
@@ -28,10 +28,10 @@
 package org.apache.hc.core5.http.nio.entity;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -60,7 +60,7 @@ public class TestPathAsyncEntityProducer {
     @BeforeEach
     public void setup() throws Exception {
         tempFile = File.createTempFile("testing", ".txt");
-        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.US_ASCII)) {
+        try (final Writer writer = new OutputStreamWriter(Files.newOutputStream(tempFile.toPath()), StandardCharsets.US_ASCII)) {
             writer.append("abcdef");
             writer.flush();
         }


### PR DESCRIPTION
Again,  this could be a matter of taste.