### PR TITLE
HTTPCORE-756: RFC 9112 conformance improvements

### DIFF
--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultConnectionReuseStrategy.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultConnectionReuseStrategy.java
@@ -309,5 +309,15 @@ public class TestDefaultConnectionReuseStrategy {
         response.addHeader("Connection", "keep-alive");
         Assertions.assertFalse(reuseStrategy.keepAlive(null, response, context));
     }
+
+    @Test
+    public void testResponseHTTP10TransferEncodingPresent() throws Exception {
+        final HttpResponse response = new BasicHttpResponse(200, "OK");
+        response.setVersion(HttpVersion.HTTP_1_0);
+        response.addHeader("Transfer-Encoding", "chunked");
+        response.addHeader("Connection", "keep-alive");
+        Assertions.assertFalse(reuseStrategy.keepAlive(null, response, context));
+    }
+
 }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultContentLengthStrategy.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultContentLengthStrategy.java
@@ -74,20 +74,56 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithIdentityTransferEncoding() throws Exception {
+    public void testEntityWithChunkTransferEncodingAndEmptyTokens() throws Exception {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
-        message.addHeader("Transfer-Encoding", "Identity");
+        message.addHeader("Transfer-Encoding", ",,Chunked,,");
+
+        Assertions.assertEquals(ContentLengthStrategy.CHUNKED, lenStrategy.determineLength(message));
+    }
+
+    @Test
+    public void testEntityWithChunkTransferEncodingDoubleChunk() throws Exception {
+        final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
+        final HttpMessage message = new TestHttpMessage();
+        message.addHeader("Transfer-Encoding", "Chunked,Chunked");
         Assertions.assertThrows(NotImplementedException.class, () ->
                 lenStrategy.determineLength(message));
     }
 
     @Test
-    public void testEntityWithInvalidTransferEncoding() throws Exception {
+    public void testEntityWithChunkTransferEncodingUnknown1() throws Exception {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
-        message.addHeader("Transfer-Encoding", "whatever");
-        Assertions.assertThrows(ProtocolException.class, () ->
+        message.addHeader("Transfer-Encoding", "blah");
+        Assertions.assertThrows(NotImplementedException.class, () ->
+                lenStrategy.determineLength(message));
+    }
+
+    @Test
+    public void testEntityWithChunkTransferEncodingUnknown2() throws Exception {
+        final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
+        final HttpMessage message = new TestHttpMessage();
+        message.addHeader("Transfer-Encoding", "blah, chunked");
+        Assertions.assertThrows(NotImplementedException.class, () ->
+                lenStrategy.determineLength(message));
+    }
+
+    @Test
+    public void testEntityWithChunkTransferEncodingUnknown3() throws Exception {
+        final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
+        final HttpMessage message = new TestHttpMessage();
+        message.addHeader("Transfer-Encoding", "chunked,blah");
+        Assertions.assertThrows(NotImplementedException.class, () ->
+                lenStrategy.determineLength(message));
+    }
+
+    @Test
+    public void testEntityWithIdentityTransferEncoding() throws Exception {
+        final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
+        final HttpMessage message = new TestHttpMessage();
+        message.addHeader("Transfer-Encoding", "Identity");
+        Assertions.assertThrows(NotImplementedException.class, () ->
                 lenStrategy.determineLength(message));
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicLineParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicLineParser.java
@@ -186,6 +186,12 @@ public class TestBasicLineParser {
         buf.clear();
         buf.append("HTTP/1.1 -200 OK");
         Assertions.assertThrows(ParseException.class, () -> parser.parseStatusLine(buf));
+        buf.clear();
+        buf.append("HTTP/1.1 0200 OK");
+        Assertions.assertThrows(ParseException.class, () -> parser.parseStatusLine(buf));
+        buf.clear();
+        buf.append("HTTP/1.1 2000 OK");
+        Assertions.assertThrows(ParseException.class, () -> parser.parseStatusLine(buf));
     }
 
     @Test


### PR DESCRIPTION
* Stricter parsing of response status line. The status code must consist of 3 digits.
* `Transfer-Encoding` handling and message frame validity improvements 