### PR TITLE
HTTPCORE-756: RFC 9110 conformance improvements

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/H2Processors.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/H2Processors.java
@@ -76,8 +76,8 @@ public final class H2Processors {
     public static HttpProcessorBuilder customClient(final String agentInfo) {
         return HttpProcessorBuilder.create()
                 .addAll(
-                        H2RequestContent.INSTANCE,
                         H2RequestTargetHost.INSTANCE,
+                        H2RequestContent.INSTANCE,
                         H2RequestConnControl.INSTANCE,
                         new RequestUserAgent(!TextUtils.isBlank(agentInfo) ? agentInfo :
                                 VersionInfo.getSoftwareInfo(SOFTWARE, "org.apache.hc.core5", HttpProcessors.class)),

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
@@ -409,8 +409,8 @@ public class H2ServerBootstrap {
                 http1Config != null ? http1Config : Http1Config.DEFAULT,
                 charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT,
                 DefaultConnectionReuseStrategy.INSTANCE,
-                DefaultHttpRequestParserFactory.INSTANCE,
-                DefaultHttpResponseWriterFactory.INSTANCE,
+                new DefaultHttpRequestParserFactory(http1Config),
+                new DefaultHttpResponseWriterFactory(http1Config),
                 DefaultContentLengthStrategy.INSTANCE,
                 DefaultContentLengthStrategy.INSTANCE,
                 http1StreamListener);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestConnControl.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestConnControl.java
@@ -41,6 +41,10 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestConnControl}.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestContent.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestContent.java
@@ -44,6 +44,10 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestContent}.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestTargetHost.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestTargetHost.java
@@ -41,6 +41,10 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestTargetHost}.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestValidateHost.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestValidateHost.java
@@ -41,6 +41,10 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link RequestValidateHost}.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseConnControl.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseConnControl.java
@@ -41,6 +41,10 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link ResponseConnControl}.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseContent.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2ResponseContent.java
@@ -42,6 +42,10 @@ import org.apache.hc.core5.util.Args;
 
 /**
  * HTTP/2 compatible extension of {@link ResponseContent}.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/ClassicTestClient.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/classic/ClassicTestClient.java
@@ -82,7 +82,7 @@ public class ClassicTestClient {
     public void start(final HttpProcessor httpProcessor) {
         if (requesterRef.get() == null) {
             final HttpRequestExecutor requestExecutor = new HttpRequestExecutor(
-                    HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE,
+                    Http1Config.DEFAULT,
                     DefaultConnectionReuseStrategy.INSTANCE,
                     LoggingHttp1StreamListener.INSTANCE);
             final StrictConnPool<HttpHost, HttpClientConnection> connPool = new StrictConnPool<>(

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp1EventHandlerFactory.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/nio/InternalServerHttp1EventHandlerFactory.java
@@ -95,7 +95,7 @@ class InternalServerHttp1EventHandlerFactory implements IOEventHandlerFactory {
         this.sslSessionInitializer = sslSessionInitializer;
         this.sslSessionVerifier = sslSessionVerifier;
         this.requestParserFactory = new DefaultHttpRequestParserFactory(this.http1Config);
-        this.responseWriterFactory = DefaultHttpResponseWriterFactory.INSTANCE;
+        this.responseWriterFactory = new DefaultHttpResponseWriterFactory(this.http1Config);
     }
 
     protected ServerHttp1StreamDuplexer createServerHttp1StreamDuplexer(

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFramework.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFramework.java
@@ -33,7 +33,6 @@ import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.HEADERS;
 import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.METHOD;
 import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.NAME;
 import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.PATH;
-import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.PROTOCOL_VERSION;
 import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.QUERY;
 import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.REQUEST;
 import static org.apache.hc.core5.testing.framework.ClientPOJOAdapter.RESPONSE;
@@ -46,8 +45,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpVersion;
-import org.apache.hc.core5.http.ProtocolVersion;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -654,30 +651,6 @@ public class TestTestingFramework {
                 final String contentType = (String) request.get(CONTENT_TYPE);
                 Assertions.assertNotNull(contentType);
                 request.put(CONTENT_TYPE, request.get(CONTENT_TYPE) + "junk");
-                return super.execute(defaultURI, request, requestHandler, responseExpectations);
-            }
-        };
-
-        final TestingFramework framework = newFrameworkAndSetAdapter(adapter);
-
-        framework.addTest();
-
-        Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
-    }
-
-    @Test
-    public void changeProtocolVersion() throws Exception {
-        final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
-            @Override
-            public Map<String, Object> execute(
-                    final String defaultURI,
-                    final Map<String, Object> request,
-                    final TestingFrameworkRequestHandler requestHandler,
-                    final Map<String, Object> responseExpectations) throws TestingFrameworkException {
-                // change the request from what is expected.
-                final ProtocolVersion protocolVersion = (ProtocolVersion) request.get(PROTOCOL_VERSION);
-                Assertions.assertNotNull(protocolVersion);
-                request.put(PROTOCOL_VERSION, HttpVersion.HTTP_1_0);
                 return super.execute(defaultURI, request, requestHandler, responseExpectations);
             }
         };

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpStatus.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpStatus.java
@@ -29,21 +29,7 @@ package org.apache.hc.core5.http;
 
 /**
  * Constants enumerating the HTTP status codes.
- * All status codes defined in RFC 7231 (HTTP/1.1), RFC 2518 (WebDAV), RFC 7540 (HTTP/2),
- * RFC 6585 (Additional HTTP Status Codes), RFC 8297 (Early Hints), RFC 7538 (Permanent Redirect),
- * RFC 7725 (An HTTP Status Code to Report Legal Obstacles) and RFC 2295 (Transparent Content
- * Negotiation) are listed.
  *
- * @see <a href="https://tools.ietf.org/html/rfc7231">RFC 7231 (HTTP/1.1)</a>
- * @see <a href="https://tools.ietf.org/html/rfc2518">RFC 2518 (WebDAV)</a>
- * @see <a href="https://tools.ietf.org/html/rfc7540">RFC 7540 (HTTP/2)</a>
- * @see <a href="https://tools.ietf.org/html/rfc6585">RFC 6585 (Additional HTTP Status Codes)</a>
- * @see <a href="https://tools.ietf.org/html/rfc8297">RFC 8297 (Early Hints)</a>
- * @see <a href="https://tools.ietf.org/html/rfc7538">RFC 7538 (Permanent Redirect)</a>
- * @see <a href="https://tools.ietf.org/html/rfc7725">RFC 7725 (An HTTP Status Code to Report Legal Obstacles)</a>
- * @see <a href="https://tools.ietf.org/html/rfc2295">RFC 2295 (Transparent Content Negotiation)</a>
- * @see <a href="https://tools.ietf.org/html/rfc2817">RFC 2817 (Upgrading to TLS Within HTTP/1.1)</a>
- * @see <a href="https://tools.ietf.org/html/rfc8470">RFC 8470 (Using Early Data in HTTP)</a>
  * @since 4.0
  */
 public final class HttpStatus {
@@ -53,12 +39,12 @@ public final class HttpStatus {
     }
 
     // --- 1xx Informational ---
-    /** {@code 100 1xx Informational} (HTTP/1.1 - RFC 7231) */
+    /** {@code 100 1xx Informational} (HTTP Semantics) */
     public static final int SC_INFORMATIONAL = 100;
 
-    /** {@code 100 Continue} (HTTP/1.1 - RFC 7231) */
+    /** {@code 100 Continue} (HTTP Semantics) */
     public static final int SC_CONTINUE = 100;
-    /** {@code 101 Switching Protocols} (HTTP/1.1 - RFC 7231)*/
+    /** {@code 101 Switching Protocols} (HTTP Semantics)*/
     public static final int SC_SWITCHING_PROTOCOLS = 101;
     /** {@code 102 Processing} (WebDAV - RFC 2518) */
     public static final int SC_PROCESSING = 102;
@@ -66,22 +52,22 @@ public final class HttpStatus {
     public static final int SC_EARLY_HINTS = 103;
 
     // --- 2xx Success ---
-    /** {@code 2xx Success} (HTTP/1.0 - RFC 7231) */
+    /** {@code 2xx Success} (HTTP Semantics) */
     public static final int SC_SUCCESS = 200;
 
-    /** {@code 200 OK} (HTTP/1.0 - RFC 7231) */
+    /** {@code 200 OK} (HTTP Semantics) */
     public static final int SC_OK = 200;
-    /** {@code 201 Created} (HTTP/1.0 - RFC 7231) */
+    /** {@code 201 Created} (HTTP Semantics) */
     public static final int SC_CREATED = 201;
-    /** {@code 202 Accepted} (HTTP/1.0 - RFC 7231) */
+    /** {@code 202 Accepted} (HTTP Semantics) */
     public static final int SC_ACCEPTED = 202;
-    /** {@code 203 Non Authoritative Information} (HTTP/1.1 - RFC 7231) */
+    /** {@code 203 Non Authoritative Information} (HTTP Semantics) */
     public static final int SC_NON_AUTHORITATIVE_INFORMATION = 203;
-    /** {@code 204 No Content} (HTTP/1.0 - RFC 7231) */
+    /** {@code 204 No Content} (HTTP Semantics) */
     public static final int SC_NO_CONTENT = 204;
-    /** {@code 205 Reset Content} (HTTP/1.1 - RFC 7231) */
+    /** {@code 205 Reset Content} (HTTP Semantics) */
     public static final int SC_RESET_CONTENT = 205;
-    /** {@code 206 Partial Content} (HTTP/1.1 - RFC 7231) */
+    /** {@code 206 Partial Content} (HTTP Semantics) */
     public static final int SC_PARTIAL_CONTENT = 206;
     /**
      * {@code 207 Multi-Status} (WebDAV - RFC 2518)
@@ -99,69 +85,73 @@ public final class HttpStatus {
     public static final int SC_IM_USED = 226;
 
     // --- 3xx Redirection ---
-    /** {@code 3xx Redirection} (HTTP/1.1 - RFC 7231) */
+    /** {@code 3xx Redirection} (HTTP Semantics) */
     public static final int SC_REDIRECTION = 300;
 
-    /** {@code 300 Multiple Choices} (HTTP/1.1 - RFC 7231) */
+    /** {@code 300 Multiple Choices} (HTTP Semantics) */
     public static final int SC_MULTIPLE_CHOICES = 300;
-    /** {@code 301 Moved Permanently} (HTTP/1.0 - RFC 7231) */
+    /** {@code 301 Moved Permanently} (HTTP Semantics) */
     public static final int SC_MOVED_PERMANENTLY = 301;
-    /** {@code 302 Moved Temporarily} (Sometimes {@code Found}) (HTTP/1.0 - RFC 7231) */
+    /** {@code 302 Moved Temporarily} (Sometimes {@code Found}) (HTTP Semantics) */
     public static final int SC_MOVED_TEMPORARILY = 302;
-    /** {@code 303 See Other} (HTTP/1.1 - RFC 7231) */
+    /** {@code 303 See Other} (HTTP Semantics) */
     public static final int SC_SEE_OTHER = 303;
-    /** {@code 304 Not Modified} (HTTP/1.0 - RFC 7231) */
+    /** {@code 304 Not Modified} (HTTP Semantics) */
     public static final int SC_NOT_MODIFIED = 304;
-    /** {@code 305 Use Proxy} (HTTP/1.1 - RFC 7231) */
+    /** {@code 305 Use Proxy} (HTTP Semantics) */
     public static final int SC_USE_PROXY = 305;
-    /** {@code 307 Temporary Redirect} (HTTP/1.1 - RFC 7231) */
+    /** {@code 307 Temporary Redirect} (HTTP Semantics) */
     public static final int SC_TEMPORARY_REDIRECT = 307;
 
-    /** {@code 308 Permanent Redirect} (HTTP/1.1 - RFC 7538) */
+    /** {@code 308 Permanent Redirect} (HTTP Semantics) */
     public static final int SC_PERMANENT_REDIRECT = 308;
 
     // --- 4xx Client Error ---
-    /** {@code 4xx Client Error} (HTTP/1.1 - RFC 7231) */
+    /** {@code 4xx Client Error} (HTTP Semantics) */
     public static final int SC_CLIENT_ERROR = 400;
 
-    /** {@code 400 Bad Request} (HTTP/1.1 - RFC 7231) */
+    /** {@code 400 Bad Request} (HTTP Semantics) */
     public static final int SC_BAD_REQUEST = 400;
-    /** {@code 401 Unauthorized} (HTTP/1.0 - RFC 7231) */
+    /** {@code 401 Unauthorized} (HTTP Semantics) */
     public static final int SC_UNAUTHORIZED = 401;
-    /** {@code 402 Payment Required} (HTTP/1.1 - RFC 7231) */
+    /** {@code 402 Payment Required} (HTTP Semantics) */
     public static final int SC_PAYMENT_REQUIRED = 402;
-    /** {@code 403 Forbidden} (HTTP/1.0 - RFC 7231) */
+    /** {@code 403 Forbidden} (HTTP Semantics) */
     public static final int SC_FORBIDDEN = 403;
-    /** {@code 404 Not Found} (HTTP/1.0 - RFC 7231) */
+    /** {@code 404 Not Found} (HTTP Semantics) */
     public static final int SC_NOT_FOUND = 404;
-    /** {@code 405 Method Not Allowed} (HTTP/1.1 - RFC 7231) */
+    /** {@code 405 Method Not Allowed} (HTTP Semantics) */
     public static final int SC_METHOD_NOT_ALLOWED = 405;
-    /** {@code 406 Not Acceptable} (HTTP/1.1 - RFC 7231) */
+    /** {@code 406 Not Acceptable} (HTTP Semantics) */
     public static final int SC_NOT_ACCEPTABLE = 406;
-    /** {@code 407 Proxy Authentication Required} (HTTP/1.1 - RFC 7231)*/
+    /** {@code 407 Proxy Authentication Required} (HTTP Semantics)*/
     public static final int SC_PROXY_AUTHENTICATION_REQUIRED = 407;
-    /** {@code 408 Request Timeout} (HTTP/1.1 - RFC 7231) */
+    /** {@code 408 Request Timeout} (HTTP Semantics) */
     public static final int SC_REQUEST_TIMEOUT = 408;
-    /** {@code 409 Conflict} (HTTP/1.1 - RFC 7231) */
+    /** {@code 409 Conflict} (HTTP Semantics) */
     public static final int SC_CONFLICT = 409;
-    /** {@code 410 Gone} (HTTP/1.1 - RFC 7231) */
+    /** {@code 410 Gone} (HTTP Semantics) */
     public static final int SC_GONE = 410;
-    /** {@code 411 Length Required} (HTTP/1.1 - RFC 7231) */
+    /** {@code 411 Length Required} (HTTP Semantics) */
     public static final int SC_LENGTH_REQUIRED = 411;
-    /** {@code 412 Precondition Failed} (HTTP/1.1 - RFC 7231) */
+    /** {@code 412 Precondition Failed} (HTTP Semantics) */
     public static final int SC_PRECONDITION_FAILED = 412;
-    /** {@code 413 Request Entity Too Large} (HTTP/1.1 - RFC 7231) */
+    /** {@code 413 Request Entity Too Large} (HTTP Semantics) */
     public static final int SC_REQUEST_TOO_LONG = 413;
-    /** {@code 414 Request-URI Too Long} (HTTP/1.1 - RFC 7231) */
+    /** {@code 414 Request-URI Too Long} (HTTP Semantics) */
     public static final int SC_REQUEST_URI_TOO_LONG = 414;
-    /** {@code 415 Unsupported Media Type} (HTTP/1.1 - RFC 7231) */
+    /** {@code 415 Unsupported Media Type} (HTTP Semantics) */
     public static final int SC_UNSUPPORTED_MEDIA_TYPE = 415;
-    /** {@code 416 Requested Range Not Satisfiable} (HTTP/1.1 - RFC 7231) */
+    /** {@code 416 Requested Range Not Satisfiable} (HTTP Semantics) */
     public static final int SC_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
-    /** {@code 417 Expectation Failed} (HTTP/1.1 - RFC 7231) */
+    /** {@code 417 Expectation Failed} (HTTP Semantics) */
     public static final int SC_EXPECTATION_FAILED = 417;
-    /** {@code 421 Misdirected Request} (HTTP/2 - RFC 7540) */
+    /** {@code 421 Misdirected Request} (HTTP Semantics) */
     public static final int SC_MISDIRECTED_REQUEST = 421;
+    /** {@code 422 Unprocessable Content} (HTTP Semantics) */
+    public static final int SC_UNPROCESSABLE_CONTENT = 422;
+    /** {@code 426 Upgrade Required} (HTTP Semantics) */
+    public static final int SC_UPGRADE_REQUIRED = 426;
 
     /**
      * Static constant for a 419 error.
@@ -177,16 +167,17 @@ public final class HttpStatus {
      * (WebDAV - draft-ietf-webdav-protocol-05?)
      */
     public static final int SC_METHOD_FAILURE = 420;
-    /** {@code 422 Unprocessable Entity} (WebDAV - RFC 2518) */
-    public static final int SC_UNPROCESSABLE_ENTITY = 422;
+    /**
+     * @deprecated Use {@link #SC_UNPROCESSABLE_CONTENT}
+     */
+    @Deprecated
+    public static final int SC_UNPROCESSABLE_ENTITY = SC_UNPROCESSABLE_CONTENT;
     /** {@code 423 Locked} (WebDAV - RFC 2518) */
     public static final int SC_LOCKED = 423;
     /** {@code 424 Failed Dependency} (WebDAV - RFC 2518) */
     public static final int SC_FAILED_DEPENDENCY = 424;
     /** {@code 425 Too Early} (Using Early Data in HTTP - RFC 8470) */
     public static final int SC_TOO_EARLY = 425;
-    /** {@code 426 Upgrade Dependency} (HTTP/1.1 - RFC 2817) */
-    public static final int SC_UPGRADE_REQUIRED = 426;
     /** {@code 428 Precondition Required} (Additional HTTP Status Codes - RFC 6585) */
     public static final int SC_PRECONDITION_REQUIRED = 428;
     /** {@code 429 Too Many Requests} (Additional HTTP Status Codes - RFC 6585) */
@@ -197,20 +188,20 @@ public final class HttpStatus {
     public static final int SC_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
 
     // --- 5xx Server Error ---
-    /** {@code 500 Server Error} (HTTP/1.0 - RFC 7231) */
+    /** {@code 500 Server Error} (HTTP Semantics) */
     public static final int SC_SERVER_ERROR = 500;
 
-    /** {@code 500 Internal Server Error} (HTTP/1.0 - RFC 7231) */
+    /** {@code 500 Internal Server Error} (HTTP Semantics) */
     public static final int SC_INTERNAL_SERVER_ERROR = 500;
-    /** {@code 501 Not Implemented} (HTTP/1.0 - RFC 7231) */
+    /** {@code 501 Not Implemented} (HTTP Semantics) */
     public static final int SC_NOT_IMPLEMENTED = 501;
-    /** {@code 502 Bad Gateway} (HTTP/1.0 - RFC 7231) */
+    /** {@code 502 Bad Gateway} (HTTP Semantics) */
     public static final int SC_BAD_GATEWAY = 502;
-    /** {@code 503 Service Unavailable} (HTTP/1.0 - RFC 7231) */
+    /** {@code 503 Service Unavailable} (HTTP Semantics) */
     public static final int SC_SERVICE_UNAVAILABLE = 503;
-    /** {@code 504 Gateway Timeout} (HTTP/1.1 - RFC 7231) */
+    /** {@code 504 Gateway Timeout} (HTTP Semantics) */
     public static final int SC_GATEWAY_TIMEOUT = 504;
-    /** {@code 505 HTTP Version Not Supported} (HTTP/1.1 - RFC 7231) */
+    /** {@code 505 HTTP Version Not Supported} (HTTP Semantics) */
     public static final int SC_HTTP_VERSION_NOT_SUPPORTED = 505;
     /** {@code 506 Variant Also Negotiates} ( Transparent Content Negotiation - RFC 2295) */
     public static final int SC_VARIANT_ALSO_NEGOTIATES = 506;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/EnglishReasonPhraseCatalog.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/EnglishReasonPhraseCatalog.java
@@ -115,7 +115,7 @@ public class EnglishReasonPhraseCatalog implements ReasonPhraseCatalog {
 
     /** Set up status code to "reason phrase" map. */
     static {
-        // HTTP 1.1 Server status codes -- see RFC 7231
+        // HTTP 1.1 Server status codes -- see RFC 9110
         setReason(HttpStatus.SC_OK,
                   "OK");
         setReason(HttpStatus.SC_CREATED,
@@ -210,8 +210,8 @@ public class EnglishReasonPhraseCatalog implements ReasonPhraseCatalog {
                 "Already Reported");
         setReason(HttpStatus.SC_IM_USED,
                 "IM Used");
-        setReason(HttpStatus.SC_UNPROCESSABLE_ENTITY,
-                  "Unprocessable Entity");
+        setReason(HttpStatus.SC_UNPROCESSABLE_CONTENT,
+                  "Unprocessable Content");
         setReason(HttpStatus.SC_INSUFFICIENT_SPACE_ON_RESOURCE,
                   "Insufficient Space On Resource");
         setReason(HttpStatus.SC_METHOD_FAILURE,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/HttpProcessors.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/HttpProcessors.java
@@ -104,8 +104,8 @@ public final class HttpProcessors {
     public static HttpProcessorBuilder customClient(final String agentInfo) {
         return HttpProcessorBuilder.create()
                 .addAll(
-                        RequestContent.INSTANCE,
                         RequestTargetHost.INSTANCE,
+                        RequestContent.INSTANCE,
                         RequestConnControl.INSTANCE,
                         new RequestUserAgent(!TextUtils.isBlank(agentInfo) ? agentInfo :
                                 VersionInfo.getSoftwareInfo(SOFTWARE, "org.apache.hc.core5", HttpProcessors.class)),

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
@@ -374,11 +374,11 @@ public class AsyncServerBootstrap {
         final ServerHttp1StreamDuplexerFactory streamHandlerFactory = new ServerHttp1StreamDuplexerFactory(
                 httpProcessor != null ? httpProcessor : HttpProcessors.server(),
                 handlerFactory,
-                http1Config != null ? http1Config : Http1Config.DEFAULT,
+                http1Config,
                 charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT,
                 connStrategy != null ? connStrategy : DefaultConnectionReuseStrategy.INSTANCE,
-                DefaultHttpRequestParserFactory.INSTANCE,
-                DefaultHttpResponseWriterFactory.INSTANCE,
+                new DefaultHttpRequestParserFactory(http1Config),
+                new DefaultHttpResponseWriterFactory(http1Config),
                 DefaultContentLengthStrategy.INSTANCE,
                 DefaultContentLengthStrategy.INSTANCE,
                 streamListener);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/RequesterBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/RequesterBootstrap.java
@@ -65,6 +65,7 @@ import org.apache.hc.core5.util.Timeout;
 public class RequesterBootstrap {
 
     private HttpProcessor httpProcessor;
+    private Http1Config http1Config;
     private ConnectionReuseStrategy connReuseStrategy;
     private SocketConfig socketConfig;
     private HttpConnectionFactory<? extends HttpClientConnection> connectFactory;
@@ -91,6 +92,14 @@ public class RequesterBootstrap {
      */
     public final RequesterBootstrap setHttpProcessor(final HttpProcessor httpProcessor) {
         this.httpProcessor = httpProcessor;
+        return this;
+    }
+
+    /**
+     * Sets HTTP/1 protocol configuration.
+     */
+    public final RequesterBootstrap setHttp1Config(final Http1Config http1Config) {
+        this.http1Config = http1Config;
         return this;
     }
 
@@ -179,7 +188,7 @@ public class RequesterBootstrap {
 
     public HttpRequester create() {
         final HttpRequestExecutor requestExecutor = new HttpRequestExecutor(
-                HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE,
+                http1Config,
                 connReuseStrategy != null ? connReuseStrategy : DefaultConnectionReuseStrategy.INSTANCE,
                 streamListener);
         final ManagedConnPool<HttpHost, HttpClientConnection> connPool;
@@ -209,7 +218,7 @@ public class RequesterBootstrap {
                 connPool,
                 socketConfig != null ? socketConfig : SocketConfig.DEFAULT,
                 connectFactory != null ? connectFactory : new DefaultBHttpClientConnectionFactory(
-                        Http1Config.DEFAULT, CharCodingConfig.DEFAULT),
+                        http1Config, CharCodingConfig.DEFAULT),
                 sslSocketFactory,
                 sslSetupHandler != null ? sslSetupHandler : new DefaultTlsSetupHandler(),
                 sslSessionVerifier,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
@@ -140,7 +140,7 @@ public class ServerBootstrap {
     }
 
     /**
-     * Sets connection configuration.
+     * Sets HTTP/1 protocol configuration.
      */
     public final ServerBootstrap setHttp1Config(final Http1Config http1Config) {
         this.http1Config = http1Config;
@@ -380,6 +380,7 @@ public class ServerBootstrap {
         final HttpService httpService = new HttpService(
                 this.httpProcessor != null ? this.httpProcessor : HttpProcessors.server(),
                 requestHandler,
+                this.http1Config,
                 this.connStrategy != null ? this.connStrategy : DefaultConnectionReuseStrategy.INSTANCE,
                 this.streamListener);
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/AbstractMessageParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/AbstractMessageParser.java
@@ -65,22 +65,23 @@ public abstract class AbstractMessageParser<T extends HttpMessage> implements Ht
     private T message;
 
     /**
-     * Creates new instance of AbstractMessageParser.
-     *
-     * @param lineParser the line parser. If {@code null}
-     *   {@link org.apache.hc.core5.http.message.LazyLineParser#INSTANCE} will be used.
-     * @param http1Config the message http1Config. If {@code null}
-     *   {@link Http1Config#DEFAULT} will be used.
-     *
-     * @since 4.3
+     * @since 5.3
      */
-    public AbstractMessageParser(final LineParser lineParser, final Http1Config http1Config) {
+    public AbstractMessageParser(final Http1Config http1Config, final LineParser lineParser) {
         super();
-        this.lineParser = lineParser != null ? lineParser : LazyLineParser.INSTANCE;
         this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
+        this.lineParser = lineParser != null ? lineParser : LazyLineParser.INSTANCE;
         this.headerLines = new ArrayList<>();
         this.headLine = new CharArrayBuffer(128);
         this.state = HEAD_LINE;
+    }
+
+    /**
+     * @deprecated Use {@link #AbstractMessageParser(Http1Config, LineParser)}
+     */
+    @Deprecated
+    public AbstractMessageParser(final LineParser lineParser, final Http1Config http1Config) {
+        this(http1Config, lineParser);
     }
 
     LineParser getLineParser() {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnection.java
@@ -108,7 +108,7 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
         this.requestWriter = (requestWriterFactory != null ? requestWriterFactory :
             DefaultHttpRequestWriterFactory.INSTANCE).create();
         this.responseParser = (responseParserFactory != null ? responseParserFactory :
-            DefaultHttpResponseParserFactory.INSTANCE).create(http1Config);
+            DefaultHttpResponseParserFactory.INSTANCE).create();
         this.incomingContentStrategy = incomingContentStrategy != null ? incomingContentStrategy :
             DefaultContentLengthStrategy.INSTANCE;
         this.outgoingContentStrategy = outgoingContentStrategy != null ? outgoingContentStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnectionFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpClientConnectionFactory.java
@@ -73,8 +73,10 @@ public class DefaultBHttpClientConnectionFactory
         this.incomingContentStrategy = incomingContentStrategy;
         this.outgoingContentStrategy = outgoingContentStrategy;
         this.responseOutOfOrderStrategy = responseOutOfOrderStrategy;
-        this.requestWriterFactory = requestWriterFactory;
-        this.responseParserFactory = responseParserFactory;
+        this.requestWriterFactory = requestWriterFactory != null ? requestWriterFactory :
+                new DefaultHttpRequestWriterFactory(this.http1Config) ;
+        this.responseParserFactory = responseParserFactory != null ? responseParserFactory :
+                new DefaultHttpResponseParserFactory(this.http1Config);
     }
 
     public DefaultBHttpClientConnectionFactory(

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnection.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnection.java
@@ -95,7 +95,7 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase implements
         super(http1Config, charDecoder, charEncoder);
         this.scheme = scheme;
         this.requestParser = (requestParserFactory != null ? requestParserFactory :
-            DefaultHttpRequestParserFactory.INSTANCE).create(http1Config);
+            DefaultHttpRequestParserFactory.INSTANCE).create();
         this.responseWriter = (responseWriterFactory != null ? responseWriterFactory :
             DefaultHttpResponseWriterFactory.INSTANCE).create();
         this.incomingContentStrategy = incomingContentStrategy != null ? incomingContentStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnectionFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnectionFactory.java
@@ -72,8 +72,10 @@ public class DefaultBHttpServerConnectionFactory implements HttpConnectionFactor
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.incomingContentStrategy = incomingContentStrategy;
         this.outgoingContentStrategy = outgoingContentStrategy;
-        this.requestParserFactory = requestParserFactory;
-        this.responseWriterFactory = responseWriterFactory;
+        this.requestParserFactory = requestParserFactory != null ? requestParserFactory :
+            new DefaultHttpRequestParserFactory(this.http1Config);
+        this.responseWriterFactory = responseWriterFactory != null ? responseWriterFactory :
+            new DefaultHttpResponseWriterFactory(this.http1Config);
     }
 
     public DefaultBHttpServerConnectionFactory(

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestParser.java
@@ -52,37 +52,39 @@ public class DefaultHttpRequestParser extends AbstractMessageParser<ClassicHttpR
     private final HttpRequestFactory<ClassicHttpRequest> requestFactory;
 
     /**
-     * Creates new instance of DefaultHttpRequestParser.
-     *
-     * @param lineParser the line parser. If {@code null}
-     *   {@link org.apache.hc.core5.http.message.LazyLineParser#INSTANCE} will be used.
-     * @param requestFactory the response factory. If {@code null}
-     *   {@link DefaultClassicHttpRequestFactory#INSTANCE} will be used.
-     * @param http1Config the message http1Config. If {@code null}
-     *   {@link Http1Config#DEFAULT} will be used.
-     *
-     * @since 4.3
+     * @since 5.3
      */
+    public DefaultHttpRequestParser(
+            final Http1Config http1Config,
+            final LineParser lineParser,
+            final HttpRequestFactory<ClassicHttpRequest> requestFactory) {
+        super(http1Config, lineParser);
+        this.requestFactory = requestFactory != null ? requestFactory : DefaultClassicHttpRequestFactory.INSTANCE;
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultHttpRequestParser(Http1Config, LineParser, HttpRequestFactory)}
+     */
+    @Deprecated
     public DefaultHttpRequestParser(
             final LineParser lineParser,
             final HttpRequestFactory<ClassicHttpRequest> requestFactory,
             final Http1Config http1Config) {
-        super(lineParser, http1Config);
-        this.requestFactory = requestFactory != null ? requestFactory : DefaultClassicHttpRequestFactory.INSTANCE;
+        this(http1Config, lineParser, requestFactory);
     }
 
     /**
      * @since 4.3
      */
     public DefaultHttpRequestParser(final Http1Config http1Config) {
-        this(null, null, http1Config);
+        this(http1Config, null, null);
     }
 
     /**
      * @since 4.3
      */
     public DefaultHttpRequestParser() {
-        this(Http1Config.DEFAULT);
+        this(Http1Config.DEFAULT, null, null);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestParserFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestParserFactory.java
@@ -47,23 +47,51 @@ public class DefaultHttpRequestParserFactory implements HttpMessageParserFactory
 
     public static final DefaultHttpRequestParserFactory INSTANCE = new DefaultHttpRequestParserFactory();
 
+    private final Http1Config http1Config;
     private final LineParser lineParser;
     private final HttpRequestFactory<ClassicHttpRequest> requestFactory;
 
-    public DefaultHttpRequestParserFactory(final LineParser lineParser,
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpRequestParserFactory(
+            final Http1Config http1Config,
+            final LineParser lineParser,
             final HttpRequestFactory<ClassicHttpRequest> requestFactory) {
         super();
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.lineParser = lineParser != null ? lineParser : LazyLineParser.INSTANCE;
         this.requestFactory = requestFactory != null ? requestFactory : DefaultClassicHttpRequestFactory.INSTANCE;
+    }
+
+    public DefaultHttpRequestParserFactory(final LineParser lineParser,
+            final HttpRequestFactory<ClassicHttpRequest> requestFactory) {
+        this(null, lineParser, requestFactory);
+    }
+
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpRequestParserFactory(final Http1Config http1Config) {
+        this(http1Config, null, null);
     }
 
     public DefaultHttpRequestParserFactory() {
         this(null, null);
     }
 
+    /**
+     * @deprecated Use {@link #create()}
+     */
+    @Deprecated
     @Override
     public HttpMessageParser<ClassicHttpRequest> create(final Http1Config http1Config) {
-        return new DefaultHttpRequestParser(this.lineParser, this.requestFactory, http1Config);
+        return new DefaultHttpRequestParser(http1Config, this.lineParser, this.requestFactory);
+    }
+
+    @Override
+    public HttpMessageParser<ClassicHttpRequest> create() {
+        return new DefaultHttpRequestParser(this.http1Config, this.lineParser, this.requestFactory);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestWriter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestWriter.java
@@ -30,8 +30,9 @@ package org.apache.hc.core5.http.impl.io;
 import java.io.IOException;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpVersion;
-import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.message.LineFormatter;
 import org.apache.hc.core5.http.message.RequestLine;
 import org.apache.hc.core5.util.CharArrayBuffer;
@@ -44,29 +45,41 @@ import org.apache.hc.core5.util.CharArrayBuffer;
  */
 public class DefaultHttpRequestWriter extends AbstractMessageWriter<ClassicHttpRequest> {
 
+    private final Http1Config http1Config;
+
     /**
-     * Creates an instance of DefaultHttpRequestWriter.
-     *
-     * @param formatter the line formatter If {@code null}
-     *   {@link org.apache.hc.core5.http.message.BasicLineFormatter#INSTANCE}
-     *   will be used.
+     * @since 5.3
      */
-    public DefaultHttpRequestWriter(final LineFormatter formatter) {
+    public DefaultHttpRequestWriter(final Http1Config http1Config, final LineFormatter formatter) {
         super(formatter);
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
+    }
+
+    public DefaultHttpRequestWriter(final LineFormatter formatter) {
+        this(null, formatter);
     }
 
     public DefaultHttpRequestWriter() {
-        this(null);
+        this(null, null);
+    }
+
+    /**
+     * Determines the HTTP protocol version to be communicated to the opposite
+     * endpoint in the message header.
+     *
+     * @since 5.3
+     */
+    protected HttpVersion protocolVersion(final HttpRequest message) {
+        return http1Config.getVersion();
     }
 
     @Override
     protected void writeHeadLine(
             final ClassicHttpRequest message, final CharArrayBuffer lineBuf) throws IOException {
-        final ProtocolVersion transportVersion = message.getVersion();
         getLineFormatter().formatRequestLine(lineBuf, new RequestLine(
                 message.getMethod(),
                 message.getRequestUri(),
-                transportVersion != null ? transportVersion : HttpVersion.HTTP_1_1));
+                protocolVersion(message)));
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestWriterFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpRequestWriterFactory.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.io;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.io.HttpMessageWriter;
 import org.apache.hc.core5.http.io.HttpMessageWriterFactory;
 import org.apache.hc.core5.http.message.BasicLineFormatter;
@@ -45,20 +46,36 @@ public class DefaultHttpRequestWriterFactory implements HttpMessageWriterFactory
 
     public static final DefaultHttpRequestWriterFactory INSTANCE = new DefaultHttpRequestWriterFactory();
 
+    private final Http1Config http1Config;
     private final LineFormatter lineFormatter;
 
-    public DefaultHttpRequestWriterFactory(final LineFormatter lineFormatter) {
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpRequestWriterFactory(final Http1Config http1Config, final LineFormatter lineFormatter) {
         super();
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.lineFormatter = lineFormatter != null ? lineFormatter : BasicLineFormatter.INSTANCE;
     }
 
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpRequestWriterFactory(final Http1Config http1Config) {
+        this(http1Config, null);
+    }
+
+    public DefaultHttpRequestWriterFactory(final LineFormatter lineFormatter) {
+        this(null, lineFormatter);
+    }
+
     public DefaultHttpRequestWriterFactory() {
-        this(null);
+        this(null, null);
     }
 
     @Override
     public HttpMessageWriter<ClassicHttpRequest> create() {
-        return new DefaultHttpRequestWriter(this.lineFormatter);
+        return new DefaultHttpRequestWriter(http1Config, lineFormatter);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpResponseParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpResponseParser.java
@@ -48,30 +48,32 @@ public class DefaultHttpResponseParser extends AbstractMessageParser<ClassicHttp
     private final HttpResponseFactory<ClassicHttpResponse> responseFactory;
 
     /**
-     * Creates new instance of DefaultHttpResponseParser.
-     *
-     * @param lineParser the line parser. If {@code null}
-     *   {@link org.apache.hc.core5.http.message.LazyLineParser#INSTANCE} will be used
-     * @param responseFactory the response factory. If {@code null}
-     *   {@link DefaultClassicHttpResponseFactory#INSTANCE} will be used.
-     * @param http1Config the message http1Config. If {@code null}
-     *   {@link Http1Config#DEFAULT} will be used.
-     *
-     * @since 4.3
+     * @since 5.3
      */
+    public DefaultHttpResponseParser(
+            final Http1Config http1Config,
+            final LineParser lineParser,
+            final HttpResponseFactory<ClassicHttpResponse> responseFactory) {
+        super(http1Config, lineParser);
+        this.responseFactory = responseFactory != null ? responseFactory : DefaultClassicHttpResponseFactory.INSTANCE;
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultHttpResponseParser(Http1Config, LineParser, HttpResponseFactory)}
+     */
+    @Deprecated
     public DefaultHttpResponseParser(
             final LineParser lineParser,
             final HttpResponseFactory<ClassicHttpResponse> responseFactory,
             final Http1Config http1Config) {
-        super(lineParser, http1Config);
-        this.responseFactory = responseFactory != null ? responseFactory : DefaultClassicHttpResponseFactory.INSTANCE;
+        this(http1Config, lineParser, responseFactory);
     }
 
     /**
      * @since 4.3
      */
     public DefaultHttpResponseParser(final Http1Config http1Config) {
-        this(null, null, http1Config);
+        this(http1Config, null, null);
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpResponseParserFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpResponseParserFactory.java
@@ -47,23 +47,51 @@ public class DefaultHttpResponseParserFactory implements HttpMessageParserFactor
 
     public static final DefaultHttpResponseParserFactory INSTANCE = new DefaultHttpResponseParserFactory();
 
+    private final Http1Config http1Config;
     private final LineParser lineParser;
     private final HttpResponseFactory<ClassicHttpResponse> responseFactory;
 
-    public DefaultHttpResponseParserFactory(final LineParser lineParser,
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpResponseParserFactory(
+            final Http1Config http1Config,
+            final LineParser lineParser,
             final HttpResponseFactory<ClassicHttpResponse> responseFactory) {
         super();
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.lineParser = lineParser != null ? lineParser : LazyLaxLineParser.INSTANCE;
         this.responseFactory = responseFactory != null ? responseFactory : DefaultClassicHttpResponseFactory.INSTANCE;
+    }
+
+    public DefaultHttpResponseParserFactory(final LineParser lineParser,
+            final HttpResponseFactory<ClassicHttpResponse> responseFactory) {
+        this(null, lineParser, responseFactory);
+    }
+
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpResponseParserFactory(final Http1Config http1Config) {
+        this(http1Config, null, null);
     }
 
     public DefaultHttpResponseParserFactory() {
         this(null, null);
     }
 
+    /**
+     * @deprecated Use {@link #create()}
+     */
+    @Deprecated
     @Override
     public HttpMessageParser<ClassicHttpResponse> create(final Http1Config http1Config) {
-        return new DefaultHttpResponseParser(this.lineParser, this.responseFactory, http1Config);
+        return new DefaultHttpResponseParser(http1Config, this.lineParser, this.responseFactory);
+    }
+
+    @Override
+    public HttpMessageParser<ClassicHttpResponse> create() {
+        return new DefaultHttpResponseParser(this.http1Config, this.lineParser, this.responseFactory);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpResponseWriterFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultHttpResponseWriterFactory.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.io;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.io.HttpMessageWriter;
 import org.apache.hc.core5.http.io.HttpMessageWriterFactory;
 import org.apache.hc.core5.http.message.BasicLineFormatter;
@@ -45,20 +46,36 @@ public class DefaultHttpResponseWriterFactory implements HttpMessageWriterFactor
 
     public static final DefaultHttpResponseWriterFactory INSTANCE = new DefaultHttpResponseWriterFactory();
 
+    private final Http1Config http1Config;
     private final LineFormatter lineFormatter;
 
-    public DefaultHttpResponseWriterFactory(final LineFormatter lineFormatter) {
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpResponseWriterFactory(final Http1Config http1Config, final LineFormatter lineFormatter) {
         super();
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.lineFormatter = lineFormatter != null ? lineFormatter : BasicLineFormatter.INSTANCE;
     }
 
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpResponseWriterFactory(final Http1Config http1Config) {
+        this(http1Config, null);
+    }
+
+    public DefaultHttpResponseWriterFactory(final LineFormatter lineFormatter) {
+        this(null, lineFormatter);
+    }
+
     public DefaultHttpResponseWriterFactory() {
-        this(null);
+        this(null, null);
     }
 
     @Override
     public HttpMessageWriter<ClassicHttpResponse> create() {
-        return new DefaultHttpResponseWriter(this.lineFormatter);
+        return new DefaultHttpResponseWriter(http1Config, lineFormatter);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexerFactory.java
@@ -80,9 +80,9 @@ public final class ClientHttp1StreamDuplexerFactory {
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :
                 DefaultConnectionReuseStrategy.INSTANCE;
         this.responseParserFactory = responseParserFactory != null ? responseParserFactory :
-                new DefaultHttpResponseParserFactory(http1Config);
+                new DefaultHttpResponseParserFactory(this.http1Config);
         this.requestWriterFactory = requestWriterFactory != null ? requestWriterFactory :
-                DefaultHttpRequestWriterFactory.INSTANCE;
+                new DefaultHttpRequestWriterFactory(this.http1Config);
         this.incomingContentStrategy = incomingContentStrategy != null ? incomingContentStrategy :
                 DefaultContentLengthStrategy.INSTANCE;
         this.outgoingContentStrategy = outgoingContentStrategy != null ? outgoingContentStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestParser.java
@@ -51,36 +51,47 @@ public class DefaultHttpRequestParser<T extends HttpRequest> extends AbstractMes
     private final HttpRequestFactory<T> requestFactory;
 
     /**
-     * Creates an instance of DefaultHttpRequestParser.
-     *
-     * @param requestFactory the request factory.
-     * @param parser the line parser. If {@code null}
-     *   {@link org.apache.hc.core5.http.message.LazyLineParser#INSTANCE} will be used.
-     * @param http1Config Message http1Config. If {@code null}
-     *   {@link Http1Config#DEFAULT} will be used.
-     *
-     * @since 4.3
+     * @since 5.3
      */
     public DefaultHttpRequestParser(
-            final HttpRequestFactory<T> requestFactory,
+            final Http1Config http1Config,
             final LineParser parser,
-            final Http1Config http1Config) {
-        super(parser, http1Config);
+            final HttpRequestFactory<T> requestFactory) {
+        super(http1Config, parser);
         this.requestFactory = Args.notNull(requestFactory, "Request factory");
     }
 
     /**
-    * @since 4.3
-    */
+     * @since 5.3
+     */
+    public DefaultHttpRequestParser(final Http1Config http1Config, final HttpRequestFactory<T> requestFactory) {
+        this(http1Config, null, requestFactory);
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultHttpRequestParser(Http1Config, HttpRequestFactory)}  }
+     */
+    @Deprecated
     public DefaultHttpRequestParser(final HttpRequestFactory<T> requestFactory, final Http1Config http1Config) {
         this(requestFactory, null, http1Config);
     }
 
     /**
-    * @since 4.3
-    */
+     * @deprecated Use {@link #DefaultHttpRequestParser(Http1Config, LineParser, HttpRequestFactory)}  }
+     */
+    @Deprecated
+    public DefaultHttpRequestParser(
+            final HttpRequestFactory<T> requestFactory,
+            final LineParser parser,
+            final Http1Config http1Config) {
+        this(http1Config, parser, requestFactory);
+    }
+
+    /**
+     * @since 4.3
+     */
     public DefaultHttpRequestParser(final HttpRequestFactory<T> requestFactory) {
-        this(requestFactory, null);
+        this(null, null, requestFactory);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestParserFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestParserFactory.java
@@ -71,7 +71,7 @@ public class DefaultHttpRequestParserFactory implements NHttpMessageParserFactor
 
     @Override
     public NHttpMessageParser<HttpRequest> create() {
-        return new DefaultHttpRequestParser<>(requestFactory, lineParser, http1Config);
+        return new DefaultHttpRequestParser<>(http1Config, lineParser, requestFactory);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestWriterFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpRequestWriterFactory.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.nio;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.message.BasicLineFormatter;
 import org.apache.hc.core5.http.message.LineFormatter;
 import org.apache.hc.core5.http.nio.NHttpMessageWriter;
@@ -45,20 +46,36 @@ public class DefaultHttpRequestWriterFactory implements NHttpMessageWriterFactor
 
     public static final DefaultHttpRequestWriterFactory INSTANCE = new DefaultHttpRequestWriterFactory();
 
+    private final Http1Config http1Config;
     private final LineFormatter lineFormatter;
 
-    public DefaultHttpRequestWriterFactory(final LineFormatter lineFormatter) {
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpRequestWriterFactory(final Http1Config http1Config, final LineFormatter lineFormatter) {
         super();
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.lineFormatter = lineFormatter != null ? lineFormatter : BasicLineFormatter.INSTANCE;
     }
 
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpRequestWriterFactory(final Http1Config http1Config) {
+        this(http1Config, null);
+    }
+
+    public DefaultHttpRequestWriterFactory(final LineFormatter lineFormatter) {
+        this(null, lineFormatter);
+    }
+
     public DefaultHttpRequestWriterFactory() {
-        this(null);
+        this(null, null);
     }
 
     @Override
     public NHttpMessageWriter<HttpRequest> create() {
-        return new DefaultHttpRequestWriter<>(this.lineFormatter);
+        return new DefaultHttpRequestWriter<>(http1Config, lineFormatter);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseParser.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseParser.java
@@ -46,27 +46,40 @@ public class DefaultHttpResponseParser<T extends HttpResponse> extends AbstractM
     private final HttpResponseFactory<T> responseFactory;
 
     /**
-     * Creates an instance of DefaultHttpResponseParser.
-     *
-     * @param responseFactory the response factory.
-     * @param parser the line parser. If {@code null}
-     *   {@link org.apache.hc.core5.http.message.LazyLineParser#INSTANCE} will be used.
-     * @param http1Config Message http1Config. If {@code null}
-     *   {@link Http1Config#DEFAULT} will be used.
-     *
-     * @since 4.3
+     * @since 5.3
      */
     public DefaultHttpResponseParser(
-            final HttpResponseFactory<T> responseFactory,
+            final Http1Config http1Config,
             final LineParser parser,
-            final Http1Config http1Config) {
-        super(parser, http1Config);
+            final HttpResponseFactory<T> responseFactory) {
+        super(http1Config, parser);
         this.responseFactory = Args.notNull(responseFactory, "Response factory");
     }
 
     /**
-     * @since 4.3
+     * @since 5.3
      */
+    public DefaultHttpResponseParser(
+            final Http1Config http1Config,
+            final HttpResponseFactory<T> responseFactory) {
+        this(http1Config, null, responseFactory);
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultHttpResponseParser(Http1Config, LineParser, HttpResponseFactory)}
+     */
+    @Deprecated
+    public DefaultHttpResponseParser(
+            final HttpResponseFactory<T> responseFactory,
+            final LineParser parser,
+            final Http1Config http1Config) {
+        this(http1Config, parser, responseFactory);
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultHttpResponseParser(Http1Config, HttpResponseFactory)}
+     */
+    @Deprecated
     public DefaultHttpResponseParser(final HttpResponseFactory<T> responseFactory, final Http1Config http1Config) {
         this(responseFactory, null, http1Config);
     }
@@ -75,7 +88,7 @@ public class DefaultHttpResponseParser<T extends HttpResponse> extends AbstractM
      * @since 4.3
      */
     public DefaultHttpResponseParser(final HttpResponseFactory<T> responseFactory) {
-        this(responseFactory, null);
+        this(null, null, responseFactory);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseParserFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseParserFactory.java
@@ -71,7 +71,7 @@ public class DefaultHttpResponseParserFactory implements NHttpMessageParserFacto
 
     @Override
     public NHttpMessageParser<HttpResponse> create() {
-        return new DefaultHttpResponseParser<>(responseFactory, lineParser, http1Config);
+        return new DefaultHttpResponseParser<>(http1Config, lineParser, responseFactory);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseWriterFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/DefaultHttpResponseWriterFactory.java
@@ -30,6 +30,7 @@ package org.apache.hc.core5.http.impl.nio;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.message.BasicLineFormatter;
 import org.apache.hc.core5.http.message.LineFormatter;
 import org.apache.hc.core5.http.nio.NHttpMessageWriter;
@@ -45,20 +46,36 @@ public class DefaultHttpResponseWriterFactory implements NHttpMessageWriterFacto
 
     public static final DefaultHttpResponseWriterFactory INSTANCE = new DefaultHttpResponseWriterFactory();
 
+    private final Http1Config http1Config;
     private final LineFormatter lineFormatter;
 
-    public DefaultHttpResponseWriterFactory(final LineFormatter lineFormatter) {
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpResponseWriterFactory(final Http1Config http1Config, final LineFormatter lineFormatter) {
         super();
+        this.http1Config = http1Config != null ? http1Config : Http1Config.DEFAULT;
         this.lineFormatter = lineFormatter != null ? lineFormatter : BasicLineFormatter.INSTANCE;
     }
 
+    /**
+     * @since 5.3
+     */
+    public DefaultHttpResponseWriterFactory(final Http1Config http1Config) {
+        this(http1Config, null);
+    }
+
+    public DefaultHttpResponseWriterFactory(final LineFormatter lineFormatter) {
+        this(null, lineFormatter);
+    }
+
     public DefaultHttpResponseWriterFactory() {
-        this(null);
+        this(null, null);
     }
 
     @Override
     public NHttpMessageWriter<HttpResponse> create() {
-        return new DefaultHttpResponseWriter<>(this.lineFormatter);
+        return new DefaultHttpResponseWriter<>(lineFormatter, http1Config);
     }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
@@ -320,6 +320,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             streamHandler = new ServerHttp1StreamHandler(
                     outputChannel,
                     httpProcessor,
+                    http1Config,
                     connectionReuseStrategy,
                     exchangeHandlerFactory,
                     context);
@@ -328,6 +329,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             streamHandler = new ServerHttp1StreamHandler(
                     new DelayedOutputChannel(outputChannel),
                     httpProcessor,
+                    http1Config,
                     connectionReuseStrategy,
                     exchangeHandlerFactory,
                     context);
@@ -350,6 +352,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             streamHandler = new ServerHttp1StreamHandler(
                     outputChannel,
                     httpProcessor,
+                    http1Config,
                     connectionReuseStrategy,
                     exchangeHandlerFactory,
                     context);
@@ -358,6 +361,7 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
             streamHandler = new ServerHttp1StreamHandler(
                     new DelayedOutputChannel(outputChannel),
                     httpProcessor,
+                    http1Config,
                     connectionReuseStrategy,
                     exchangeHandlerFactory,
                     context);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexerFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexerFactory.java
@@ -85,9 +85,9 @@ public final class ServerHttp1StreamDuplexerFactory {
         this.connectionReuseStrategy = connectionReuseStrategy != null ? connectionReuseStrategy :
                 DefaultConnectionReuseStrategy.INSTANCE;
         this.requestParserFactory = requestParserFactory != null ? requestParserFactory :
-                new DefaultHttpRequestParserFactory(http1Config);
+                new DefaultHttpRequestParserFactory(this.http1Config);
         this.responseWriterFactory = responseWriterFactory != null ? responseWriterFactory :
-                DefaultHttpResponseWriterFactory.INSTANCE;
+                new DefaultHttpResponseWriterFactory(this.http1Config);
         this.incomingContentStrategy = incomingContentStrategy != null ? incomingContentStrategy :
                 DefaultContentLengthStrategy.INSTANCE;
         this.outgoingContentStrategy = outgoingContentStrategy != null ? outgoingContentStrategy :

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/HttpMessageParserFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/HttpMessageParserFactory.java
@@ -37,6 +37,14 @@ import org.apache.hc.core5.http.config.Http1Config;
  */
 public interface HttpMessageParserFactory<T extends MessageHeaders> {
 
+    /**
+     * @deprecated Use {@link #create()}
+     */
+    @Deprecated
     HttpMessageParser<T> create(Http1Config http1Config);
+
+    default HttpMessageParser<T> create() {
+        return create(Http1Config.DEFAULT);
+    }
 
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/MessageSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/MessageSupport.java
@@ -203,6 +203,17 @@ public class MessageSupport {
         }
     }
 
+    /**
+     * @since 5.3
+     */
+    public static void parseTokens(final MessageHeaders headers, final String headerName, final Consumer<String> consumer) {
+        Args.notNull(headers, "Headers");
+        final Iterator<Header> it = headers.headerIterator(headerName);
+        while (it.hasNext()) {
+            parseTokens(it.next(), consumer);
+        }
+    }
+
     public static Set<String> parseTokens(final CharSequence src, final ParserCursor cursor) {
         Args.notNull(src, "Source");
         Args.notNull(cursor, "Cursor");
@@ -311,6 +322,17 @@ public class MessageSupport {
             final String value = header.getValue();
             final ParserCursor cursor = new ParserCursor(0, value.length());
             parseElements(value, cursor, consumer);
+        }
+    }
+
+    /**
+     * @since 5.3
+     */
+    public static void parseElements(final MessageHeaders headers, final String headerName, final Consumer<HeaderElement> consumer) {
+        Args.notNull(headers, "Headers");
+        final Iterator<Header> it = headers.headerIterator(headerName);
+        while (it.hasNext()) {
+            parseElements(it.next(), consumer);
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ForwardedRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ForwardedRequest.java
@@ -47,10 +47,10 @@ import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.util.Args;
 
 /**
- * The ForwardedRequest class is an implementation of the {@link HttpRequestInterceptor} interface
- * that can be used by a proxy server to add a Forwarded header to an HTTP request. The Forwarded
- * header is used to capture information about the intermediate nodes that a request has passed
- * through. This information can be useful for security purposes or for debugging purposes.
+ * This request interceptor can be used by an HTTP proxy or an intermediary to add a Forwarded header
+ * to outgoing request messages.
+ * The Forwarded header is used to capture information about the intermediate nodes that a request
+ * has passed through. This information can be useful for security purposes or for debugging purposes.
  * <p>
  * The Forwarded header consists of a list of key-value pairs separated by semicolons. The keys that
  * can be used in the Forwarded header include "host", "port", "proto", "for", and "by". The host
@@ -73,7 +73,6 @@ import org.apache.hc.core5.util.Args;
  * already exists in the request, the existing header is not overwritten; instead, the new header
  * value is appended to the existing header value, with a comma separator.
  * <p>
- * This implementation of the ForwardedRequest class is immutable and thread-safe.
  *
  * @since 5.3
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/HttpDateGenerator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/HttpDateGenerator.java
@@ -47,8 +47,12 @@ public class HttpDateGenerator {
 
     private static final int GRANULARITY_MILLIS = 1000;
 
-    /** Date format pattern used to generate the header in RFC 1123 format. */
+    /**
+     * @deprecated Use {@link #INTERNET_MESSAGE_FORMAT}
+     */
+    @Deprecated
     public static final String PATTERN_RFC1123 = "EEE, dd MMM yyyy HH:mm:ss zzz";
+    public static final String INTERNET_MESSAGE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
 
     /**
      * @deprecated This attribute is no longer supported as a part of the public API.
@@ -60,7 +64,7 @@ public class HttpDateGenerator {
     public static final ZoneId GMT_ID = ZoneId.of("GMT");
 
     /** Singleton instance. */
-    public static final HttpDateGenerator INSTANCE = new HttpDateGenerator(PATTERN_RFC1123, GMT_ID);
+    public static final HttpDateGenerator INSTANCE = new HttpDateGenerator(INTERNET_MESSAGE_FORMAT, GMT_ID);
 
     private final DateTimeFormatter dateTimeFormatter;
     private long dateAsMillis;
@@ -68,17 +72,6 @@ public class HttpDateGenerator {
     private ZoneId zoneId;
 
     private final ReentrantLock lock;
-
-    HttpDateGenerator() {
-        dateTimeFormatter =new DateTimeFormatterBuilder()
-                .parseLenient()
-                .parseCaseInsensitive()
-                .appendPattern(PATTERN_RFC1123)
-                .toFormatter();
-        zoneId = GMT_ID;
-        this.lock = new ReentrantLock();
-
-    }
 
     private HttpDateGenerator(final String pattern, final ZoneId zoneId) {
         dateTimeFormatter = new DateTimeFormatterBuilder()

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
@@ -35,6 +35,7 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.MisdirectedRequestException;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.net.URIAuthority;
@@ -73,6 +74,9 @@ public class RequestConformance implements HttpRequestInterceptor {
             if (TextUtils.isBlank(hostName)) {
                 throw new ProtocolException("Request host is empty");
             }
+        }
+        if (URIScheme.HTTPS.same(request.getScheme()) && context.getAttribute(HttpCoreContext.SSL_SESSION) == null) {
+            throw new MisdirectedRequestException("HTTPS request over non-secure connection");
         }
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
@@ -43,8 +43,12 @@ import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TextUtils;
 
 /**
- * ResponseConformance is responsible for making the protocol conformance checks
- * of incoming request messages.
+ * This request interceptor is responsible for execution of the protocol conformance
+ * checks on incoming request messages.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 5.3
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConnControl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConnControl.java
@@ -41,10 +41,13 @@ import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestConnControl is responsible for adding {@code Connection} header
- * to the outgoing requests, which is essential for managing persistence of
- * {@code HTTP/1.0} connections. This interceptor is recommended for
- * client side protocol processors.
+ * This request interceptor is responsible for adding {@code Connection} header
+ * to outgoing requests, which is essential for managing persistence of
+ * {@code HTTP/1.0} connections.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -46,12 +46,13 @@ import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestContent is the most important interceptor for outgoing requests.
- * It is responsible for delimiting content length by adding
- * {@code Content-Length} or {@code Transfer-Content} headers based
+ * This request interceptor is responsible for delimiting the message content
+ * by adding {@code Content-Length} or {@code Transfer-Content} headers based
  * on the properties of the enclosed entity and the protocol version.
- * This interceptor is required for correct functioning of client side protocol
- * processors.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestDate.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestDate.java
@@ -39,9 +39,12 @@ import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestDate interceptor is responsible for adding {@code Date} header
- * to the outgoing requests This interceptor is optional for client side
- * protocol processors.
+ * This request interceptor is responsible for adding {@code Date} header
+ * to outgoing request messages.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestExpectContinue.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestExpectContinue.java
@@ -42,9 +42,12 @@ import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestExpectContinue is responsible for enabling the 'expect-continue'
- * handshake by adding {@code Expect} header. This interceptor is
- * recommended for client side protocol processors.
+ * This request interceptor is responsible for activation of the 'expect-continue'
+ * handshake by adding a {@code Expect} header describing client expectations.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestTargetHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestTargetHost.java
@@ -44,9 +44,12 @@ import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestHostOutgoing is responsible for adding {@code Host} header to the outgoing message.
- * This interceptor is required for client side protocol processors.
- *
+ * This request interceptor is responsible for adding {@code Host} header to
+ * outgoing request messages.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  * @since 4.0
  */
 @Contract(threading = ThreadingBehavior.IMMUTABLE)

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestTargetHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestTargetHost.java
@@ -65,6 +65,7 @@ public class RequestTargetHost implements HttpRequestInterceptor {
         super();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
             throws HttpException, IOException {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestUserAgent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestUserAgent.java
@@ -39,8 +39,11 @@ import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestUserAgent is responsible for adding {@code User-Agent} header.
- * This interceptor is recommended for client side protocol processors.
+ * This request interceptor is responsible for adding {@code User-Agent} header.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the client-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestValidateHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestValidateHost.java
@@ -68,6 +68,11 @@ public class RequestValidateHost implements HttpRequestInterceptor {
             throws HttpException, IOException {
         Args.notNull(request, "HTTP request");
 
+        // Request authority already specified (likely in an absolute request URI)
+        if (request.getAuthority() != null) {
+            return;
+        }
+
         final Header header = request.getHeader(HttpHeaders.HOST);
         if (header != null) {
             final URIAuthority authority;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestValidateHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestValidateHost.java
@@ -45,9 +45,12 @@ import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.util.Args;
 
 /**
- * RequestTargetHost is responsible for copying {@code Host} header value to
- * {@link HttpRequest#setAuthority(URIAuthority)} of the incoming message.
- * This interceptor is required for server side protocol processors.
+ * This request interceptor is responsible for copying {@code Host} header value to
+ * {@link HttpRequest#setAuthority(URIAuthority)} of incoming request messages.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 5.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConformance.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConformance.java
@@ -40,8 +40,12 @@ import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.util.Args;
 
 /**
- * ResponseConformance is responsible for making the protocol conformance checks
+ * This response interceptor is responsible for making the protocol conformance checks
  * of outgoing response messages.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 5.3
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
@@ -47,10 +47,13 @@ import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.util.Args;
 
 /**
- * ResponseConnControl is responsible for adding {@code Connection} header
- * to the outgoing responses, which is essential for managing persistence of
- * {@code HTTP/1.0} connections. This interceptor is recommended for
- * server side protocol processors.
+ * This response interceptor is responsible for adding {@code Connection} header
+ * to outgoing responses, which is essential for managing persistence of
+ * {@code HTTP/1.0} connections.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseContent.java
@@ -45,12 +45,13 @@ import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.util.Args;
 
 /**
- * ResponseContent is the most important interceptor for outgoing responses.
- * It is responsible for delimiting content length by adding
- * {@code Content-Length} or {@code Transfer-Content} headers based
+ * This response interceptor is responsible for delimiting the message content
+ * by adding {@code Content-Length} or {@code Transfer-Content} headers based
  * on the properties of the enclosed entity and the protocol version.
- * This interceptor is required for correct functioning of server side protocol
- * processors.
+ * <p>
+ * This interceptor is essential for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseDate.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseDate.java
@@ -40,9 +40,12 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.util.Args;
 
 /**
- * ResponseDate is responsible for adding {@code Date} header to the
- * outgoing responses. This interceptor is recommended for server side protocol
- * processors.
+ * This response interceptor is responsible for adding {@code Date} header
+ * to outgoing response messages.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseServer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseServer.java
@@ -39,8 +39,11 @@ import org.apache.hc.core5.http.HttpResponseInterceptor;
 import org.apache.hc.core5.util.Args;
 
 /**
- * ResponseServer is responsible for adding {@code Server} header. This
- * interceptor is recommended for server side protocol processors.
+ * This response interceptor is responsible for adding {@code Server} header.
+ * <p>
+ * This interceptor is recommended for the HTTP protocol conformance and
+ * the correct operation of the server-side message processing pipeline.
+ * </p>
  *
  * @since 4.0
  */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ViaRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ViaRequest.java
@@ -42,8 +42,8 @@ import org.apache.hc.core5.util.Args;
 
 
 /**
- * An Apache HttpComponents {@link HttpRequestInterceptor} to add the {@link HttpHeaders#VIA} HTTP
- * header to requests.
+ * This request interceptor can be used by an HTTP proxy or intemediary to add the
+ * {@link HttpHeaders#VIA} HTTP header to outgoing request messages.
  * <p>The {@link  HttpHeaders#VIA} header is used to indicate intermediate protocols and recipients
  * between the user agent and the server (on requests) or between the origin server and the client
  * (on responses). It can be used for tracking message forwards, avoiding request loops, and

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/ExpectSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/ExpectSupport.java
@@ -1,0 +1,71 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http.support;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HeaderElements;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.message.MessageSupport;
+import org.apache.hc.core5.util.TextUtils;
+
+/**
+ * Server side Expect header handling support.
+ *
+ * @since 5.3
+ */
+@Internal
+public class ExpectSupport {
+
+    public static Expectation parse(
+            final HttpRequest request,
+            final EntityDetails entityDetails) throws ProtocolException {
+        // Ignore Expect header in messages older than HTTP/1.1
+        if (request.getVersion() != null && request.getVersion().lessEquals(HttpVersion.HTTP_1_0)) {
+            return null;
+        }
+        final AtomicReference<Expectation> expectationRef = new AtomicReference<>();
+        MessageSupport.parseTokens(request, HttpHeaders.EXPECT, t -> {
+            if (t.equalsIgnoreCase(HeaderElements.CONTINUE)) {
+                expectationRef.compareAndSet(null, Expectation.CONTINUE);
+            } else if (!TextUtils.isBlank(t)) {
+                expectationRef.set(Expectation.UNKNOWN);
+            }
+        });
+        final Expectation expectation = expectationRef.get();
+        if (expectation == Expectation.CONTINUE && entityDetails == null) {
+            throw new ProtocolException("Expect-Continue request without an enclosed entity");
+        }
+        return expectation;
+    }
+}
+

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/Expectation.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/Expectation.java
@@ -1,0 +1,42 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http.support;
+
+import org.apache.hc.core5.annotation.Internal;
+
+/**
+ * Message expectations. Presently only {@literal 100-continue} is recognized.
+ *
+ * @since 5.3
+ */
+@Internal
+public enum Expectation {
+
+    CONTINUE, UNKNOWN
+
+}
+

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -1015,6 +1015,16 @@ public class TestStandardInterceptors {
     }
 
     @Test
+    public void testRequestAbsoluteRequestURITakesPrecedenceOverHostHeader() throws Exception {
+        final HttpContext context = new BasicHttpContext(null);
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "https://somehost/blah?huh");
+        request.setHeader(HttpHeaders.HOST, "blah");
+        final RequestValidateHost interceptor = new RequestValidateHost();
+        interceptor.process(request, request.getEntity(), context);
+        Assertions.assertEquals(new URIAuthority("somehost"), request.getAuthority());
+    }
+
+    @Test
     public void testRequestConformance() throws Exception {
         final HttpContext context = new BasicHttpContext(null);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestExpectSupport.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestExpectSupport.java
@@ -1,0 +1,110 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http.support;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.impl.BasicEntityDetails;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestExpectSupport {
+
+    @Test
+    public void testExpectParsingBasics() throws Exception {
+        Assertions.assertEquals(Expectation.CONTINUE,
+                ExpectSupport.parse(
+                        BasicRequestBuilder.post()
+                                .addHeader("Expect", "100-continue")
+                                .build(),
+                        new BasicEntityDetails(100, ContentType.TEXT_PLAIN)));
+    }
+
+    @Test
+    public void testExpectParsingTolerateEmptyTokens() throws Exception {
+        Assertions.assertEquals(Expectation.CONTINUE,
+                ExpectSupport.parse(
+                        BasicRequestBuilder.post()
+                                .addHeader("Expect", ",,,")
+                                .addHeader("Expect", ",100-continue")
+                                .addHeader("Expect", ",,,")
+                                .build(),
+                        new BasicEntityDetails(100, ContentType.TEXT_PLAIN)));
+    }
+
+    @Test
+    public void testExpectParsingMissingEntity() throws Exception {
+        Assertions.assertThrows(ProtocolException.class,
+                () -> ExpectSupport.parse(
+                        BasicRequestBuilder.post()
+                                .addHeader("Expect", "100-continue")
+                                .build(),
+                        null));
+    }
+
+    @Test
+    public void testExpectParsingUnknownExpectation() throws Exception {
+        Assertions.assertEquals(Expectation.UNKNOWN,
+                ExpectSupport.parse(
+                        BasicRequestBuilder.post()
+                                .addHeader("Expect", "whatever")
+                                .addHeader("Expect", "100-continue")
+                                .build(),
+                        new BasicEntityDetails(100, ContentType.TEXT_PLAIN)));
+    }
+
+    @Test
+    public void testExpectParsingUnknownExpectation2() throws Exception {
+        Assertions.assertEquals(Expectation.UNKNOWN,
+                ExpectSupport.parse(
+                        BasicRequestBuilder.post()
+                                .addHeader("Expect", "100-continue, whatever")
+                                .build(),
+                        new BasicEntityDetails(100, ContentType.TEXT_PLAIN)));
+    }
+
+    @Test
+    public void testExpectParsingNoExpectation() throws Exception {
+        Assertions.assertNull(ExpectSupport.parse(
+                        BasicRequestBuilder.post()
+                                .build(),
+                        new BasicEntityDetails(100, ContentType.TEXT_PLAIN)));
+    }
+
+    @Test
+    public void testExpectParsingIgnoreHTTP10() throws Exception {
+        Assertions.assertNull(ExpectSupport.parse(
+                BasicRequestBuilder.post()
+                        .setVersion(HttpVersion.HTTP_1_0)
+                        .addHeader("Expect", "100-continue")
+                        .build(),
+                new BasicEntityDetails(100, ContentType.TEXT_PLAIN)));
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -47,6 +47,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class TestURIBuilder {
 
     private static final String CH_HELLO = "\u0047\u0072\u00FC\u0065\u007A\u0069\u005F\u007A\u00E4\u006D\u00E4";


### PR DESCRIPTION
This PR contains several incremental RFC 9110 conformance improvements
* Handling of HTTPS requests over insecure (non-TLS) connections
* Support for handling connection specific headers
* `Expect` header processing improvements
* Client protocol handlers to generate `Host` header first whenever possible
* Request authority from the absolute request URI to take precedence over `Host` header
* Protocol handlers to always signal the actual HTTP protocol version instead of the version specified by the outgoing message
* Protocol level for HTTP/1 endpoints can now be configured (HTTP endpoints can be forced into the HTTP/1.0 mode)  