### PR TITLE
HTTPCORE-756 - Deprecation of userInfo in Compliance with RFC 9110

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
@@ -264,8 +264,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
     public void setUri(final URI requestUri) {
         this.scheme = requestUri.getScheme();
         if (requestUri.getHost() != null) {
-            this.authority = new URIAuthority(
-                    requestUri.getRawUserInfo(), requestUri.getHost(), requestUri.getPort());
+            this.authority = new URIAuthority(requestUri.getHost(), requestUri.getPort());
         } else if (requestUri.getRawAuthority() != null) {
             try {
                 this.authority = URIAuthority.create(requestUri.getRawAuthority());

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/AbstractRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/AbstractRequestBuilder.java
@@ -173,7 +173,7 @@ public abstract class AbstractRequestBuilder<T> extends AbstractMessageBuilder<T
         } else {
             this.scheme = uri.getScheme();
             if (uri.getHost() != null) {
-                this.authority = new URIAuthority(uri.getRawUserInfo(), uri.getHost(), uri.getPort());
+                this.authority = new URIAuthority(uri.getHost(), uri.getPort());
             } else if (uri.getRawAuthority() != null) {
                 try {
                     this.authority = URIAuthority.create(uri.getRawAuthority());

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIAuthority.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIAuthority.java
@@ -47,25 +47,23 @@ import org.apache.hc.core5.util.Tokenizer;
 public final class URIAuthority implements NamedEndpoint, Serializable {
 
     private static final long serialVersionUID = 1L;
-    private final String userInfo;
     private final Host host;
 
     static URIAuthority parse(final CharSequence s, final Tokenizer.Cursor cursor) throws URISyntaxException {
         final Tokenizer tokenizer = Tokenizer.INSTANCE;
-        String userInfo = null;
         final int initPos = cursor.getPos();
         final String token = tokenizer.parseContent(s, cursor, URISupport.HOST_SEPARATORS);
         if (!cursor.atEnd() && s.charAt(cursor.getPos()) == '@') {
             cursor.updatePos(cursor.getPos() + 1);
             if (!TextUtils.isBlank(token)) {
-                userInfo = token;
+                throw URISupport.createException(s, cursor, "Userinfo component is deprecated for http and https URIs");
             }
         } else {
             //Rewind
             cursor.updatePos(initPos);
         }
         final Host host = Host.parse(s, cursor);
-        return new URIAuthority(userInfo, host);
+        return new URIAuthority(host);
     }
 
     static URIAuthority parse(final CharSequence s) throws URISyntaxException {
@@ -73,17 +71,9 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
         return parse(s, cursor);
     }
 
-    static void format(final StringBuilder buf, final URIAuthority uriAuthority) {
-        if (uriAuthority.getUserInfo() != null) {
-            buf.append(uriAuthority.getUserInfo());
-            buf.append("@");
-        }
-        Host.format(buf, uriAuthority);
-    }
-
     static String format(final URIAuthority uriAuthority) {
         final StringBuilder buf = new StringBuilder();
-        format(buf, uriAuthority);
+        Host.format(buf, uriAuthority);
         return buf.toString();
     }
 
@@ -93,46 +83,49 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
      * @throws IllegalArgumentException
      *             If the port parameter is outside the specified range of valid port values, which is between 0 and
      *             65535, inclusive. {@code -1} indicates the scheme default port.
+     * @deprecated
      */
+    @Deprecated
     public URIAuthority(final String userInfo, final String hostname, final int port) {
-        super();
-        this.userInfo = userInfo;
-        this.host = new Host(hostname, port);
+      this(hostname, port);
     }
 
     public URIAuthority(final String hostname, final int port) {
-        this(null, hostname, port);
+        super();
+        this.host = new Host(hostname, port);
     }
 
     /**
      * @since 5.2
+     * @deprecated
      */
+    @Deprecated
     public URIAuthority(final String userInfo, final Host host) {
-        super();
-        Args.notNull(host, "Host");
-        this.userInfo = userInfo;
-        this.host = host;
+      this(host);
     }
 
     /**
      * @since 5.2
      */
     public URIAuthority(final Host host) {
-        this(null, host);
+        super();
+        Args.notNull(host, "Host");
+        this.host = host;
     }
 
     /**
      * @since 5.2
+     * @deprecated
      */
+    @Deprecated
     public URIAuthority(final String userInfo, final NamedEndpoint endpoint) {
-        super();
-        Args.notNull(endpoint, "Endpoint");
-        this.userInfo = userInfo;
-        this.host = new Host(endpoint.getHostName(), endpoint.getPort());
+        this(endpoint);
     }
 
-    public URIAuthority(final NamedEndpoint namedEndpoint) {
-        this(null, namedEndpoint);
+    public URIAuthority(final NamedEndpoint endpoint) {
+        super();
+        Args.notNull(endpoint, "Endpoint");
+        this.host = new Host(endpoint.getHostName(), endpoint.getPort());
     }
 
     /**
@@ -151,11 +144,15 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
     }
 
     public URIAuthority(final String hostname) {
-        this(null, hostname, -1);
+        this( hostname, -1);
     }
 
+    /**
+     * @deprecated do not use.
+     */
+    @Deprecated
     public String getUserInfo() {
-        return userInfo;
+        return null;
     }
 
     @Override
@@ -180,8 +177,7 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
         }
         if (obj instanceof URIAuthority) {
             final URIAuthority that = (URIAuthority) obj;
-            return Objects.equals(this.userInfo, that.userInfo) &&
-                    Objects.equals(this.host, that.host);
+            return Objects.equals(this.host, that.host);
         }
         return false;
     }
@@ -189,7 +185,6 @@ public final class URIAuthority implements NamedEndpoint, Serializable {
     @Override
     public int hashCode() {
         int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, userInfo);
         hash = LangUtils.hashCode(hash, host);
         return hash;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -74,8 +74,6 @@ public class URIBuilder {
     private String scheme;
     private String encodedSchemeSpecificPart;
     private String encodedAuthority;
-    private String userInfo;
-    private String encodedUserInfo;
     private String host;
     private int port;
     private String encodedPath;
@@ -142,7 +140,6 @@ public class URIBuilder {
      * @since 5.2
      */
     public URIBuilder setAuthority(final NamedEndpoint authority) {
-        setUserInfo(null);
         setHost(authority.getHostName());
         setPort(authority.getPort());
         return this;
@@ -156,7 +153,6 @@ public class URIBuilder {
      * @since 5.2
      */
     public URIBuilder setAuthority(final URIAuthority authority) {
-        setUserInfo(authority.getUserInfo());
         setHost(authority.getHostName());
         setPort(authority.getPort());
         return this;
@@ -180,7 +176,7 @@ public class URIBuilder {
      * @since 5.2
      */
     public URIAuthority getAuthority() {
-        return new URIAuthority(getUserInfo(), getHost(), getPort());
+        return new URIAuthority(getHost(), getPort());
     }
 
     /**
@@ -327,19 +323,6 @@ public class URIBuilder {
                 authoritySpecified = true;
             } else if (this.host != null) {
                 sb.append("//");
-                if (this.encodedUserInfo != null) {
-                    sb.append(this.encodedUserInfo).append("@");
-                } else if (this.userInfo != null) {
-                    final int idx = this.userInfo.indexOf(':');
-                    if (idx != -1) {
-                        PercentCodec.encode(sb, this.userInfo.substring(0, idx), this.charset);
-                        sb.append(':');
-                        PercentCodec.encode(sb, this.userInfo.substring(idx + 1), this.charset);
-                    } else {
-                        PercentCodec.encode(sb, this.userInfo, this.charset);
-                    }
-                    sb.append("@");
-                }
                 if (InetAddressUtils.isIPv6Address(this.host)) {
                     sb.append("[").append(this.host).append("]");
                 } else {
@@ -390,13 +373,9 @@ public class URIBuilder {
                 ? uriHost.substring(1, uriHost.length() - 1)
                 : uriHost;
         this.port = uri.getPort();
-        this.encodedUserInfo = uri.getRawUserInfo();
-        this.userInfo = uri.getUserInfo();
         if (this.encodedAuthority != null && this.host == null) {
             try {
                 final URIAuthority uriAuthority = URIAuthority.parse(this.encodedAuthority);
-                this.encodedUserInfo = uriAuthority.getUserInfo();
-                this.userInfo = PercentCodec.decode(uriAuthority.getUserInfo(), charset);
                 this.host = PercentCodec.decode(uriAuthority.getHostName(), charset);
                 this.port = uriAuthority.getPort();
             } catch (final URISyntaxException ignore) {
@@ -471,14 +450,13 @@ public class URIBuilder {
     /**
      * Sets URI user info. The value is expected to be unescaped and may contain non ASCII
      * characters.
-     *
+     * @deprecated
      * @return this.
      */
+    @Deprecated
     public URIBuilder setUserInfo(final String userInfo) {
-        this.userInfo = !TextUtils.isBlank(userInfo) ? userInfo : null;
         this.encodedSchemeSpecificPart = null;
         this.encodedAuthority = null;
-        this.encodedUserInfo = null;
         return this;
     }
 
@@ -897,11 +875,12 @@ public class URIBuilder {
 
     /**
      * Gets the user info.
-     *
-     * @return  the user info.
+     * @deprecated do not use.
+     * @return  {@code null}.
      */
+    @Deprecated
     public String getUserInfo() {
-        return this.userInfo;
+        return null;
     }
 
     /**
@@ -1032,7 +1011,6 @@ public class URIBuilder {
         // Force Percent-Encoding re-encoding
         this.encodedSchemeSpecificPart = null;
         this.encodedAuthority = null;
-        this.encodedUserInfo = null;
         this.encodedPath = null;
         this.encodedQuery = null;
         this.encodedFragment = null;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpRequestWrapperTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpRequestWrapperTest.java
@@ -120,7 +120,7 @@ public class HttpRequestWrapperTest {
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
         Assertions.assertEquals("/stuff?param=value", httpRequestWrapper.getPath());
-        Assertions.assertEquals(new URIAuthority("user:pwd", "host", 9443), httpRequestWrapper.getAuthority());
+        Assertions.assertEquals(new URIAuthority("host", 9443), httpRequestWrapper.getAuthority());
         Assertions.assertEquals("https", httpRequestWrapper.getScheme());
         Assertions.assertEquals(new URI("https://host:9443/stuff?param=value"), httpRequestWrapper.getUri());
     }
@@ -152,11 +152,11 @@ public class HttpRequestWrapperTest {
 
     @Test
     public void testRequestHostWithReservedChars() throws Exception {
-        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://someuser%21@%21example%21.com/stuff"));
+        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://%21example%21.com/stuff"));
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
         Assertions.assertEquals("/stuff", httpRequestWrapper.getPath());
-        Assertions.assertEquals(new URIAuthority("someuser%21", "%21example%21.com", -1), httpRequestWrapper.getAuthority());
+        Assertions.assertEquals(new URIAuthority( "%21example%21.com", -1), httpRequestWrapper.getAuthority());
         Assertions.assertEquals(new URI("http://%21example%21.com/stuff"), httpRequestWrapper.getUri());
     }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicMessages.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicMessages.java
@@ -165,7 +165,7 @@ public class TestBasicMessages {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("https://user:pwd@host:9443/stuff?param=value"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff?param=value", request.getPath());
-        Assertions.assertEquals(new URIAuthority("user:pwd", "host", 9443), request.getAuthority());
+        Assertions.assertEquals(new URIAuthority("host", 9443), request.getAuthority());
         Assertions.assertEquals("https", request.getScheme());
         Assertions.assertEquals(new URI("https://host:9443/stuff?param=value"), request.getUri());
     }
@@ -190,10 +190,10 @@ public class TestBasicMessages {
 
     @Test
     public void testRequestHostWithReservedChars() throws Exception {
-        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://someuser%21@%21example%21.com/stuff"));
+        final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://%21example%21.com/stuff"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff", request.getPath());
-        Assertions.assertEquals(new URIAuthority("someuser%21", "%21example%21.com", -1), request.getAuthority());
+        Assertions.assertEquals(new URIAuthority("%21example%21.com", -1), request.getAuthority());
         Assertions.assertEquals(new URI("http://%21example%21.com/stuff"), request.getUri());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
@@ -64,17 +64,10 @@ public class TestURIAuthority {
         final URIAuthority host2 = new URIAuthority("somehost", 80);
         final URIAuthority host3 = new URIAuthority("someotherhost", 8080);
         final URIAuthority host4 = new URIAuthority("somehost", 80);
-        final URIAuthority host5 = new URIAuthority("SomeHost", 80);
-        final URIAuthority host6 = new URIAuthority("user", "SomeHost", 80);
-        final URIAuthority host7 = new URIAuthority("user", "somehost", 80);
 
-        Assertions.assertEquals(host1.hashCode(), host1.hashCode());
         Assertions.assertTrue(host1.hashCode() != host2.hashCode());
         Assertions.assertTrue(host1.hashCode() != host3.hashCode());
         Assertions.assertEquals(host2.hashCode(), host4.hashCode());
-        Assertions.assertEquals(host2.hashCode(), host5.hashCode());
-        Assertions.assertTrue(host5.hashCode() != host6.hashCode());
-        Assertions.assertEquals(host6.hashCode(), host7.hashCode());
     }
 
     @Test
@@ -84,15 +77,15 @@ public class TestURIAuthority {
         final URIAuthority host3 = new URIAuthority("someotherhost", 8080);
         final URIAuthority host4 = new URIAuthority("somehost", 80);
         final URIAuthority host5 = new URIAuthority("SomeHost", 80);
-        final URIAuthority host6 = new URIAuthority("user", "SomeHost", 80);
-        final URIAuthority host7 = new URIAuthority("user", "somehost", 80);
+        final URIAuthority host6 = new URIAuthority( "SomeHost", 80);
+        final URIAuthority host7 = new URIAuthority( "somehost", 80);
 
         Assertions.assertEquals(host1, host1);
         Assertions.assertNotEquals(host1, host2);
         Assertions.assertNotEquals(host1, host3);
         Assertions.assertEquals(host2, host4);
         Assertions.assertEquals(host2, host5);
-        Assertions.assertNotEquals(host5, host6);
+        Assertions.assertEquals(host5, host6);
         Assertions.assertEquals(host6, host7);
     }
 
@@ -130,10 +123,8 @@ public class TestURIAuthority {
                 CoreMatchers.equalTo(new URIAuthority("somehost", -1)));
         assertThat(URIAuthority.parse("somehost#blah"),
                 CoreMatchers.equalTo(new URIAuthority("somehost", -1)));
-        assertThat(URIAuthority.parse("aaaa@:8080"),
-                CoreMatchers.equalTo(new URIAuthority("aaaa", "", 8080)));
         assertThat(URIAuthority.parse("@:"),
-                CoreMatchers.equalTo(new URIAuthority(null, "", -1)));
+                CoreMatchers.equalTo(new URIAuthority( "", -1)));
         assertThat(URIAuthority.parse("somehost:8080"),
                 CoreMatchers.equalTo(new URIAuthority("somehost", 8080)));
         assertThat(URIAuthority.parse("somehost:8080/blah"),
@@ -146,39 +137,39 @@ public class TestURIAuthority {
                 CoreMatchers.equalTo(new URIAuthority("somehost", 8080)));
         Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("somehost:aaaaa"));
         Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("somehost:90ab"));
-
-        assertThat(URIAuthority.parse("someuser@somehost"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-        assertThat(URIAuthority.parse("someuser@somehost/blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-        assertThat(URIAuthority.parse("someuser@somehost?blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-        assertThat(URIAuthority.parse("someuser@somehost#blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-
-        assertThat(URIAuthority.parse("someuser@somehost:"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-        assertThat(URIAuthority.parse("someuser@somehost:/blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-        assertThat(URIAuthority.parse("someuser@somehost:?blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-        assertThat(URIAuthority.parse("someuser@somehost:#blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", -1)));
-
-        assertThat(URIAuthority.parse("someuser@somehost:8080"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", 8080)));
-        assertThat(URIAuthority.parse("someuser@somehost:8080/blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", 8080)));
-        assertThat(URIAuthority.parse("someuser@somehost:8080?blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", 8080)));
-        assertThat(URIAuthority.parse("someuser@somehost:8080#blah"),
-                CoreMatchers.equalTo(new URIAuthority("someuser", "somehost", 8080)));
-        assertThat(URIAuthority.parse("@somehost:8080"),
-                CoreMatchers.equalTo(new URIAuthority("somehost", 8080)));
-        assertThat(URIAuthority.parse("test:test@localhost:38339"),
-                CoreMatchers.equalTo(new URIAuthority("test:test", "localhost", 38339)));
         Assertions.assertThrows(URISyntaxException.class, () ->
-                URIAuthority.create("blah@goggle.com:80@google.com/"));
+                URIAuthority.parse("someuser@somehost"));
+        assertThat(URIAuthority.parse("somehost/blah"),
+
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+        assertThat(URIAuthority.parse("somehost?blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+        assertThat(URIAuthority.parse("somehost#blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+
+        assertThat(URIAuthority.parse("somehost:"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+        assertThat(URIAuthority.parse("somehost:/blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+        assertThat(URIAuthority.parse("somehost:?blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+        assertThat(URIAuthority.parse("somehost:#blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", -1)));
+
+        assertThat(URIAuthority.parse("somehost:8080"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", 8080)));
+        assertThat(URIAuthority.parse("somehost:8080/blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", 8080)));
+        assertThat(URIAuthority.parse("somehost:8080?blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", 8080)));
+        assertThat(URIAuthority.parse("somehost:8080#blah"),
+                CoreMatchers.equalTo(new URIAuthority( "somehost", 8080)));
+        assertThat(URIAuthority.parse("somehost:8080"),
+                CoreMatchers.equalTo(new URIAuthority("somehost", 8080)));
+        assertThat(URIAuthority.parse("localhost:38339"),
+                CoreMatchers.equalTo(new URIAuthority( "localhost", 38339)));
+        Assertions.assertThrows(URISyntaxException.class, () ->
+                URIAuthority.create("goggle.com:80@google.com/"));
     }
 
     @Test
@@ -187,7 +178,7 @@ public class TestURIAuthority {
         Assertions.assertEquals(new URIAuthority("SomeHost", 8080), URIAuthority.create("SomeHost:8080"));
         Assertions.assertEquals(new URIAuthority("somehost", 1234), URIAuthority.create("somehost:1234"));
         Assertions.assertEquals(new URIAuthority("somehost", -1), URIAuthority.create("somehost"));
-        Assertions.assertEquals(new URIAuthority("user", "somehost", -1), URIAuthority.create("user@somehost"));
+        Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("user@somehost"));
         Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create(" host"));
         Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("host  "));
         Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("host :8080"));
@@ -206,8 +197,6 @@ public class TestURIAuthority {
     @Test
     public void testIpv6HostToString() {
         Assertions.assertEquals("[::1]:80", new URIAuthority("::1", 80).toString());
-        Assertions.assertEquals("user@[::1]:80", new URIAuthority("user", "::1", 80).toString());
         Assertions.assertEquals("[::1]", new URIAuthority("::1", -1).toString());
-        Assertions.assertEquals("user@[::1]", new URIAuthority("user", "::1", -1).toString());
     }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -30,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -200,7 +201,7 @@ public class TestURIBuilder {
     public void testMutationRemovePort() throws Exception {
         final URI uri = new URI("http://stuff@localhost:80/stuff?param=stuff#fragment");
         final URI result = new URIBuilder(uri).setPort(-1).build();
-        Assertions.assertEquals(new URI("http://stuff@localhost/stuff?param=stuff#fragment"), result);
+        Assertions.assertEquals(new URI("http://localhost/stuff?param=stuff#fragment"), result);
     }
 
     @Test
@@ -242,7 +243,7 @@ public class TestURIBuilder {
 
        Assertions.assertEquals(uri.getHost(), bld.getHost());
 
-       Assertions.assertEquals(uri.getUserInfo(), bld.getUserInfo());
+       Assertions.assertNotEquals(uri.getUserInfo(), bld.getUserInfo());
 
        Assertions.assertEquals(uri.getPath(), bld.getPath());
 
@@ -269,7 +270,7 @@ public class TestURIBuilder {
 
        Assertions.assertEquals(uri.getHost(), bld.getHost());
 
-       Assertions.assertEquals(uri.getUserInfo(), bld.getUserInfo());
+       Assertions.assertNotEquals(uri.getUserInfo(), bld.getUserInfo());
 
        Assertions.assertEquals(uri.getPath(), bld.getPath());
 
@@ -356,7 +357,7 @@ public class TestURIBuilder {
 
     @Test
     public void testSetAuthorityFromURIAuthority() throws Exception {
-        final URIAuthority authority = URIAuthority.create("u:p@localhost:88");
+        final URIAuthority authority = URIAuthority.create("@localhost:88");
         final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(authority);
         // Check builder
         Assertions.assertEquals(authority.getUserInfo(), uribuilder.getAuthority().getUserInfo());
@@ -368,7 +369,12 @@ public class TestURIBuilder {
         Assertions.assertEquals(authority.getHostName(), result.getHost());
         Assertions.assertEquals(authority.getPort(), result.getPort());
         Assertions.assertEquals(authority.toString(), result.getAuthority());
-        Assertions.assertEquals(new URI("http://u:p@localhost:88"), result);
+        Assertions.assertEquals(new URI("http://localhost:88"), result);
+    }
+
+    @Test
+    public void testSetAuthorityFromURIAuthorityWhitUserPass() {
+        Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("u:p@localhost:88"));
     }
 
     @Test
@@ -496,7 +502,7 @@ public class TestURIBuilder {
 
         Assertions.assertEquals(uri.getHost(), bld.getHost());
 
-        Assertions.assertEquals(uri.getUserInfo(), bld.getUserInfo());
+        Assertions.assertNotEquals(uri.getUserInfo(), bld.getUserInfo());
 
         Assertions.assertEquals(uri.getPath(), bld.getPath());
 
@@ -631,8 +637,8 @@ public class TestURIBuilder {
     @Test
     public void testGetHostWithReservedChars() throws Exception {
         final URIBuilder uribuilder = new URIBuilder("http://someuser%21@%21example%21.com/");
-        Assertions.assertEquals("!example!.com", uribuilder.getHost());
-        Assertions.assertEquals("someuser!", uribuilder.getUserInfo());
+        Assertions.assertEquals(null, uribuilder.getHost(), "SHOULD parse for userinfo and treat its presence as an error");
+        Assertions.assertEquals(null, uribuilder.getUserInfo());
     }
 
     @Test


### PR DESCRIPTION
Description:

This pull request addresses the recommendations set out in RFC 9110 regarding the deprecation of the userInfo subcomponent in "http" or "https" URIs.

Changes:

- Removed all references to `userInfo` within the `URIAuthority` class.
- Deprecated methods in both `URIAuthority` and `URIBuilder` that utilized `userInfo`.
- Added exception handling for potential security risks associated with `userinfo` in received URIs.

