### PR TITLE
Add support for Internationalized Domain Names (IDN)

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/Host.java
@@ -27,6 +27,7 @@
 package org.apache.hc.core5.net;
 
 import java.io.Serializable;
+import java.net.IDN;
 import java.net.URISyntaxException;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -59,7 +60,7 @@ public final class Host implements NamedEndpoint, Serializable {
 
     static Host parse(final CharSequence s, final Tokenizer.Cursor cursor) throws URISyntaxException {
         final Tokenizer tokenizer = Tokenizer.INSTANCE;
-        final String hostName;
+        String hostName;
         final boolean ipv6Brackets = !cursor.atEnd() && s.charAt(cursor.getPos()) == '[';
         if (ipv6Brackets) {
             cursor.updatePos(cursor.getPos() + 1);
@@ -73,6 +74,9 @@ public final class Host implements NamedEndpoint, Serializable {
             }
         } else {
             hostName = tokenizer.parseContent(s, cursor, URISupport.PORT_SEPARATORS);
+            if (!TextUtils.isAllASCII(hostName)) {
+                hostName = IDN.toASCII(hostName);
+            }
         }
         String portText = null;
         if (!cursor.atEnd() && s.charAt(cursor.getPos()) == ':') {

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -141,4 +141,22 @@ public final class TextUtils {
         return s.toLowerCase(Locale.ROOT);
     }
 
+
+    /**
+     * Determines whether the given {@link CharSequence} contains only ASCII characters.
+     *
+     * @param s the {@link CharSequence} to check
+     * @return true if the {@link CharSequence} contains only ASCII characters, false otherwise
+     * @throws IllegalArgumentException if the input {@link CharSequence} is null
+     * @since 5.3
+     */
+    public static boolean isAllASCII(final CharSequence s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) > 0x7F) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
@@ -106,7 +106,7 @@ public class ClassicPostExecutionExample {
 
         final String requestUri = "/post";
         for (int i = 0; i < requestBodies.length; i++) {
-            final ClassicHttpRequest request = ClassicRequestBuilder.post()
+            final ClassicHttpRequest request = ClassicRequestBuilder.get()
                     .setHttpHost(target)
                     .setPath(requestUri)
                     .build();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
@@ -106,7 +106,7 @@ public class ClassicPostExecutionExample {
 
         final String requestUri = "/post";
         for (int i = 0; i < requestBodies.length; i++) {
-            final ClassicHttpRequest request = ClassicRequestBuilder.get()
+            final ClassicHttpRequest request = ClassicRequestBuilder.post()
                     .setHttpHost(target)
                     .setPath(requestUri)
                     .build();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.support;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hc.core5.http.HeaderMatcher;
 import org.apache.hc.core5.http.HeadersMatcher;
@@ -235,6 +236,13 @@ public class TestBasicMessageBuilders {
         Assertions.assertEquals(HttpVersion.HTTP_2, builder.getVersion());
         assertThat(builder.getHeaders(), HeadersMatcher.same(
                 new BasicHeader("h1", "v1"), new BasicHeader("h1", "v2"), new BasicHeader("h2", "v2")));
+    }
+
+    @Test
+    void testIDNIntegration() {
+        final String url = "http://müller.example.com:8080/path";
+        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create(url));
+        assertEquals(new URIAuthority("xn--mller-kva.example.com",8080), request.getAuthority());
     }
 
 }


### PR DESCRIPTION
Improve IDN support in URI parsing by converting non-ASCII characters to their ASCII-compatible form using the java.net.IDN class. This allows for better interoperability with systems that may not support Unicode characters in domain names. The change was made by adding a conditional statement that checks if the hostname contains non-ASCII characters, and if so, applies the IDN conversion. 