### PR TITLE
The official document POST example incorrectly calls the GET method

### DIFF
--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
@@ -106,7 +106,7 @@ public class ClassicPostExecutionExample {
 
         final String requestUri = "/post";
         for (int i = 0; i < requestBodies.length; i++) {
-            final ClassicHttpRequest request = ClassicRequestBuilder.get()
+            final ClassicHttpRequest request = ClassicRequestBuilder.post()
                     .setHttpHost(target)
                     .setPath(requestUri)
                     .build();


### PR DESCRIPTION
The official document POST example incorrectly calls the GET method. For beginners, it is necessary to revise.