### PR TITLE
Filter characters before byte conversion

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
@@ -183,7 +183,14 @@ class SessionOutputBufferImpl extends ExpandableBuffer implements SessionOutputB
                     buffer().position(off + len);
                 } else {
                     for (int i = 0; i < lineBuffer.length(); i++) {
-                        buffer().put((byte) lineBuffer.charAt(i));
+                        final int c = lineBuffer.charAt(i);
+                        if ((c >= 0x20 && c <= 0x7E) || // Visible ASCII
+                            (c >= 0xA0 && c <= 0xFF) || // Visible ISO-8859-1
+                             c == 0x09) {               // TAB
+                            buffer().put((byte) c);
+                        } else {
+                            buffer().put((byte) '?');
+                        }
                     }
                 }
             } else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
@@ -171,7 +171,14 @@ class SessionOutputBufferImpl extends ExpandableBuffer implements SessionOutputB
                     final int off = buffer().position();
                     final int arrayOffset = buffer().arrayOffset();
                     for (int i = 0; i < len; i++) {
-                        b[arrayOffset + off + i]  = (byte) lineBuffer.charAt(i);
+                        final int c = lineBuffer.charAt(i);
+                        if ((c >= 0x20 && c <= 0x7E) || // Visible ASCII
+                            (c >= 0xA0 && c <= 0xFF) || // Visible ISO-8859-1
+                             c == 0x09) {               // TAB
+                            b[arrayOffset + off + i] = (byte) c;
+                        } else {
+                            b[arrayOffset + off + i] = '?';
+                        }
                     }
                     buffer().position(off + len);
                 } else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SessionOutputBufferImpl.java
@@ -42,6 +42,8 @@ import org.apache.hc.core5.http.nio.SessionOutputBuffer;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.CharArrayBuffer;
 
+import static org.apache.hc.core5.util.TextUtils.filterIfRequired;
+
 class SessionOutputBufferImpl extends ExpandableBuffer implements SessionOutputBuffer {
 
     private static final byte[] CRLF = new byte[] {Chars.CR, Chars.LF};
@@ -172,25 +174,13 @@ class SessionOutputBufferImpl extends ExpandableBuffer implements SessionOutputB
                     final int arrayOffset = buffer().arrayOffset();
                     for (int i = 0; i < len; i++) {
                         final int c = lineBuffer.charAt(i);
-                        if ((c >= 0x20 && c <= 0x7E) || // Visible ASCII
-                            (c >= 0xA0 && c <= 0xFF) || // Visible ISO-8859-1
-                             c == 0x09) {               // TAB
-                            b[arrayOffset + off + i] = (byte) c;
-                        } else {
-                            b[arrayOffset + off + i] = '?';
-                        }
+                        b[arrayOffset + off + i] = filterIfRequired(c);
                     }
                     buffer().position(off + len);
                 } else {
                     for (int i = 0; i < lineBuffer.length(); i++) {
                         final int c = lineBuffer.charAt(i);
-                        if ((c >= 0x20 && c <= 0x7E) || // Visible ASCII
-                            (c >= 0xA0 && c <= 0xFF) || // Visible ISO-8859-1
-                             c == 0x09) {               // TAB
-                            buffer().put((byte) c);
-                        } else {
-                            buffer().put((byte) '?');
-                        }
+                        buffer().put(filterIfRequired(c));
                     }
                 }
             } else {

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/ByteArrayBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/ByteArrayBuffer.java
@@ -30,6 +30,8 @@ package org.apache.hc.core5.util;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 
+import static org.apache.hc.core5.util.TextUtils.filterIfRequired;
+
 /**
  * A resizable byte array.
  *
@@ -139,13 +141,7 @@ public final class ByteArrayBuffer implements Serializable {
 
         for (int i1 = off, i2 = oldlen; i2 < newlen; i1++, i2++) {
             final int c = b[i1];
-            if ((c >= 0x20 && c <= 0x7E) || // Visible ASCII
-                (c >= 0xA0 && c <= 0xFF) || // Visible ISO-8859-1
-                c == 0x09) {                // TAB
-                this.array[i2] = (byte) c;
-            } else {
-                this.array[i2] = '?';
-            }
+            this.array[i2] = filterIfRequired(c);
         }
         this.len = newlen;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -26,6 +26,7 @@
  */
 
 package org.apache.hc.core5.util;
+import org.apache.hc.core5.annotation.Internal;
 
 import java.util.Locale;
 
@@ -139,6 +140,22 @@ public final class TextUtils {
             return null;
         }
         return s.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Filter characters before byte conversion
+     *
+     * @since 5.2
+     */
+    @Internal
+    public static byte filterIfRequired(final int c) {
+        if ((c >= 0x20 && c <= 0x7E) || // Visible ASCII
+            (c >= 0xA0 && c <= 0xFF) || // Visible ISO-8859-1
+             c == 0x09) {               // TAB
+            return (byte) c;
+        } else {
+            return '?';
+        }
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestSessionInOutBuffers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestSessionInOutBuffers.java
@@ -196,8 +196,8 @@ public class TestSessionInOutBuffers {
 
     @Test
     public void testNonASCIIWriteLine() throws Exception {
-        String testString = "123\u010Anew-header-from-some-header:injected-value";
-        String expectedResult = "123?new-header-from-some-header:injected-value";
+        final String testString = "123\u010Anew-header-from-some-header:injected-value";
+        final String expectedResult = "123?new-header-from-some-header:injected-value";
 
         final CharArrayBuffer chbuffer = new CharArrayBuffer(32);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 16);


### PR DESCRIPTION
This change causes SessionOutputBufferImpl to filter out all characters that
cannot be correctly converted to ISO-8859-1 by simple downcasting to a
byte.

Fix is inspired from: https://github.com/apache/httpcomponents-core/pull/116
Above mentioned fix was applied to Sync clients only. This request make similar change to async client. Once approved, I will raise similar request for 4.x branch.