### PR TITLE
fix: URIBuilder.getFirstQueryParam throws exception when query is emty

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -967,7 +967,7 @@ public class URIBuilder {
      * @since 5.2
      */
     public NameValuePair getFirstQueryParam(final String name) {
-        return queryParams.stream().filter(e -> name.equals(e.getName())).findFirst().orElse(null);
+        return getQueryParams().stream().filter(e -> name.equals(e.getName())).findFirst().orElse(null);
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -967,7 +967,8 @@ public class URIBuilder {
      * @since 5.2
      */
     public NameValuePair getFirstQueryParam(final String name) {
-        return getQueryParams().stream().filter(e -> name.equals(e.getName())).findFirst().orElse(null);
+        if (this.queryParams == null) return null;
+        return queryParams.stream().filter(e -> name.equals(e.getName())).findFirst().orElse(null);
     }
 
     /**

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -399,6 +399,8 @@ public class TestURIBuilder {
         //
         uribuilder = new URIBuilder("http://localhost:80/?param=some%20other%20stuff&blah=blah&blah=blah2");
         Assertions.assertEquals("blah", uribuilder.getFirstQueryParam("blah").getValue());
+        uribuilder.removeQuery();
+        Assertions.assertNull(uribuilder.getFirstQueryParam("param"));
     }
 
     @Test


### PR DESCRIPTION
Due to description of `URIBuilder.getFirstQueryParam()` it must return `null` if named parameter not found. When query is empty `this.queryParams == null` so calling `queryParams.stream()...` results in exception. So `queryParams` replaced with `getQueryParams()` which returns empty array in such case.