### PR TITLE
HTTPCORE-759 Content-Length missing on null entity request content

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -110,6 +110,10 @@ public class RequestContent implements HttpRequestInterceptor {
                 throw new ProtocolException("Content-Length header already present");
             }
         }
+        if (entity == null) {
+            request.addHeader(HttpHeaders.CONTENT_LENGTH, "0");
+            return;
+        }
         if (entity != null) {
 
             // Check for OPTIONS request with content but no Content-Type header


### PR DESCRIPTION
Quick fix for maximum compatibility per JIRA