### PR TITLE
Support InetAddress throughout request execution

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHost.java
@@ -84,7 +84,19 @@ public final class HttpHost implements NamedEndpoint, Serializable {
         Args.containsNoBlanks(hostname, "Host name");
         this.host = new Host(hostname, port);
         this.schemeName = scheme != null ? TextUtils.toLowerCase(scheme) : DEFAULT_SCHEME.id;
-        this.address = address;
+        this.address = updateAddress(address, hostname);
+    }
+
+    private InetAddress updateAddress(final InetAddress address, final String hostname) {
+        if (address == null) {
+            return address;
+        }
+        try {
+          return InetAddress.getByAddress(hostname, address.getAddress());
+        }
+        catch (final java.net.UnknownHostException e) { // should not be possible
+            return address;
+        }
     }
 
     /**
@@ -197,7 +209,9 @@ public final class HttpHost implements NamedEndpoint, Serializable {
      * @since 5.0
      */
     public HttpHost(final String scheme, final InetAddress address, final int port) {
-        this(scheme, Args.notNull(address,"Inet address"), address.getHostName(), port);
+        this.address = Args.notNull(address,"Inet address");
+        this.host = new Host(address.getHostName(), port);
+        this.schemeName = scheme != null ? TextUtils.toLowerCase(scheme) : DEFAULT_SCHEME.id;
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpRequest.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.core5.http;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -93,6 +94,22 @@ public interface HttpRequest extends HttpMessage {
      * @since 5.0
      */
     void setAuthority(URIAuthority authority);
+
+    /**
+     * Returns address of this request message.
+     *
+     * @return  the address or {@code null}.
+     *
+     * @since 5.3
+     */
+    InetAddress getAddress();
+
+    /**
+     * Sets address of this request message.
+     *
+     * @since 5.3
+     */
+    void setAddress(InetAddress address);
 
     /**
      * Returns request URI of this request message. It may be an absolute or relative URI.

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultAddressResolver.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultAddressResolver.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.core5.http.impl;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import org.apache.hc.core5.function.Resolver;
@@ -56,7 +57,10 @@ public final class DefaultAddressResolver implements Resolver<HttpHost, InetSock
                 port = 443;
             }
         }
-        return new InetSocketAddress(host.getHostName(), port);
+        final InetAddress address = host.getAddress();
+        return (address == null)
+          ? new InetSocketAddress(host.getHostName(), port)
+          : new InetSocketAddress(address, port);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/HttpAsyncRequester.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl.bootstrap;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
@@ -289,7 +290,10 @@ public class HttpAsyncRequester extends AsyncRequester implements ConnPoolContro
                 if (authority == null) {
                     throw new ProtocolException("Request authority not specified");
                 }
-                final HttpHost target = new HttpHost(scheme, authority);
+                final InetAddress address = request.getAddress();
+                final HttpHost target = (address == null)
+                  ? new HttpHost(scheme, authority)
+                  : new HttpHost(scheme, address, authority.getPort());
                 connect(target, timeout, null, new FutureCallback<AsyncClientEndpoint>() {
 
                     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.core5.http.io.support;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -238,6 +239,15 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
     }
 
     /**
+     * @since 5.3
+     */
+    @Override
+    public ClassicRequestBuilder setAddress(final InetAddress address) {
+        super.setAddress(address);
+        return this;
+    }
+
+    /**
      * @since 5.1
      */
     @Override
@@ -377,7 +387,7 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
             throw new IllegalStateException(Method.TRACE + " requests may not include an entity");
         }
 
-        final BasicClassicHttpRequest result = new BasicClassicHttpRequest(method, getScheme(), getAuthority(), path);
+        final BasicClassicHttpRequest result = new BasicClassicHttpRequest(method, getScheme(), getAuthority(), getAddress(), path);
         result.setVersion(getVersion());
         result.setHeaders(getHeaders());
         result.setEntity(entityCopy);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicClassicHttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicClassicHttpRequest.java
@@ -33,6 +33,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.net.URIAuthority;
 
+import java.net.InetAddress;
 import java.net.URI;
 
 /**
@@ -52,12 +53,28 @@ public class BasicClassicHttpRequest extends BasicHttpRequest implements Classic
      * @param method request method.
      * @param scheme request scheme.
      * @param authority request authority.
+     * @param address request address.
+     * @param path request path.
+     *
+     * @since 5.3
+     */
+    public BasicClassicHttpRequest(final String method, final String scheme, final URIAuthority authority, final InetAddress address, final String path) {
+        super(method, scheme, authority, address, path);
+    }
+
+
+    /**
+     * Creates request message with the given method, host and request path.
+     *
+     * @param method request method.
+     * @param scheme request scheme.
+     * @param authority request authority.
      * @param path request path.
      *
      * @since 5.1
      */
     public BasicClassicHttpRequest(final String method, final String scheme, final URIAuthority authority, final String path) {
-        super(method, scheme, authority, path);
+        this(method, scheme, authority, null, path);
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -52,9 +53,30 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
     private String path;
     private String scheme;
     private URIAuthority authority;
+    private InetAddress address;
     private ProtocolVersion version;
     private URI requestUri;
     private boolean absoluteRequestUri;
+
+    /**
+     * Creates request message with the given method, host and request path.
+     *
+     * @param method request method.
+     * @param scheme request scheme.
+     * @param authority request authority.
+     * @param address request address.
+     * @param path request path.
+     *
+     * @since 5.3
+     */
+    public BasicHttpRequest(final String method, final String scheme, final URIAuthority authority, final InetAddress address, final String path) {
+        super();
+        this.method = Args.notNull(method, "Method name");
+        this.scheme = scheme;
+        this.authority = authority;
+        this.address = address;
+        this.path = path;
+    }
 
     /**
      * Creates request message with the given method, host and request path.
@@ -67,11 +89,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
      * @since 5.1
      */
     public BasicHttpRequest(final String method, final String scheme, final URIAuthority authority, final String path) {
-        super();
-        this.method = Args.notNull(method, "Method name");
-        this.scheme = scheme;
-        this.authority = authority;
-        this.path = path;
+        this(method, scheme, authority, null, path);
     }
 
     /**
@@ -106,6 +124,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
         this.method = Args.notNull(method, "Method name");
         this.scheme = host != null ? host.getSchemeName() : null;
         this.authority = host != null ? new URIAuthority(host) : null;
+        this.address = host != null ? host.getAddress() : null;
         this.path = path;
     }
 
@@ -157,6 +176,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
         this.method = Args.notNull(method, "Method").name();
         this.scheme = host != null ? host.getSchemeName() : null;
         this.authority = host != null ? new URIAuthority(host) : null;
+        this.address = host != null ? host.getAddress() : null;
         this.path = path;
     }
 
@@ -238,6 +258,22 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
     }
 
     /**
+     * @since 5.3
+     */
+    @Override
+    public InetAddress getAddress() {
+        return this.address;
+    }
+
+    /**
+     * @since 5.3
+     */
+    @Override
+    public void setAddress(final InetAddress address) {
+        this.address = address;
+    }
+
+    /**
      * Sets a flag that the {@link #getRequestUri()} method should return the request URI
      * in an absolute form.
      * <p>
@@ -275,6 +311,7 @@ public class BasicHttpRequest extends HeaderGroup implements HttpRequest {
         } else {
             this.authority = null;
         }
+        this.address = null; // resolve this later
         final StringBuilder buf = new StringBuilder();
         final String rawPath = requestUri.getRawPath();
         if (!TextUtils.isBlank(rawPath)) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/HttpRequestWrapper.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/HttpRequestWrapper.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.core5.http.message;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -77,6 +78,22 @@ public class HttpRequestWrapper extends AbstractMessageWrapper<HttpRequest> impl
     @Override
     public void setAuthority(final URIAuthority authority) {
         getMessage().setAuthority(authority);
+    }
+
+    /**
+     * @since 5.3
+     */
+    @Override
+    public InetAddress getAddress() {
+        return getMessage().getAddress();
+    }
+
+    /**
+     * @since 5.3
+     */
+    @Override
+    public void setAddress(final InetAddress address) {
+        getMessage().setAddress(address);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -368,7 +368,7 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
             throw new IllegalStateException(Method.TRACE + " requests may not include an entity");
         }
 
-        final BasicHttpRequest request = new BasicHttpRequest(method, getScheme(), getAuthority(), path);
+        final BasicHttpRequest request = new BasicHttpRequest(method, getScheme(), getAuthority(), getAddress(), path);
         request.setVersion(getVersion());
         request.setHeaders(getHeaders());
         request.setAbsoluteRequestUri(isAbsoluteRequestUri());

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/AbstractRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/AbstractRequestBuilder.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.core5.http.support;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -56,6 +57,7 @@ public abstract class AbstractRequestBuilder<T> extends AbstractMessageBuilder<T
     final private String method;
     private String scheme;
     private URIAuthority authority;
+    private InetAddress address;
     private String path;
     private Charset charset;
     private List<NameValuePair> parameters;
@@ -94,6 +96,7 @@ public abstract class AbstractRequestBuilder<T> extends AbstractMessageBuilder<T
         }
         setScheme(request.getScheme());
         setAuthority(request.getAuthority());
+        setAddress(request.getAddress());
         setPath(request.getPath());
         this.parameters = null;
         super.digest(request);
@@ -127,11 +130,27 @@ public abstract class AbstractRequestBuilder<T> extends AbstractMessageBuilder<T
         return this;
     }
 
+    /**
+     * @since 5.3
+     */
+    public InetAddress getAddress() {
+        return address;
+    }
+
+    /**
+     * @since 5.3
+     */
+    public AbstractRequestBuilder<T> setAddress(final InetAddress address) {
+      this.address = address;
+      return this;
+    }
+
     public AbstractRequestBuilder<T> setHttpHost(final HttpHost httpHost) {
         if (httpHost == null) {
             return this;
         }
         this.authority = new URIAuthority(httpHost);
+        this.address = httpHost.getAddress();
         this.scheme = httpHost.getSchemeName();
         return this;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -315,7 +315,7 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
                 // should never happen
             }
         }
-        final BasicHttpRequest result = new BasicHttpRequest(getMethod(), getScheme(), getAuthority(), path);
+        final BasicHttpRequest result = new BasicHttpRequest(getMethod(), getScheme(), getAuthority(), getAddress(), path);
         result.setVersion(getVersion());
         result.setHeaders(getHeaders());
         result.setAbsoluteRequestUri(isAbsoluteRequestUri());

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -214,6 +214,14 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
     }
 
     /**
+     * @since 5.3
+     */
+    public BasicRequestBuilder setAddress(final InetAddress address) {
+      this.address = address;
+      return this;
+    }
+
+    /**
      * @since 5.1
      */
     @Override


### PR DESCRIPTION
Note that this patch is probably incomplete - it does not break existing tests, but no tests were added nor updated to verify the new code.

We have a need to set the InetAddress for a request - the ip tells us where to connect and the hostname is needed for ssl verification.  We could have also done this with lots of separate conn pools and tls strategies, or maybe with a custom conn pool.  I preferred to have this per request, though (rather than per requester).

The current request builder supports setting HttpHost using InetAddress, but request doesn't support HttpHost so the InetAddress is lost when creating the request.  During execution, HttpHost is recreated - but with a subset of the info that was in the original HttpHost.  Additionally, the socket is created using a subset of the potential in HttpHost.  I've added InetAddress to HttpRequest and changed socket creation to use the address when it exists.

Ideally, we'd have more control of the Host header auto-entered by the request (to not include the port), but this isn't a technical requirement.

It wasn't clear how you're using branches.  Master seems to be 5.2.x, but the 5.3.x branch is missing 4 months up updates to master.  Though the version is 5.2.x, the javadoc entries I added say 5.3.

Also note that tests failed using java 11, but complete successfully with java 1.8.