### PR TITLE
Fix the issue with invalid scoped IPv6 addresses in InetAddressUtils.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
@@ -79,6 +79,19 @@ public class InetAddressUtils {
                  "::" +
                  "(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,5})?)$"); // 0-6 hex fields
 
+    /**
+     * Regular expression pattern to match the scope ID in an IPv6 scoped address.
+     * The scope ID should be a non-empty string consisting of only alphanumeric characters or "-".
+     */
+    private static final Pattern SCOPE_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+$");
+
+    /**
+     * Delimiter used to separate an IPv6 address from its scope ID.
+     */
+    private static final String SCOPE_ID_DELIMITER = "%";
+
+
+
     /*
      *  The above pattern is not totally rigorous as it allows for more than 7 hex fields in total
      */
@@ -139,7 +152,20 @@ public class InetAddressUtils {
      * @return true if the input parameter is a valid standard or compressed IPv6 address
      */
     public static boolean isIPv6Address(final String input) {
-        return isIPv6StdAddress(input) || isIPv6HexCompressedAddress(input);
+        final int index = input.indexOf(SCOPE_ID_DELIMITER);
+        if (index == -1) {
+            return isIPv6StdAddress(input) || isIPv6HexCompressedAddress(input);
+        } else {
+            final String address = input.substring(0, index);
+            if (isIPv6StdAddress(address) || isIPv6HexCompressedAddress(address)) {
+                // Check if the scope ID is valid
+                final String scopeId = input.substring(index + 1);
+                // Scope ID should be a non-empty string consisting of only alphanumeric characters or "-"
+                return !scopeId.isEmpty() && SCOPE_ID_PATTERN.matcher(scopeId).matches();
+            } else {
+                return false;
+            }
+        }
     }
 
     /**

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
@@ -73,6 +73,11 @@ public class TestInetAddressUtils {
         Assertions.assertTrue(InetAddressUtils.isIPv6Address("2001:db8::1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6Address("::1"));
         Assertions.assertTrue(InetAddressUtils.isIPv6Address("::")); // http://tools.ietf.org/html/rfc4291#section-2.2
+
+        //HTTPCORE-674 InetAddressUtils scoped ID support
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%eth2"));
+        Assertions.assertTrue(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%3"));
     }
 
     @Test
@@ -88,6 +93,19 @@ public class TestInetAddressUtils {
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress("1::3:4:5:6:7:8:9")); // too many fields after ::
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressedAddress("::3:4:5:6:7:8:9")); // too many fields after ::
         Assertions.assertFalse(InetAddressUtils.isIPv6Address("")); // empty
+
+        //Invalid scoped IDs
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%eth2#"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%3@"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a#eth2"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%eth2!"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("2001:0db8:0:0::1428:57ab%"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("2001:0db8:0:0::1428:57ab%eth2#"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%eth2#3"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("2001:0db8:0:0::1428:57ab%eth2#3"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("fe80::1ff:fe23:4567:890a%3#eth2"));
+        Assertions.assertFalse(InetAddressUtils.isIPv6Address("2001:0db8:0:0::1428:57ab%3#eth2"));
     }
 
     @Test


### PR DESCRIPTION
This Pull Request addresses the issue of properly handling scoped IPv6 addresses in the InetAddressUtils class. The previous implementation had incorrect behavior when handling scoped IPv6 addresses. This fix updates the logic to properly check the format of the scope ID and to return false when the address is not a valid standard or compressed IPv6 address.
