### PR TITLE
HTTPCORE-737: Add maven.compiler.release if build jdk >= 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,18 @@
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters,java.nio.ByteBuffer,java.nio.CharBuffer</hc.animal-sniffer.signature.ignores>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>java-8-api</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+    </profile>
+  </profiles>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
This change makes sure if build jdk is based on Java >=9 API compatibility with Java 8 is maintained. Current source and target flags make sure source is Java 8 and generated byte code is Java 8 but it does not the package is compiled against Java 8 API.


Tested with both Java 8 and Java 11 build jdk. And tested Java 11 generated jar in a Java 8 runtime.