### PR TITLE
HTTPCORE-751: H2 protocol handler incorrect handling of the remote MAX_FRAME_SIZE

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/FrameOutputBuffer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/FrameOutputBuffer.java
@@ -45,8 +45,8 @@ import org.apache.hc.core5.util.Args;
 public final class FrameOutputBuffer {
 
     private final BasicH2TransportMetrics metrics;
-    private volatile int maxFramePayloadSize;
-    private volatile ByteBuffer buffer;
+    private int maxFramePayloadSize;
+    private ByteBuffer buffer;
 
     public FrameOutputBuffer(final BasicH2TransportMetrics metrics, final int maxFramePayloadSize) {
         Args.notNull(metrics, "HTTP2 transport metrics");
@@ -60,7 +60,28 @@ public final class FrameOutputBuffer {
         this(new BasicH2TransportMetrics(), maxFramePayloadSize);
     }
 
+    /**
+     * @deprecated Misnomer. Use {@link #resize(int)}.
+     */
+    @Deprecated
     public void expand(final int maxFramePayloadSize) {
+        resize(maxFramePayloadSize);
+    }
+
+    /**
+     * @since 5.2
+     */
+    public int getMaxFramePayloadSize() {
+        return maxFramePayloadSize;
+    }
+
+    /**
+     * @since 5.2
+     */
+    public void resize(final int maxFramePayloadSize) {
+        if (buffer.capacity() == maxFramePayloadSize) {
+            return;
+        }
         this.maxFramePayloadSize = maxFramePayloadSize;
         final ByteBuffer newBuffer = ByteBuffer.allocate(FrameConsts.HEAD_LEN + maxFramePayloadSize);
         if (buffer.position() > 0) {

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/TestFrameInOutBuffers.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/TestFrameInOutBuffers.java
@@ -289,5 +289,13 @@ public class TestFrameInOutBuffers {
                 inBuffer.read(readableChannel));
     }
 
+    @Test
+    public void testOutputBufferResize() throws Exception {
+        final FrameOutputBuffer outBuffer = new FrameOutputBuffer(16 * 1024);
+        Assertions.assertEquals(16 * 1024, outBuffer.getMaxFramePayloadSize());
+        outBuffer.resize(1024);
+        Assertions.assertEquals(1024, outBuffer.getMaxFramePayloadSize());
+    }
+
 }
 


### PR DESCRIPTION
H2 protocol handler always resizes the output frame buffer to the remove MAX_FRAME_SIZE instead of doing so only then the remote MAX_FRAME_SIZE is lesser than the current MAX_FRAME_SIZE (partially reverts HTTPCORE-707)