### PR TITLE
Add security warning to TrustStrategy documentation

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContextBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContextBuilder.java
@@ -253,6 +253,11 @@ public class SSLContextBuilder {
         return this;
     }
 
+    /**
+     * @param trustStrategy
+     *            custom trust strategy to use; can be {@code null} in which case
+     *            only the default trust managers will be used
+     */
     public SSLContextBuilder loadTrustMaterial(
             final KeyStore trustStore,
             final TrustStrategy trustStrategy) throws NoSuchAlgorithmException, KeyStoreException {

--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/TrustStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/TrustStrategy.java
@@ -36,13 +36,13 @@ import java.security.cert.X509Certificate;
  *
  * <h2>Security Warning</h2>
  * If a trust strategy considers a certificate chain to be trusted, then the default trust manager
- * will not be consulted. Trust strategy implementations must therefore properly check the complete
- * certificate chain. Checking for example only the subject of a certificate does not protect
- * against man-in-the-middle attacks. For self-signed certificates prefer specifying a keystore
+ * will not be consulted. Trust strategy implementations should therefore consider properly checking
+ * the complete certificate chain. Checking for example only the subject of a certificate does not
+ * protect against man-in-the-middle attacks. For self-signed certificates prefer specifying a keystore
  * containing the certificate chain when calling the {@link SSLContextBuilder} {@code loadTrustMaterial}
  * methods instead of implementing a custom trust strategy.
  *
- * <p>A trust strategy cannot be used for certificate pinning. When {@code isTrusted} returns
+ * <p>A trust strategy alone cannot be used for certificate pinning. When {@code isTrusted} returns
  * {@code false} the certificate check falls back to the trust manager which might consider
  * the certificate trusted. See the {@link #isTrusted(X509Certificate[], String)} documentation.
  *

--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/TrustStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/TrustStrategy.java
@@ -34,6 +34,19 @@ import java.security.cert.X509Certificate;
  * configured in the actual SSL context. This interface can be used to override the standard
  * JSSE certificate verification process.
  *
+ * <h2>Security Warning</h2>
+ * If a trust strategy considers a certificate chain to be trusted, then the default trust manager
+ * will not be consulted. Trust strategy implementations must therefore properly check the complete
+ * certificate chain. Checking for example only the subject of a certificate does not protect
+ * against man-in-the-middle attacks. For self-signed certificates prefer specifying a keystore
+ * containing the certificate chain when calling the {@link SSLContextBuilder} {@code loadTrustMaterial}
+ * methods instead of implementing a custom trust strategy.
+ *
+ * <p>A trust strategy cannot be used for certificate pinning. When {@code isTrusted} returns
+ * {@code false} the certificate check falls back to the trust manager which might consider
+ * the certificate trusted. See the {@link #isTrusted(X509Certificate[], String)} documentation.
+ *
+ * @see SSLContextBuilder
  * @since 4.4
  */
 public interface TrustStrategy {


### PR DESCRIPTION
This tries to make the security aspects of `TrustStrategy` clearer and suggest that it might not be needed when self-signed certificates are used.

Relates to https://github.com/apache/httpcomponents-client/pull/490

Any feedback is appreciated!