### PR TITLE
HTTP message support improvements

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultConnectionReuseStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/DefaultConnectionReuseStrategy.java
@@ -81,9 +81,9 @@ public class DefaultConnectionReuseStrategy implements ConnectionReuseStrategy {
         Args.notNull(response, "HTTP response");
 
         if (request != null) {
-            final Iterator<String> ti = new BasicTokenIterator(request.headerIterator(HttpHeaders.CONNECTION));
-            while (ti.hasNext()) {
-                final String token = ti.next();
+            final Iterator<String> it = MessageSupport.iterateTokens(request, HttpHeaders.CONNECTION);
+            while (it.hasNext()) {
+                final String token = it.next();
                 if (HeaderElements.CLOSE.equalsIgnoreCase(token)) {
                     return false;
                 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
@@ -57,7 +57,7 @@ import org.apache.hc.core5.http.io.HttpMessageParserFactory;
 import org.apache.hc.core5.http.io.HttpMessageWriter;
 import org.apache.hc.core5.http.io.HttpMessageWriterFactory;
 import org.apache.hc.core5.http.io.ResponseOutOfOrderStrategy;
-import org.apache.hc.core5.http.message.BasicTokenIterator;
+import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -271,9 +271,9 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
         if (entity == null) {
             return;
         }
-        final Iterator<String> ti = new BasicTokenIterator(request.headerIterator(HttpHeaders.CONNECTION));
-        while (ti.hasNext()) {
-            final String token = ti.next();
+        final Iterator<String> it = MessageSupport.iterateTokens(request, HttpHeaders.CONNECTION);
+        while (it.hasNext()) {
+            final String token = it.next();
             if (HeaderElements.CLOSE.equalsIgnoreCase(token)) {
                 this.consistent = false;
                 return;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderElement.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderElement.java
@@ -55,7 +55,7 @@ public class BasicHeaderElement implements HeaderElement {
     public BasicHeaderElement(
             final String name,
             final String value,
-            final NameValuePair[] parameters) {
+            final NameValuePair... parameters) {
         super();
         this.name = Args.notNull(name, "Name");
         this.value = value;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderValueParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderValueParser.java
@@ -93,7 +93,10 @@ public class BasicHeaderValueParser implements HeaderValueParser {
         final NameValuePair nvp = parseNameValuePair(buffer, cursor);
         NameValuePair[] params = null;
         if (!cursor.atEnd()) {
-            final char ch = buffer.charAt(cursor.getPos() - 1);
+            final char ch = buffer.charAt(cursor.getPos());
+            if (ch == PARAM_DELIMITER || ch == ELEM_DELIMITER) {
+                cursor.updatePos(cursor.getPos() + 1);
+            }
             if (ch != ELEM_DELIMITER) {
                 params = parseParameters(buffer, cursor);
             }
@@ -110,9 +113,14 @@ public class BasicHeaderValueParser implements HeaderValueParser {
         while (!cursor.atEnd()) {
             final NameValuePair param = parseNameValuePair(buffer, cursor);
             params.add(param);
-            final char ch = buffer.charAt(cursor.getPos() - 1);
-            if (ch == ELEM_DELIMITER) {
-                break;
+            if (!cursor.atEnd()) {
+                final char ch = buffer.charAt(cursor.getPos());
+                if (ch == PARAM_DELIMITER) {
+                    cursor.updatePos(cursor.getPos() + 1);
+                }
+                if (ch == ELEM_DELIMITER) {
+                    break;
+                }
             }
         }
         return params.toArray(EMPTY_NAME_VALUE_ARRAY);
@@ -127,15 +135,12 @@ public class BasicHeaderValueParser implements HeaderValueParser {
         if (cursor.atEnd()) {
             return new BasicNameValuePair(name, null);
         }
-        final int delim = buffer.charAt(cursor.getPos());
-        cursor.updatePos(cursor.getPos() + 1);
+        final char delim = buffer.charAt(cursor.getPos());
         if (delim != '=') {
             return new BasicNameValuePair(name, null);
         }
+        cursor.updatePos(cursor.getPos() + 1);
         final String value = tokenizer.parseValue(buffer, cursor, VALUE_DELIMITER);
-        if (!cursor.atEnd()) {
-            cursor.updatePos(cursor.getPos() + 1);
-        }
         return new BasicNameValuePair(name, value);
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueFormatter.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueFormatter.java
@@ -145,10 +145,10 @@ public class TestBasicHeaderValueFormatter {
         final NameValuePair param2 = new BasicNameValuePair("param", "this\\that");
         final NameValuePair param3 = new BasicNameValuePair("param", "this,that");
         final NameValuePair param4 = new BasicNameValuePair("param", null);
-        final HeaderElement element1 = new BasicHeaderElement("name1", "value1", new NameValuePair[] {param1});
-        final HeaderElement element2 = new BasicHeaderElement("name2", "value2", new NameValuePair[] {param2});
-        final HeaderElement element3 = new BasicHeaderElement("name3", "value3", new NameValuePair[] {param3});
-        final HeaderElement element4 = new BasicHeaderElement("name4", "value4", new NameValuePair[] {param4});
+        final HeaderElement element1 = new BasicHeaderElement("name1", "value1", param1);
+        final HeaderElement element2 = new BasicHeaderElement("name2", "value2", param2);
+        final HeaderElement element3 = new BasicHeaderElement("name3", "value3", param3);
+        final HeaderElement element4 = new BasicHeaderElement("name4", "value4", param4);
         final HeaderElement element5 = new BasicHeaderElement("name5", null);
         final HeaderElement[] elements = new HeaderElement[] {element1, element2, element3, element4, element5};
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueParser.java
@@ -153,8 +153,8 @@ public class TestBasicHeaderValueParser {
         param = this.parser.parseNameValuePair(buffer, cursor);
         Assertions.assertEquals("test", param.getName());
         Assertions.assertNull(param.getValue());
-        Assertions.assertEquals(s.length(), cursor.getPos());
-        Assertions.assertTrue(cursor.atEnd());
+        Assertions.assertEquals(s.length() - 1, cursor.getPos());
+        Assertions.assertFalse(cursor.atEnd());
 
         s = "test  ,12";
         buffer = new CharArrayBuffer(16);
@@ -164,7 +164,7 @@ public class TestBasicHeaderValueParser {
         param = this.parser.parseNameValuePair(buffer, cursor);
         Assertions.assertEquals("test", param.getName());
         Assertions.assertNull(param.getValue());
-        Assertions.assertEquals(s.length() - 2, cursor.getPos());
+        Assertions.assertEquals(s.length() - 3, cursor.getPos());
         Assertions.assertFalse(cursor.atEnd());
 
         s = "test=stuff";
@@ -197,7 +197,7 @@ public class TestBasicHeaderValueParser {
         param = this.parser.parseNameValuePair(buffer, cursor);
         Assertions.assertEquals("test", param.getName());
         Assertions.assertEquals("stuff", param.getValue());
-        Assertions.assertEquals(s.length() - 4, cursor.getPos());
+        Assertions.assertEquals(s.length() - 5, cursor.getPos());
         Assertions.assertFalse(cursor.atEnd());
 
         s = "test  = \"stuff\"";
@@ -281,7 +281,7 @@ public class TestBasicHeaderValueParser {
         Assertions.assertEquals("stuff; stuff", params[2].getValue());
         Assertions.assertEquals("test3", params[3].getName());
         Assertions.assertEquals("stuff", params[3].getValue());
-        Assertions.assertEquals(s.length() - 3, cursor.getPos());
+        Assertions.assertEquals(s.length() - 4, cursor.getPos());
         Assertions.assertFalse(cursor.atEnd());
 
         s = "  ";

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestMessageSupport.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestMessageSupport.java
@@ -28,14 +28,19 @@
 package org.apache.hc.core5.http.message;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpMessage;
+import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.apache.hc.core5.util.CharArrayBuffer;
 import org.junit.jupiter.api.Assertions;
@@ -54,29 +59,55 @@ public class TestMessageSupport {
 
     @Test
     public void testTokenSetFormatting() throws Exception {
-        final Header header = MessageSupport.format(HttpHeaders.TRAILER, makeSet("z", "b", "a"));
+        final Header header = MessageSupport.header(HttpHeaders.TRAILER, makeSet("z", "b", "a"));
         Assertions.assertNotNull(header);
         Assertions.assertEquals("z, b, a", header.getValue());
     }
 
     @Test
+    public void testTokenListFormatting() throws Exception {
+        final Header header = MessageSupport.headerOfTokens(HttpHeaders.TRAILER, Arrays.asList("z", "b", "a", "a"));
+        Assertions.assertNotNull(header);
+        Assertions.assertEquals("z, b, a, a", header.getValue());
+    }
+
+    @Test
     public void testTokenSetFormattingSameName() throws Exception {
-        final Header header = MessageSupport.format(HttpHeaders.TRAILER, makeSet("a", "a", "a"));
+        final Header header = MessageSupport.header(HttpHeaders.TRAILER, makeSet("a", "a", "a"));
         Assertions.assertNotNull(header);
         Assertions.assertEquals("a", header.getValue());
     }
 
     @Test
-    public void testTokensFormattingSameName() throws Exception {
-        final Header header = MessageSupport.format(HttpHeaders.TRAILER, "a", "a", "a");
+    public void testTokenListFormattingSameName() throws Exception {
+        final Header header = MessageSupport.header(HttpHeaders.TRAILER, "a", "a", "a");
         Assertions.assertNotNull(header);
         Assertions.assertEquals("a, a, a", header.getValue());
     }
 
     @Test
-    public void testTrailerNoTrailers() throws Exception {
-        final Header header = MessageSupport.format(HttpHeaders.TRAILER);
-        Assertions.assertNull(header);
+    public void testParseTokensWithConsumer() throws Exception {
+        final String s = "a, b, c, c";
+        final ParserCursor cursor = new ParserCursor(0, s.length());
+        final List<String> tokens = new ArrayList<>();
+        MessageSupport.parseTokens(s, cursor, tokens::add);
+        Assertions.assertEquals(Arrays.asList("a", "b", "c", "c"), tokens);
+    }
+
+    @Test
+    public void testParseTokenHeaderWithConsumer() throws Exception {
+        final Header header = new BasicHeader(HttpHeaders.TRAILER, "a, b, c, c");
+        final List<String> tokens = new ArrayList<>();
+        MessageSupport.parseTokens(header, tokens::add);
+        Assertions.assertEquals(Arrays.asList("a", "b", "c", "c"), tokens);
+    }
+
+    @Test
+    public void testParseTokenBufferWithConsumer() throws Exception {
+        final CharArrayBuffer buf = new CharArrayBuffer(128);
+        buf.append("stuff: a, b, c, c");
+        final Header header = BufferedHeader.create(buf);
+        Assertions.assertEquals(makeSet("a", "b", "c", "c"), MessageSupport.parseTokens(header));
     }
 
     @Test
@@ -93,11 +124,197 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseTokenBufferedHeader() throws Exception {
+    public void testParseTokenBuffer() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(128);
         buf.append("stuff: a, b, c, c");
         final Header header = BufferedHeader.create(buf);
         Assertions.assertEquals(makeSet("a", "b", "c"), MessageSupport.parseTokens(header));
+    }
+
+    @Test
+    public void testElementListFormatting() throws Exception {
+        final List<HeaderElement> elements = Arrays.asList(
+                new BasicHeaderElement("name1", "value1", new BasicNameValuePair("param", "regular_stuff")),
+                new BasicHeaderElement("name2", "value2", new BasicNameValuePair("param", "this\\that")),
+                new BasicHeaderElement("name3", "value3", new BasicNameValuePair("param", "this,that")),
+                new BasicHeaderElement("name4", "value4", new BasicNameValuePair("param", null)),
+                new BasicHeaderElement("name5", null));
+
+        final Header header = MessageSupport.headerOfElements("Some-header", elements);
+        Assertions.assertNotNull(header);
+        Assertions.assertEquals("name1=value1; param=regular_stuff, name2=value2; " +
+                "param=\"this\\\\that\", name3=value3; param=\"this,that\", " +
+                "name4=value4; param, name5", header.getValue());
+    }
+
+    @Test
+    public void testElementArrayFormatting() throws Exception {
+        final HeaderElement[] elements = {
+                new BasicHeaderElement("name1", "value1", new BasicNameValuePair("param", "regular_stuff")),
+                new BasicHeaderElement("name2", "value2", new BasicNameValuePair("param", "this\\that")),
+                new BasicHeaderElement("name3", "value3", new BasicNameValuePair("param", "this,that")),
+                new BasicHeaderElement("name4", "value4", new BasicNameValuePair("param", null)),
+                new BasicHeaderElement("name5", null)};
+
+        final Header header = MessageSupport.header("Some-Header", elements);
+        Assertions.assertNotNull(header);
+        Assertions.assertEquals("name1=value1; param=regular_stuff, name2=value2; " +
+                "param=\"this\\\\that\", name3=value3; param=\"this,that\", " +
+                "name4=value4; param, name5", header.getValue());
+    }
+
+    @Test
+    public void testParseElementsBufferWithConsumer() throws Exception {
+        final CharArrayBuffer buf = new CharArrayBuffer(64);
+        buf.append("name1 = value1; name2; name3=\"value3\" , name4=value4; " +
+                "name5=value5, name6= ; name7 = value7; name8 = \" value8\"");
+        final List<HeaderElement> elements = new ArrayList<>();
+        final ParserCursor cursor = new ParserCursor(0, buf.length());
+        MessageSupport.parseElements(buf, cursor, elements::add);
+        // there are 3 elements
+        Assertions.assertEquals(3,elements.size());
+        // 1st element
+        Assertions.assertEquals("name1", elements.get(0).getName());
+        Assertions.assertEquals("value1", elements.get(0).getValue());
+        // 1st element has 2 getParameters()
+        Assertions.assertEquals(2, elements.get(0).getParameters().length);
+        Assertions.assertEquals("name2", elements.get(0).getParameters()[0].getName());
+        Assertions.assertNull(elements.get(0).getParameters()[0].getValue());
+        Assertions.assertEquals("name3", elements.get(0).getParameters()[1].getName());
+        Assertions.assertEquals("value3", elements.get(0).getParameters()[1].getValue());
+        // 2nd element
+        Assertions.assertEquals("name4", elements.get(1).getName());
+        Assertions.assertEquals("value4", elements.get(1).getValue());
+        // 2nd element has 1 parameter
+        Assertions.assertEquals(1, elements.get(1).getParameters().length);
+        Assertions.assertEquals("name5", elements.get(1).getParameters()[0].getName());
+        Assertions.assertEquals("value5", elements.get(1).getParameters()[0].getValue());
+        // 3rd element
+        Assertions.assertEquals("name6", elements.get(2).getName());
+        Assertions.assertEquals("", elements.get(2).getValue());
+        // 3rd element has 2 getParameters()
+        Assertions.assertEquals(2, elements.get(2).getParameters().length);
+        Assertions.assertEquals("name7", elements.get(2).getParameters()[0].getName());
+        Assertions.assertEquals("value7", elements.get(2).getParameters()[0].getValue());
+        Assertions.assertEquals("name8", elements.get(2).getParameters()[1].getName());
+        Assertions.assertEquals(" value8", elements.get(2).getParameters()[1].getValue());
+    }
+
+    @Test
+    public void testParseElementsHeaderWithConsumer() throws Exception {
+        final Header header = new BasicHeader("Some-Header",
+                "name1 = value1; name2; name3=\"value3\" , name4=value4; " +
+                "name5=value5, name6= ; name7 = value7; name8 = \" value8\"");
+        final List<HeaderElement> elements = new ArrayList<>();
+        MessageSupport.parseElements(header, elements::add);
+        // there are 3 elements
+        Assertions.assertEquals(3,elements.size());
+        // 1st element
+        Assertions.assertEquals("name1", elements.get(0).getName());
+        Assertions.assertEquals("value1", elements.get(0).getValue());
+        // 1st element has 2 getParameters()
+        Assertions.assertEquals(2, elements.get(0).getParameters().length);
+        Assertions.assertEquals("name2", elements.get(0).getParameters()[0].getName());
+        Assertions.assertNull(elements.get(0).getParameters()[0].getValue());
+        Assertions.assertEquals("name3", elements.get(0).getParameters()[1].getName());
+        Assertions.assertEquals("value3", elements.get(0).getParameters()[1].getValue());
+        // 2nd element
+        Assertions.assertEquals("name4", elements.get(1).getName());
+        Assertions.assertEquals("value4", elements.get(1).getValue());
+        // 2nd element has 1 parameter
+        Assertions.assertEquals(1, elements.get(1).getParameters().length);
+        Assertions.assertEquals("name5", elements.get(1).getParameters()[0].getName());
+        Assertions.assertEquals("value5", elements.get(1).getParameters()[0].getValue());
+        // 3rd element
+        Assertions.assertEquals("name6", elements.get(2).getName());
+        Assertions.assertEquals("", elements.get(2).getValue());
+        // 3rd element has 2 getParameters()
+        Assertions.assertEquals(2, elements.get(2).getParameters().length);
+        Assertions.assertEquals("name7", elements.get(2).getParameters()[0].getName());
+        Assertions.assertEquals("value7", elements.get(2).getParameters()[0].getValue());
+        Assertions.assertEquals("name8", elements.get(2).getParameters()[1].getName());
+        Assertions.assertEquals(" value8", elements.get(2).getParameters()[1].getValue());
+    }
+
+    @Test
+    public void testParseElementsHeader() throws Exception {
+        final Header header = new BasicHeader("Some-Header",
+                "name1 = value1; name2; name3=\"value3\" , name4=value4; " +
+                        "name5=value5, name6= ; name7 = value7; name8 = \" value8\"");
+        final List<HeaderElement> elements = MessageSupport.parseElements(header);
+        // there are 3 elements
+        Assertions.assertEquals(3,elements.size());
+        // 1st element
+        Assertions.assertEquals("name1", elements.get(0).getName());
+        Assertions.assertEquals("value1", elements.get(0).getValue());
+        // 1st element has 2 getParameters()
+        Assertions.assertEquals(2, elements.get(0).getParameters().length);
+        Assertions.assertEquals("name2", elements.get(0).getParameters()[0].getName());
+        Assertions.assertNull(elements.get(0).getParameters()[0].getValue());
+        Assertions.assertEquals("name3", elements.get(0).getParameters()[1].getName());
+        Assertions.assertEquals("value3", elements.get(0).getParameters()[1].getValue());
+        // 2nd element
+        Assertions.assertEquals("name4", elements.get(1).getName());
+        Assertions.assertEquals("value4", elements.get(1).getValue());
+        // 2nd element has 1 parameter
+        Assertions.assertEquals(1, elements.get(1).getParameters().length);
+        Assertions.assertEquals("name5", elements.get(1).getParameters()[0].getName());
+        Assertions.assertEquals("value5", elements.get(1).getParameters()[0].getValue());
+        // 3rd element
+        Assertions.assertEquals("name6", elements.get(2).getName());
+        Assertions.assertEquals("", elements.get(2).getValue());
+        // 3rd element has 2 getParameters()
+        Assertions.assertEquals(2, elements.get(2).getParameters().length);
+        Assertions.assertEquals("name7", elements.get(2).getParameters()[0].getName());
+        Assertions.assertEquals("value7", elements.get(2).getParameters()[0].getValue());
+        Assertions.assertEquals("name8", elements.get(2).getParameters()[1].getName());
+        Assertions.assertEquals(" value8", elements.get(2).getParameters()[1].getValue());
+    }
+
+    @Test
+    public void testParamListFormatting() throws Exception {
+        final CharArrayBuffer buf = new CharArrayBuffer(64);
+        MessageSupport.formatParameters(buf, Arrays.asList(
+                new BasicNameValuePair("param", "regular_stuff"),
+                new BasicNameValuePair("param", "this\\that"),
+                new BasicNameValuePair("param", "this,that")
+        ));
+        Assertions.assertEquals("param=regular_stuff; param=\"this\\\\that\"; param=\"this,that\"",
+                buf.toString());
+    }
+
+    @Test
+    public void testParamArrayFormatting() throws Exception {
+        final CharArrayBuffer buf = new CharArrayBuffer(64);
+        MessageSupport.formatParameters(buf,
+                new BasicNameValuePair("param", "regular_stuff"),
+                new BasicNameValuePair("param", "this\\that"),
+                new BasicNameValuePair("param", "this,that")
+        );
+        Assertions.assertEquals("param=regular_stuff; param=\"this\\\\that\"; param=\"this,that\"",
+                buf.toString());
+    }
+
+    @Test
+    public void testParseParams() {
+        final String s =
+                "test; test1 =  stuff   ; test2 =  \"stuff; stuff\"; test3=stuff,123";
+        final CharArrayBuffer buffer = new CharArrayBuffer(16);
+        buffer.append(s);
+        final ParserCursor cursor = new ParserCursor(0, s.length());
+
+        final List<NameValuePair> params = new ArrayList<>();
+        MessageSupport.parseParameters(buffer, cursor, params::add);
+        Assertions.assertEquals("test", params.get(0).getName());
+        Assertions.assertNull(params.get(0).getValue());
+        Assertions.assertEquals("test1", params.get(1).getName());
+        Assertions.assertEquals("stuff", params.get(1).getValue());
+        Assertions.assertEquals("test2", params.get(2).getName());
+        Assertions.assertEquals("stuff; stuff", params.get(2).getValue());
+        Assertions.assertEquals("test3", params.get(3).getName());
+        Assertions.assertEquals("stuff", params.get(3).getValue());
+        Assertions.assertEquals(s.length() - 4, cursor.getPos());
+        Assertions.assertFalse(cursor.atEnd());
     }
 
     @Test


### PR DESCRIPTION
This patch corrects the name/value parsing code in `BasicHeaderValueParser` and adds a number of message element formatting and parsing methods to `MessageSupport`