### PR TITLE
HTTPCORE-746 - Refactor Synchronized Blocks to Use ReentrantLock.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOSessionPool.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/AbstractIOSessionPool.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -58,10 +59,13 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
     private final ConcurrentMap<T, PoolEntry> sessionPool;
     private final AtomicBoolean closed;
 
+    private final ReentrantLock lock;
+
     public AbstractIOSessionPool() {
         super();
         this.sessionPool = new ConcurrentHashMap<>();
         this.closed = new AtomicBoolean(false);
+        this.lock = new ReentrantLock();
     }
 
     protected abstract Future<IOSession> connectSession(
@@ -81,7 +85,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
     public final void close(final CloseMode closeMode) {
         if (closed.compareAndSet(false, true)) {
             for (final PoolEntry poolEntry : sessionPool.values()) {
-                synchronized (poolEntry) {
+                lock.lock();
+                try {
                     if (poolEntry.session != null) {
                         closeSession(poolEntry.session, closeMode);
                         poolEntry.session = null;
@@ -98,6 +103,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
                             break;
                         }
                     }
+                } finally {
+                    lock.unlock();
                 }
             }
             sessionPool.clear();
@@ -170,7 +177,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
             final T namedEndpoint,
             final Timeout connectTimeout,
             final FutureCallback<IOSession> callback) {
-        synchronized (poolEntry) {
+        poolEntry.lock.lock();
+        try {
             if (poolEntry.session != null && requestNew) {
                 closeSession(poolEntry.session, CloseMode.GRACEFUL);
                 poolEntry.session = null;
@@ -193,7 +201,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
 
                                 @Override
                                 public void completed(final IOSession result) {
-                                    synchronized (poolEntry) {
+                                    poolEntry.lock.lock();
+                                    try {
                                         poolEntry.session = result;
                                         for (;;) {
                                             final FutureCallback<IOSession> callback = poolEntry.requestQueue.poll();
@@ -203,12 +212,15 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
                                                 break;
                                             }
                                         }
+                                    } finally {
+                                        poolEntry.lock.unlock();
                                     }
                                 }
 
                                 @Override
                                 public void failed(final Exception ex) {
-                                    synchronized (poolEntry) {
+                                    poolEntry.lock.lock();
+                                    try {
                                         poolEntry.session = null;
                                         for (;;) {
                                             final FutureCallback<IOSession> callback = poolEntry.requestQueue.poll();
@@ -218,6 +230,8 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
                                                 break;
                                             }
                                         }
+                                    } finally {
+                                        poolEntry.lock.unlock();
                                     }
                                 }
 
@@ -229,19 +243,24 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
                             });
                 }
             }
+        } finally {
+            poolEntry.lock.unlock();
         }
     }
 
     public final void enumAvailable(final Callback<IOSession> callback) {
         for (final PoolEntry poolEntry: sessionPool.values()) {
             if (poolEntry.session != null) {
-                synchronized (poolEntry) {
+                lock.lock();
+                try {
                     if (poolEntry.session != null) {
                         callback.execute(poolEntry.session);
                         if (!poolEntry.session.isOpen()) {
                             poolEntry.session = null;
                         }
                     }
+                } finally {
+                    lock.unlock();
                 }
             }
         }
@@ -251,11 +270,14 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
         final long deadline = System.currentTimeMillis() - (TimeValue.isPositive(idleTime) ? idleTime.toMilliseconds() : 0);
         for (final PoolEntry poolEntry: sessionPool.values()) {
             if (poolEntry.session != null) {
-                synchronized (poolEntry) {
+                lock.lock();
+                try {
                     if (poolEntry.session != null && poolEntry.session.getLastReadTime() <= deadline) {
                         closeSession(poolEntry.session, CloseMode.GRACEFUL);
                         poolEntry.session = null;
                     }
+                } finally {
+                    lock.unlock();
                 }
             }
         }
@@ -278,9 +300,11 @@ public abstract class AbstractIOSessionPool<T> implements ModalCloseable {
         final Queue<FutureCallback<IOSession>> requestQueue;
         volatile Future<IOSession> sessionFuture;
         volatile IOSession session;
+        final ReentrantLock lock; // Added
 
         PoolEntry() {
             this.requestQueue = new ArrayDeque<>();
+            this.lock = new ReentrantLock();
         }
 
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/DummyProvider.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/DummyProvider.java
@@ -31,6 +31,7 @@ import java.security.Provider;
 import java.security.Security;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class DummyProvider extends Provider {
 
@@ -40,8 +41,11 @@ public class DummyProvider extends Provider {
 
     private final Set<String> requestedTypes = new HashSet<>();
 
+    private final ReentrantLock lock;
+
     public DummyProvider() {
         super(NAME, 1.1, "http core fake provider 1.1");
+        this.lock = new ReentrantLock();
     }
 
     public boolean hasBeenRequested(final String what) {
@@ -58,7 +62,12 @@ public class DummyProvider extends Provider {
     }
 
     @Override
-    public synchronized Set<Service> getServices() {
-        return realJSSEProvider.getServices();
+    public Set<Service> getServices() {
+        lock.lock();
+        try {
+            return realJSSEProvider.getServices();
+        } finally {
+            lock.unlock();
+        }
     }
 }


### PR DESCRIPTION
Title: Refactor Synchronized Blocks to Use ReentrantLock 


This commit replaces instances of 'synchronized' keyword with the explicit use of 'ReentrantLock' to provide more advanced synchronization mechanisms. 

Changes include:
- Replaced 'synchronized' methods with methods that use a 'ReentrantLock' for managing state.
- Modified methods to use the 'lock' and 'unlock' methods of 'ReentrantLock' to ensure safe execution of critical sections.


These changes provide more granular control over locks, fair locking behavior, and the ability to interrupt thread waiting for a lock or timeout if a lock cannot be obtained immediately.

