### PR TITLE
HTTPCORE-740: Introduce Read interest during connection close for graceful closure

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -415,7 +415,15 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
             newMask = EventMask.READ;
             break;
         case NOT_HANDSHAKING:
-            newMask = this.appEventMask;
+            if (this.status >= CLOSING && isOutboundDone() && !isInboundDone()) {
+                // NEED_UNWRAP behavior
+                newMask = EventMask.READ;
+            } else if (this.status >= CLOSING && !isOutboundDone() && isInboundDone()) {
+                // NEED_WRAP behavior
+                newMask = EventMask.READ_WRITE;
+            } else {
+                newMask = this.appEventMask;
+            }
             break;
         case NEED_TASK:
             break;


### PR DESCRIPTION
Java SSLEngine is returning NOT_HANDSHAKING in most connection closure scenarios due to this [commit](https://github.com/AdoptOpenJDK/openjdk-jdk11u/commit/8d1b63a4db2c6348a97b3cf45bd4d2caa7cad6b5). This PR tries incorporate this behaviour.