### PR TITLE
[HTTPCORE-745] ContentType.create(String, NameValuePair...) defensive copy

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -387,7 +387,7 @@ public final class ContentType implements Serializable {
             final String mimeType, final NameValuePair... params) throws UnsupportedCharsetException {
         final String type = TextUtils.toLowerCase(Args.notBlank(mimeType, "MIME type"));
         Args.check(valid(type), "MIME type may not contain reserved characters");
-        return create(mimeType, params, true);
+        return create(mimeType, params != null ? params.clone() : null, true);
     }
 
     /**
@@ -483,7 +483,7 @@ public final class ContentType implements Serializable {
     /**
      * Creates a new instance with this MIME type and the given parameters.
      *
-     * @param params
+     * @param params parameters.
      * @return a new instance with this MIME type and the given parameters.
      * @since 4.4
      */

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestContentType.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestContentType.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.Assertions;
@@ -134,6 +135,22 @@ public class TestContentType {
         Assertions.assertNull(ContentType.parse("   "));
         Assertions.assertNull(ContentType.parse(";"));
         Assertions.assertNull(ContentType.parse("="));
+    }
+
+    @Test
+    public void testWithParamArrayChange() throws Exception {
+        final BasicNameValuePair[] params = {new BasicNameValuePair("charset", "UTF-8"),
+                new BasicNameValuePair("p", "this"),
+                new BasicNameValuePair("p", "that")};
+        final ContentType contentType = ContentType.create("text/plain", params);
+        Assertions.assertEquals("text/plain", contentType.getMimeType());
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+        Assertions.assertEquals("text/plain; charset=UTF-8; p=this; p=that", contentType.toString());
+        Arrays.setAll(params, i -> null);
+        Assertions.assertEquals("this", contentType.getParameter("p"));
+        Assertions.assertEquals("text/plain", contentType.getMimeType());
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+        Assertions.assertEquals("text/plain; charset=UTF-8; p=this; p=that", contentType.toString());
     }
 
     @Test


### PR DESCRIPTION
[HTTPCORE-745] ContentType.create(String, NameValuePair...) should make a defensive copy of its input array