### PR TITLE
Mention HttpStatus and StatusCode in JavaDoc in more places

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpResponse.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpResponse.java
@@ -41,6 +41,8 @@ public interface HttpResponse extends HttpMessage {
      * Obtains the code of this response message.
      *
      * @return  the status code.
+     *
+     * @see HttpStatus
      */
     int getCode();
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpStatus.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpStatus.java
@@ -31,6 +31,8 @@ package org.apache.hc.core5.http;
  * Constants enumerating the HTTP status codes.
  *
  * @since 4.0
+ * @see org.apache.hc.core5.http.message.StatusLine.StatusClass
+ * @see org.apache.hc.core5.http.message.StatusLine.StatusClass#from(int)
  */
 public final class HttpStatus {
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/StatusLine.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/StatusLine.java
@@ -174,6 +174,7 @@ public final class StatusLine implements Serializable {
 
     /**
      * Standard classes of HTTP status codes, plus {@code OTHER} for non-standard codes.
+     * @see org.apache.hc.core5.http.HttpStatus
      */
     public enum StatusClass {
 
@@ -212,6 +213,7 @@ public final class StatusLine implements Serializable {
          *
          * @param statusCode response status code to get the class for.
          * @return class of the response status code.
+         * @see org.apache.hc.core5.http.HttpStatus
          */
         public static StatusClass from(final int statusCode) {
             final StatusClass statusClass;


### PR DESCRIPTION
I was originally searching for a way to test that `HttpStatus` code was "successful".
I didn't want to create a utility in my code base which checks `200 <= code && code < 300`, because it's a too frequent pattern.
I found `org.apache.hc.core5.http.message.StatusLine.StatusClass#from` but I spent a couple of minutes for that.
It would be much easier if it was mentioned in the `HttpStatus` JavaDoc, because those two entities are closely interconnected.

