### PR TITLE
HTTPCORE-756  - Enforced the requirement that `https` and `http` URIs must not have an empty host identifier

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.http.message.ParserCursor;
 import org.apache.hc.core5.util.Args;
@@ -306,6 +307,9 @@ public class URIBuilder {
      * Builds a {@link URI} instance.
      */
     public URI build() throws URISyntaxException {
+        if ((URIScheme.HTTPS.same(scheme) || URIScheme.HTTP.same(scheme))  && (TextUtils.isBlank(host))) {
+            throw new URISyntaxException(scheme, "http/https URI cannot have an empty host identifier");
+        }
         return new URI(buildString());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestBasicFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestBasicFuture.java
@@ -296,5 +296,4 @@ public class TestBasicFuture {
             }
         });
     }
-
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -178,9 +178,9 @@ public class TestURIBuilder {
     @Test
     public void testMutationToRelativeUri() throws Exception {
         final URI uri = new URI("http://stuff@localhost:80/stuff?param=stuff#fragment");
-        final URIBuilder uribuilder = new URIBuilder(uri).setHost((String) null);
+        final URIBuilder uribuilder = new URIBuilder(uri).setHost("localhost");
         final URI result = uribuilder.build();
-        Assertions.assertEquals(new URI("http:///stuff?param=stuff#fragment"), result);
+        Assertions.assertEquals(new URI("http://localhost:80/stuff?param=stuff#fragment"), result);
     }
 
     @Test
@@ -911,8 +911,7 @@ public class TestURIBuilder {
                 new URIBuilder("file:../../.././").optimize().build().toASCIIString());
         Assertions.assertEquals("http://host/",
                 new URIBuilder("http://host/../../.././").optimize().build().toASCIIString());
-        Assertions.assertEquals("http:/",
-                new URIBuilder("http:///../../.././").optimize().build().toASCIIString());
+        Assertions.assertThrows(URISyntaxException.class, () -> new URIBuilder("http:///../../.././").optimize().build().toASCIIString());
     }
 
     @Test
@@ -957,5 +956,31 @@ public class TestURIBuilder {
         Assertions.assertEquals("[::1]", uri.getHost());
         Assertions.assertEquals("/path", builder.getPath());
         Assertions.assertEquals("/path", uri.getPath());
+    }
+
+    @Test
+    public void testHttpsUriWithEmptyHost() {
+        final URIBuilder uribuilder = new URIBuilder()
+                .setScheme("https")
+                .setUserInfo("stuff")
+                .setHost("")
+                .setPort(80)
+                .setPath("/some stuff")
+                .setParameter("param", "stuff")
+                .setFragment("fragment");
+        Assertions.assertThrows(URISyntaxException.class, uribuilder::build);
+    }
+
+    @Test
+    public void testHttpUriWithEmptyHost() {
+        final URIBuilder uribuilder = new URIBuilder()
+                .setScheme("http")
+                .setUserInfo("stuff")
+                .setHost("")
+                .setPort(80)
+                .setPath("/some stuff")
+                .setParameter("param", "stuff")
+                .setFragment("fragment");
+        Assertions.assertThrows(URISyntaxException.class, uribuilder::build);
     }
 }


### PR DESCRIPTION
This PR brings our `URIBuilder` in line with the standards set by RFC 9110, specifically Section 4.2.2 regarding HTTPS URIs.

Changes:

- Implemented a check to ensure `https` and `http` URIs do not have an empty host identifier.
[RFC](https://www.rfc-editor.org/rfc/rfc9110#name-https-uri-scheme) mandates such URIs be rejected as invalid.