### PR TITLE
HTTPCORE-756: server-side request / response protocol conformance checks

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/H2Processors.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/H2Processors.java
@@ -29,8 +29,10 @@ package org.apache.hc.core5.http2.impl;
 import org.apache.hc.core5.http.impl.HttpProcessors;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.HttpProcessorBuilder;
+import org.apache.hc.core5.http.protocol.RequestConformance;
 import org.apache.hc.core5.http.protocol.RequestExpectContinue;
 import org.apache.hc.core5.http.protocol.RequestUserAgent;
+import org.apache.hc.core5.http.protocol.ResponseConformance;
 import org.apache.hc.core5.http.protocol.ResponseDate;
 import org.apache.hc.core5.http.protocol.ResponseServer;
 import org.apache.hc.core5.http2.protocol.H2RequestConnControl;
@@ -52,13 +54,15 @@ public final class H2Processors {
     public static HttpProcessorBuilder customServer(final String serverInfo) {
         return HttpProcessorBuilder.create()
                 .addAll(
-                        new ResponseDate(),
+                        ResponseConformance.INSTANCE,
+                        ResponseDate.INSTANCE,
                         new ResponseServer(!TextUtils.isBlank(serverInfo) ? serverInfo :
                                 VersionInfo.getSoftwareInfo(SOFTWARE, "org.apache.hc.core5", H2Processors.class)),
                         H2ResponseContent.INSTANCE,
                         H2ResponseConnControl.INSTANCE)
                 .addAll(
-                        H2RequestValidateHost.INSTANCE);
+                        H2RequestValidateHost.INSTANCE,
+                        RequestConformance.INSTANCE);
     }
 
     public static HttpProcessor server(final String serverInfo) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamHandler.java
@@ -123,7 +123,6 @@ class ServerH2StreamHandler implements H2StreamHandler {
             @Override
             public void sendResponse(
                     final HttpResponse response, final EntityDetails responseEntityDetails, final HttpContext httpContext) throws HttpException, IOException {
-                ServerSupport.validateResponse(response, responseEntityDetails);
                 commitResponse(response, responseEntityDetails);
             }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/HttpProcessors.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/HttpProcessors.java
@@ -28,12 +28,14 @@ package org.apache.hc.core5.http.impl;
 
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.HttpProcessorBuilder;
+import org.apache.hc.core5.http.protocol.RequestConformance;
 import org.apache.hc.core5.http.protocol.RequestConnControl;
 import org.apache.hc.core5.http.protocol.RequestContent;
 import org.apache.hc.core5.http.protocol.RequestExpectContinue;
 import org.apache.hc.core5.http.protocol.RequestTargetHost;
 import org.apache.hc.core5.http.protocol.RequestUserAgent;
 import org.apache.hc.core5.http.protocol.RequestValidateHost;
+import org.apache.hc.core5.http.protocol.ResponseConformance;
 import org.apache.hc.core5.http.protocol.ResponseConnControl;
 import org.apache.hc.core5.http.protocol.ResponseContent;
 import org.apache.hc.core5.http.protocol.ResponseDate;
@@ -60,13 +62,15 @@ public final class HttpProcessors {
     public static HttpProcessorBuilder customServer(final String serverInfo) {
         return HttpProcessorBuilder.create()
                 .addAll(
-                        new ResponseDate(),
+                        ResponseConformance.INSTANCE,
+                        ResponseDate.INSTANCE,
                         new ResponseServer(!TextUtils.isBlank(serverInfo) ? serverInfo :
                                 VersionInfo.getSoftwareInfo(SOFTWARE, "org.apache.hc.core5", HttpProcessors.class)),
-                        new ResponseContent(),
-                        new ResponseConnControl())
+                        ResponseContent.INSTANCE,
+                        ResponseConnControl.INSTANCE)
                 .addAll(
-                        new RequestValidateHost());
+                        RequestValidateHost.INSTANCE,
+                        RequestConformance.INSTANCE);
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/ServerSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/ServerSupport.java
@@ -27,9 +27,6 @@
 package org.apache.hc.core5.http.impl;
 
 import org.apache.hc.core5.annotation.Internal;
-import org.apache.hc.core5.http.EntityDetails;
-import org.apache.hc.core5.http.HttpException;
-import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.MethodNotSupportedException;
 import org.apache.hc.core5.http.MisdirectedRequestException;
@@ -45,19 +42,6 @@ import org.apache.hc.core5.http.UnsupportedHttpVersionException;
  */
 @Internal
 public class ServerSupport {
-
-    public static void validateResponse(
-            final HttpResponse response,
-            final EntityDetails responseEntityDetails) throws HttpException {
-        final int status = response.getCode();
-        switch (status) {
-            case HttpStatus.SC_NO_CONTENT:
-            case HttpStatus.SC_NOT_MODIFIED:
-                if (responseEntityDetails != null) {
-                    throw new HttpException("Response " + status + " must not enclose an entity");
-                }
-        }
-    }
 
     public static String toErrorMessage(final Exception ex) {
         final String message = ex.getMessage();

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpService.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpService.java
@@ -215,7 +215,6 @@ public class HttpService {
                         if (transportVersion != null && transportVersion.greaterEquals(HttpVersion.HTTP_2)) {
                             throw new UnsupportedHttpVersionException(transportVersion);
                         }
-                        ServerSupport.validateResponse(response, response.getEntity());
                         context.setProtocolVersion(transportVersion != null ? transportVersion : HttpVersion.HTTP_1_1);
                         context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
                         processor.process(response, response.getEntity(), context);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
@@ -125,7 +125,6 @@ class ServerHttp1StreamHandler implements ResourceHolder {
             @Override
             public void sendResponse(
                     final HttpResponse response, final EntityDetails responseEntityDetails, final HttpContext httpContext) throws HttpException, IOException {
-                ServerSupport.validateResponse(response, responseEntityDetails);
                 commitResponse(response, responseEntityDetails);
             }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
@@ -57,6 +57,8 @@ import org.apache.hc.core5.util.Args;
 @Contract(threading = ThreadingBehavior.IMMUTABLE)
 public class ResponseConnControl implements HttpResponseInterceptor {
 
+    public static final ResponseConnControl INSTANCE = new ResponseConnControl();
+
     public ResponseConnControl() {
         super();
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseContent.java
@@ -57,6 +57,8 @@ import org.apache.hc.core5.util.Args;
 @Contract(threading = ThreadingBehavior.IMMUTABLE)
 public class ResponseContent implements HttpResponseInterceptor {
 
+    public static final ResponseContent INSTANCE = new ResponseContent();
+
     private final boolean overwrite;
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseDate.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseDate.java
@@ -49,6 +49,8 @@ import org.apache.hc.core5.util.Args;
 @Contract(threading = ThreadingBehavior.SAFE)
 public class ResponseDate implements HttpResponseInterceptor {
 
+    public static final ResponseDate INSTANCE = new ResponseDate();
+
     public ResponseDate() {
         super();
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -997,4 +997,87 @@ public class TestStandardInterceptors {
         Assertions.assertThrows(ProtocolException.class, () ->
                 interceptor.process(request, request.getEntity(), context));
     }
+
+    @Test
+    public void testRequestConformance() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
+        request.setScheme("http");
+        request.setAuthority(new URIAuthority("somehost", 8888));
+        request.setPath("/path");
+        final RequestConformance interceptor = new RequestConformance();
+        interceptor.process(request, request.getEntity(), context);
+    }
+
+    @Test
+    public void testRequestConformanceSchemeMissing() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
+        request.setAuthority(new URIAuthority("somehost", 8888));
+        request.setPath("/path");
+        final RequestConformance interceptor = new RequestConformance();
+        Assertions.assertThrows(ProtocolException.class, () ->
+                interceptor.process(request, request.getEntity(), context));
+    }
+
+    @Test
+    public void testRequestConformancePathMissing() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
+        request.setScheme("http");
+        request.setAuthority(new URIAuthority("somehost", 8888));
+        request.setPath("");
+        final RequestConformance interceptor = new RequestConformance();
+        Assertions.assertThrows(ProtocolException.class, () ->
+                interceptor.process(request, request.getEntity(), context));
+    }
+
+    @Test
+    public void testRequestConformanceHostMissing() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
+        request.setScheme("http");
+        request.setAuthority(new URIAuthority("", -1));
+        request.setPath("/path");
+        final RequestConformance interceptor = new RequestConformance();
+        Assertions.assertThrows(ProtocolException.class, () ->
+                interceptor.process(request, request.getEntity(), context));
+    }
+
+    @Test
+    public void testResponseConformanceNoContent() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
+        final ResponseConformance interceptor = new ResponseConformance();
+        interceptor.process(response, response.getEntity(), context);
+    }
+
+    @Test
+    public void testResponseConformanceNotModified() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NOT_MODIFIED, "Not Modified");
+        final ResponseConformance interceptor = new ResponseConformance();
+        interceptor.process(response, response.getEntity(), context);
+    }
+
+    @Test
+    public void testResponseConformanceNoContentWithEntity() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
+        response.setEntity(new StringEntity("stuff"));
+        final ResponseConformance interceptor = new ResponseConformance();
+        Assertions.assertThrows(ProtocolException.class, () ->
+            interceptor.process(response, response.getEntity(), context));
+    }
+
+    @Test
+    public void testResponseConformanceNotModifiedWithEntity() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NOT_MODIFIED, "Not Modified");
+        response.setEntity(new StringEntity("stuff"));
+        final ResponseConformance interceptor = new ResponseConformance();
+        Assertions.assertThrows(ProtocolException.class, () ->
+            interceptor.process(response, response.getEntity(), context));
+    }
+
 }


### PR DESCRIPTION
* Moved outgoing response conformance checks to the correct place in the protocol pipeline
* Added incoming request conformance checks based on RFC 9110. 