### PR TITLE
[HTTPCORE-750] H2ConnPool creates too many conns under high load at initialization time

### DIFF
--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
@@ -263,8 +263,8 @@ public class TestAbstractIOSessionPool {
 
     @Test
     public void testGetSessionConnectUnknownHost() throws Exception {
-
         Mockito.when(connectFuture.isDone()).thenReturn(true);
+        Mockito.when(connectFuture.get()).thenThrow(new RuntimeException("Connection failure"));
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.any(),


### PR DESCRIPTION
This code change checks the connection is ready to use or not before abandoning it.
When it is ready to use, it will use the conn to complete all the callbacks in the request queue, otherwise, create a new conn.

With the previous logic, under high load, H2ConnPool could create a lot of conns per endpoint and each conn will consume a lot of memory: a pair of input/output buffers.