### PR TITLE
Hygiene changes to Deadline

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Deadline.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Deadline.java
@@ -27,7 +27,6 @@
 
 package org.apache.hc.core5.util;
 
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -60,12 +59,12 @@ public class Deadline {
     /**
      * The maximum (longest-lived) deadline.
      */
-    public static Deadline MAX_VALUE = new Deadline(INTERNAL_MAX_VALUE);
+    public static final Deadline MAX_VALUE = new Deadline(INTERNAL_MAX_VALUE);
 
     /**
      * The minimum (shortest-lived) deadline.
      */
-    public static Deadline MIN_VALUE = new Deadline(INTERNAL_MIN_VALUE);
+    public static final Deadline MIN_VALUE = new Deadline(INTERNAL_MIN_VALUE);
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
             .parseLenient()
@@ -122,9 +121,8 @@ public class Deadline {
      *
      * @param source a string in the format {@value #DATE_FORMAT}.
      * @return a deadline from a string in the format {@value #DATE_FORMAT}.
-     * @throws ParseException if the specified source string cannot be parsed.
      */
-    public static Deadline parse(final String source) throws ParseException {
+    public static Deadline parse(final String source) {
         if (source == null) {
             return null;
         }


### PR DESCRIPTION
Since this is the v5.3 branch which is in alpha stage, is it fine to break binary compatibility by making Deadline.MIN_VALUE and Deadline.MAX_VALUE final and removing the checked exception from Deadline.parse since it cannot be thrown from the method body?

For context regarding MIN_VALUE/MAX_VALUE: https://github.com/apache/httpcomponents-core/pull/355

Thanks.