### PR TITLE
HTTPCORE-756 - Enhance HTTP header handling and deprecate legacy features

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHeaders.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHeaders.java
@@ -40,6 +40,16 @@ public final class HttpHeaders {
 
     public static final String ACCEPT = "Accept";
 
+    /**
+     * The Accept-Charset header is discouraged due to the ubiquity of UTF-8
+     * and potential issues with bandwidth, latency, and fingerprinting.
+     * Most modern user agents do not send Accept-Charset unless specifically configured to do so.
+     * It's recommended to default to UTF-8 for character encoding.
+     *
+     * @since 5.3
+     * @deprecated do not use.
+     */
+    @Deprecated
     public static final String ACCEPT_CHARSET = "Accept-Charset";
 
     public static final String ACCEPT_ENCODING = "Accept-Encoding";

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/MessageSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/MessageSupport.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.FormattedHeader;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HeaderElement;
+import org.apache.hc.core5.http.HeaderElements;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpMessage;
 import org.apache.hc.core5.http.HttpResponse;
@@ -151,6 +152,11 @@ public class MessageSupport {
     }
 
     public static void addTrailerHeader(final HttpMessage message, final EntityDetails entity) {
+        // Ensure using chunked transfer encoding
+        if (!message.containsHeader(HttpHeaders.TRANSFER_ENCODING) ||
+                !HeaderElements.CHUNKED_ENCODING.equals(message.getFirstHeader(HttpHeaders.TRANSFER_ENCODING).getValue())) {
+            return;
+        }
         if (entity != null && !message.containsHeader(HttpHeaders.TRAILER)) {
             final Set<String> trailerNames = entity.getTrailerNames();
             if (trailerNames != null && !trailerNames.isEmpty()) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestMessageSupport.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestMessageSupport.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HeaderElements;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpMessage;
@@ -105,6 +106,7 @@ public class TestMessageSupport {
         final HttpEntity entity = HttpEntities.create("some stuff with trailers", StandardCharsets.US_ASCII,
                 new BasicHeader("z", "this"), new BasicHeader("b", "that"), new BasicHeader("a", "this and that"));
         final HttpMessage message = new BasicHttpResponse(200);
+        message.addHeader(HttpHeaders.TRANSFER_ENCODING, HeaderElements.CHUNKED_ENCODING);
         MessageSupport.addTrailerHeader(message, entity);
         MessageSupport.addContentTypeHeader(message, entity);
 
@@ -115,6 +117,19 @@ public class TestMessageSupport {
         Assertions.assertEquals("z, b, a", h1.getValue());
         Assertions.assertNotNull(h2);
         Assertions.assertEquals("text/plain; charset=US-ASCII", h2.getValue());
+    }
+
+    @Test
+    public void testAddContentHeadersNullEncodingNullTrailer() throws Exception {
+        final HttpEntity entity = HttpEntities.create("some stuff with trailers", StandardCharsets.US_ASCII,
+                new BasicHeader("z", "this"), new BasicHeader("b", "that"), new BasicHeader("a", "this and that"));
+        final HttpMessage message = new BasicHttpResponse(200);
+        MessageSupport.addTrailerHeader(message, entity);
+        MessageSupport.addContentTypeHeader(message, entity);
+
+        final Header h1 = message.getFirstHeader(HttpHeaders.TRAILER);
+
+        Assertions.assertNull(h1);
     }
 
     @Test


### PR DESCRIPTION
This PR introduces two significant changes to improve our alignment with modern HTTP standards:

- Trailer Headers with Chunked Transfer Encoding: We've added a check to ensure that trailer headers are only appended when using chunked transfer encoding. This change ensures that our library remains compliant with the HTTP standards regarding the use of trailer headers.

- Deprecation of ACCEPT_CHARSET: In line with the recommendations from the latest [RFC,](https://www.rfc-editor.org/rfc/rfc9110#name-changes-from-rfc-7231) we've deprecated the `ACCEPT_CHARSET` constant. This change signals to developers that its use is discouraged and helps guide them towards more modern practices.