### PR TITLE
HttpCoreContext to use instance variables for standard attributes

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -1420,8 +1420,8 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
                     localConfig.getInitialWindowSize(),
                     remoteConfig.getInitialWindowSize());
             final HttpCoreContext context = HttpCoreContext.create();
-            context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-            context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+            context.setSSLSession(getSSLSession());
+            context.setEndpointDetails(getEndpointDetails());
             final H2StreamHandler streamHandler = new ServerPushH2StreamHandler(
                     channel, httpProcessor, connMetrics, pushProducer, context);
             final H2Stream stream = new H2Stream(channel, streamHandler, false);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamHandler.java
@@ -137,7 +137,7 @@ class ClientH2StreamHandler implements H2StreamHandler {
     private void commitRequest(final HttpRequest request, final EntityDetails entityDetails) throws HttpException, IOException {
         if (requestCommitted.compareAndSet(false, true)) {
             context.setProtocolVersion(HttpVersion.HTTP_2);
-            context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+            context.setRequest(request);
 
             httpProcessor.process(request, entityDetails, context);
 
@@ -205,7 +205,7 @@ class ClientH2StreamHandler implements H2StreamHandler {
                 }
 
                 final EntityDetails entityDetails = endStream ? null : new IncomingEntityDetails(response, -1);
-                context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
+                context.setResponse(response);
                 httpProcessor.process(response, entityDetails, context);
                 connMetrics.incrementResponseCount();
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamMultiplexer.java
@@ -111,9 +111,9 @@ public class ClientH2StreamMultiplexer extends AbstractH2StreamMultiplexer {
             final RequestExecutionCommand executionCommand = (RequestExecutionCommand) command;
             final AsyncClientExchangeHandler exchangeHandler = executionCommand.getExchangeHandler();
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory = executionCommand.getPushHandlerFactory();
-            final HttpCoreContext context = HttpCoreContext.adapt(executionCommand.getContext());
-            context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-            context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+            final HttpCoreContext context = HttpCoreContext.cast(executionCommand.getContext());
+            context.setSSLSession(getSSLSession());
+            context.setEndpointDetails(getEndpointDetails());
             return new ClientH2StreamHandler(channel, httpProcessor, connMetrics, exchangeHandler,
                     pushHandlerFactory != null ? pushHandlerFactory : this.pushHandlerFactory,
                     context);
@@ -128,8 +128,8 @@ public class ClientH2StreamMultiplexer extends AbstractH2StreamMultiplexer {
             final BasicHttpConnectionMetrics connMetrics,
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory) throws IOException {
         final HttpCoreContext context = HttpCoreContext.create();
-        context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+        context.setSSLSession(getSSLSession());
+        context.setEndpointDetails(getEndpointDetails());
         return new ClientPushH2StreamHandler(channel, httpProcessor, connMetrics,
                 pushHandlerFactory != null ? pushHandlerFactory : this.pushHandlerFactory,
                 context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientPushH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientPushH2StreamHandler.java
@@ -115,7 +115,7 @@ class ClientPushH2StreamHandler implements H2StreamHandler {
             }
 
             context.setProtocolVersion(HttpVersion.HTTP_2);
-            context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+            context.setRequest(request);
 
             httpProcessor.process(request, null, context);
             connMetrics.incrementRequestCount();
@@ -134,7 +134,7 @@ class ClientPushH2StreamHandler implements H2StreamHandler {
             final HttpResponse response = DefaultH2ResponseConverter.INSTANCE.convert(headers);
             final EntityDetails entityDetails = endStream ? null : new IncomingEntityDetails(request, -1);
 
-            context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
+            context.setResponse(response);
             httpProcessor.process(response, entityDetails, context);
             connMetrics.incrementResponseCount();
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamHandler.java
@@ -170,7 +170,7 @@ class ServerH2StreamHandler implements H2StreamHandler {
             if (status < HttpStatus.SC_SUCCESS) {
                 throw new HttpException("Invalid response: " + status);
             }
-            context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
+            context.setResponse(response);
             httpProcessor.process(response, responseEntityDetails, context);
 
             final List<Header> responseHeaders = DefaultH2ResponseConverter.INSTANCE.convert(response);
@@ -230,7 +230,7 @@ class ServerH2StreamHandler implements H2StreamHandler {
                 exchangeHandler = handler;
 
                 context.setProtocolVersion(HttpVersion.HTTP_2);
-                context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+                context.setRequest(request);
 
                 try {
                     httpProcessor.process(request, requestEntityDetails, context);

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexer.java
@@ -105,8 +105,8 @@ public class ServerH2StreamMultiplexer extends AbstractH2StreamMultiplexer {
             final BasicHttpConnectionMetrics connMetrics,
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory) throws IOException {
         final HttpCoreContext context = HttpCoreContext.create();
-        context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+        context.setSSLSession(getSSLSession());
+        context.setEndpointDetails(getEndpointDetails());
         return new ServerH2StreamHandler(channel, httpProcessor, connMetrics, exchangeHandlerFactory, context);
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerPushH2StreamHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerPushH2StreamHandler.java
@@ -166,7 +166,7 @@ class ServerPushH2StreamHandler implements H2StreamHandler {
         if (responseCommitted.compareAndSet(false, true)) {
 
             context.setProtocolVersion(HttpVersion.HTTP_2);
-            context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
+            context.setResponse(response);
             httpProcessor.process(response, responseEntityDetails, context);
 
             final List<Header> headers = DefaultH2ResponseConverter.INSTANCE.convert(response);
@@ -186,7 +186,7 @@ class ServerPushH2StreamHandler implements H2StreamHandler {
             final AsyncPushProducer pushProducer) throws HttpException, IOException {
 
         context.setProtocolVersion(HttpVersion.HTTP_2);
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, promise);
+        context.setRequest(promise);
         httpProcessor.process(promise, null, context);
 
         final List<Header> headers = DefaultH2RequestConverter.INSTANCE.convert(promise);

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2FileServerExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2FileServerExample.java
@@ -137,7 +137,8 @@ public class H2FileServerExample {
                     public void handle(
                             final Message<HttpRequest, Void> message,
                             final ResponseTrigger responseTrigger,
-                            final HttpContext context) throws HttpException, IOException {
+                            final HttpContext localContext) throws HttpException, IOException {
+                        final HttpCoreContext context = HttpCoreContext.cast(localContext);
                         final HttpRequest request = message.getHead();
                         final URI requestUri;
                         try {
@@ -180,8 +181,7 @@ public class H2FileServerExample {
                                 contentType = ContentType.DEFAULT_BINARY;
                             }
 
-                            final HttpCoreContext coreContext = HttpCoreContext.adapt(context);
-                            final EndpointDetails endpoint = coreContext.getEndpointDetails();
+                            final EndpointDetails endpoint = context.getEndpointDetails();
                             System.out.println(endpoint + ": serving file " + file.getPath());
                             responseTrigger.submitResponse(
                                     AsyncResponseBuilder.create(HttpStatus.SC_OK)

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2GreetingServer.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2GreetingServer.java
@@ -134,10 +134,10 @@ public class H2GreetingServer {
         @Override
         protected void handle(final Message<HttpRequest, String> requestMessage,
                               final AsyncServerRequestHandler.ResponseTrigger responseTrigger,
-                              final HttpContext context) throws HttpException, IOException {
+                              final HttpContext localContext) throws HttpException, IOException {
 
-            final HttpCoreContext coreContext = HttpCoreContext.adapt(context);
-            final EndpointDetails endpoint = coreContext.getEndpointDetails();
+            final HttpCoreContext context = HttpCoreContext.cast(localContext);
+            final EndpointDetails endpoint = context.getEndpointDetails();
             final HttpRequest req = requestMessage.getHead();
             final String httpEntity = requestMessage.getBody();
 
@@ -146,7 +146,7 @@ public class H2GreetingServer {
 
             // recording the request
             System.out.printf("[%s] %s %s %s%n", Instant.now(),
-                    endpoint.getRemoteAddress(),
+                    endpoint != null ? endpoint.getRemoteAddress() : null,
                     req.getMethod(),
                     req.getPath());
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2IntegrationTest.java
@@ -922,16 +922,16 @@ public abstract class H2IntegrationTest {
 
             final HttpRequest request = new BasicHttpRequest(Method.GET, createRequestURI(serverEndpoint, "/hello"));
             request.addHeader(HttpHeaders.CONNECTION, HeaderElements.CLOSE);
-            final HttpCoreContext coreContext = HttpCoreContext.create();
+            final HttpCoreContext context = HttpCoreContext.create();
             final Future<Message<HttpResponse, String>> future = streamEndpoint.execute(
                         new BasicRequestProducer(request, null),
                         new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
-                        coreContext, null);
+                        context, null);
             final ExecutionException exception = Assertions.assertThrows(ExecutionException.class, () ->
                     future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit()));
             assertThat(exception.getCause(), CoreMatchers.instanceOf(ProtocolException.class));
 
-            final EndpointDetails endpointDetails = coreContext.getEndpointDetails();
+            final EndpointDetails endpointDetails = context.getEndpointDetails();
             assertThat(endpointDetails.getRequestCount(), CoreMatchers.equalTo(0L));
         }
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamDuplexer.java
@@ -309,9 +309,9 @@ public class ClientHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
     @Override
     void execute(final RequestExecutionCommand executionCommand) throws HttpException, IOException {
         final AsyncClientExchangeHandler exchangeHandler = executionCommand.getExchangeHandler();
-        final HttpCoreContext context = HttpCoreContext.adapt(executionCommand.getContext());
-        context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+        final HttpCoreContext context = HttpCoreContext.cast(executionCommand.getContext());
+        context.setSSLSession(getSSLSession());
+        context.setEndpointDetails(getEndpointDetails());
         final ClientHttp1StreamHandler handler = new ClientHttp1StreamHandler(
                 outputChannel,
                 httpProcessor,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ClientHttp1StreamHandler.java
@@ -150,7 +150,7 @@ class ClientHttp1StreamHandler implements ResourceHolder {
                 throw new UnsupportedHttpVersionException(transportVersion);
             }
             context.setProtocolVersion(transportVersion != null ? transportVersion : http1Config.getVersion());
-            context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+            context.setRequest(request);
 
             httpProcessor.process(request, entityDetails, context);
 
@@ -239,7 +239,7 @@ class ClientHttp1StreamHandler implements ResourceHolder {
         }
 
         context.setProtocolVersion(transportVersion != null ? transportVersion : HttpVersion.HTTP_1_1);
-        context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
+        context.setResponse(response);
         httpProcessor.process(response, entityDetails, context);
 
         if (entityDetails == null && !keepAlive) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamDuplexer.java
@@ -315,8 +315,8 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
         suspendSessionInput();
         final ServerHttp1StreamHandler streamHandler;
         final HttpCoreContext context = HttpCoreContext.create();
-        context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+        context.setSSLSession(getSSLSession());
+        context.setEndpointDetails(getEndpointDetails());
         if (outgoing == null) {
             streamHandler = new ServerHttp1StreamHandler(
                     outputChannel,
@@ -347,8 +347,8 @@ public class ServerHttp1StreamDuplexer extends AbstractHttp1StreamDuplexer<HttpR
         }
         final ServerHttp1StreamHandler streamHandler;
         final HttpCoreContext context = HttpCoreContext.create();
-        context.setAttribute(HttpCoreContext.SSL_SESSION, getSSLSession());
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, getEndpointDetails());
+        context.setSSLSession(getSSLSession());
+        context.setEndpointDetails(getEndpointDetails());
         if (outgoing == null) {
             streamHandler = new ServerHttp1StreamHandler(
                     outputChannel,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/ServerHttp1StreamHandler.java
@@ -174,7 +174,7 @@ class ServerHttp1StreamHandler implements ResourceHolder {
                 throw new HttpException("Invalid response: " + status);
             }
 
-            context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
+            context.setResponse(response);
             httpProcessor.process(response, responseEntityDetails, context);
 
             final boolean endStream = responseEntityDetails == null ||
@@ -269,7 +269,7 @@ class ServerHttp1StreamHandler implements ResourceHolder {
             throw new UnsupportedHttpVersionException(transportVersion);
         }
         context.setProtocolVersion(transportVersion != null ? transportVersion : http1Config.getVersion());
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         try {
             httpProcessor.process(request, requestEntityDetails, context);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/BasicHttpContext.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/BasicHttpContext.java
@@ -42,8 +42,9 @@ import org.apache.hc.core5.util.Args;
  * Please note instances of this class can be thread unsafe if the
  * parent context is not thread safe.
  *
- * @since 4.0
+ * @deprecated Do not use.
  */
+@Deprecated
 @Contract(threading = ThreadingBehavior.SAFE_CONDITIONAL)
 public class BasicHttpContext implements HttpContext {
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ForwardedRequest.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ForwardedRequest.java
@@ -105,16 +105,17 @@ public class ForwardedRequest implements HttpRequestInterceptor {
      * @param request the HTTP request to which the Forwarded header is to be added (not
      *                {@code null})
      * @param entity  the entity details of the request (can be {@code null})
-     * @param context the HTTP context in which the request is being executed (not {@code null})
+     * @param localContext the HTTP context in which the request is being executed (not {@code null})
      * @throws HttpException     if there is an error processing the request
      * @throws IOException       if an IO error occurs while processing the request
      * @throws ProtocolException if the request authority is not specified
      */
     @Override
-    public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context) throws HttpException, IOException {
+    public void process(final HttpRequest request, final EntityDetails entity, final HttpContext localContext) throws HttpException, IOException {
         Args.notNull(request, "HTTP request");
-        Args.notNull(context, "HTTP context");
+        Args.notNull(localContext, "HTTP context");
 
+        final HttpCoreContext context = HttpCoreContext.cast(localContext);
         final ProtocolVersion ver = context.getProtocolVersion() != null ? context.getProtocolVersion() : HttpVersion.HTTP_1_1;
 
         final URIAuthority authority = request.getAuthority();
@@ -134,7 +135,7 @@ public class ForwardedRequest implements HttpRequestInterceptor {
         }
 
         // Add the current hop details
-        final EndpointDetails endpointDetails = (EndpointDetails) context.getAttribute(HttpCoreContext.CONNECTION_ENDPOINT);
+        final EndpointDetails endpointDetails = context.getEndpointDetails();
 
         // Add the "by" parameter
         if (endpointDetails != null) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
@@ -62,7 +62,7 @@ public class RequestConformance implements HttpRequestInterceptor {
     }
 
     @Override
-    public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
+    public void process(final HttpRequest request, final EntityDetails entity, final HttpContext localContext)
             throws HttpException, IOException {
         Args.notNull(request, "HTTP request");
 
@@ -79,7 +79,8 @@ public class RequestConformance implements HttpRequestInterceptor {
                 throw new ProtocolException("Request host is empty");
             }
         }
-        if (URIScheme.HTTPS.same(request.getScheme()) && context.getAttribute(HttpCoreContext.SSL_SESSION) == null) {
+        final HttpCoreContext context = HttpCoreContext.cast(localContext);
+        if (URIScheme.HTTPS.same(request.getScheme()) && context.getSSLSession() == null) {
             throw new MisdirectedRequestException("HTTPS request over non-secure connection");
         }
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/ResponseConnControl.java
@@ -67,11 +67,12 @@ public class ResponseConnControl implements HttpResponseInterceptor {
     }
 
     @Override
-    public void process(final HttpResponse response, final EntityDetails entity, final HttpContext context)
+    public void process(final HttpResponse response, final EntityDetails entity, final HttpContext localContext)
             throws HttpException, IOException {
         Args.notNull(response, "HTTP response");
-        Args.notNull(context, "HTTP context");
+        Args.notNull(localContext, "HTTP context");
 
+        final HttpCoreContext context = HttpCoreContext.cast(localContext);
         // Always drop connection after certain type of responses
         final int status = response.getCode();
         if (status == HttpStatus.SC_BAD_REQUEST ||
@@ -91,8 +92,7 @@ public class ResponseConnControl implements HttpResponseInterceptor {
             if (entity != null && entity.getContentLength() < 0 && ver.lessEquals(HttpVersion.HTTP_1_0)) {
                 response.setHeader(HttpHeaders.CONNECTION, HeaderElements.CLOSE);
             } else {
-                final HttpCoreContext coreContext = HttpCoreContext.adapt(context);
-                final HttpRequest request = coreContext.getRequest();
+                final HttpRequest request = context.getRequest();
                 boolean closeRequested = false;
                 boolean keepAliveRequested = false;
                 if (request != null) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncClientSNIExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncClientSNIExample.java
@@ -101,7 +101,7 @@ public class AsyncClientSNIExample {
         final InetAddress targetAddress = InetAddress.getByName("www.google.com");
         // Target host (google.ch)
         final HttpHost target = new HttpHost("https", targetAddress, "www.google.ch", 443);
-        final HttpCoreContext coreContext = HttpCoreContext.create();
+        final HttpCoreContext context = HttpCoreContext.create();
 
         final CountDownLatch latch = new CountDownLatch(1);
         final HttpRequest request = BasicRequestBuilder.get()
@@ -113,14 +113,14 @@ public class AsyncClientSNIExample {
                 new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
                 null,
                 Timeout.ofSeconds(5),
-                coreContext,
+                context,
                 new FutureCallback<Message<HttpResponse, String>>() {
 
                     @Override
                     public void completed(final Message<HttpResponse, String> message) {
                         final HttpResponse response = message.getHead();
                         System.out.println(request.getRequestUri() + "->" + response.getCode());
-                        final SSLSession sslSession = coreContext.getSSLSession();
+                        final SSLSession sslSession = context.getSSLSession();
                         if (sslSession != null) {
                             try {
                                 System.out.println("Peer: " + sslSession.getPeerPrincipal());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFileServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/AsyncFileServerExample.java
@@ -102,7 +102,8 @@ public class AsyncFileServerExample {
                     public void handle(
                             final Message<HttpRequest, Void> message,
                             final ResponseTrigger responseTrigger,
-                            final HttpContext context) throws HttpException, IOException {
+                            final HttpContext localContext) throws HttpException, IOException {
+                        final HttpCoreContext context = HttpCoreContext.cast(localContext);
                         final HttpRequest request = message.getHead();
                         final URI requestUri;
                         try {
@@ -145,8 +146,7 @@ public class AsyncFileServerExample {
                                 contentType = ContentType.DEFAULT_BINARY;
                             }
 
-                            final HttpCoreContext coreContext = HttpCoreContext.adapt(context);
-                            final EndpointDetails endpoint = coreContext.getEndpointDetails();
+                            final EndpointDetails endpoint = context.getEndpointDetails();
 
                             println(endpoint + " | serving file " + file.getPath());
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicClientSNIExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicClientSNIExample.java
@@ -87,16 +87,16 @@ public class ClassicClientSNIExample {
         final InetAddress targetAddress = InetAddress.getByName("www.google.com");
         // Target host (google.ch)
         final HttpHost target = new HttpHost("https", targetAddress, "www.google.ch", 443);
-        final HttpCoreContext coreContext = HttpCoreContext.create();
+        final HttpCoreContext context = HttpCoreContext.create();
 
         final ClassicHttpRequest request = ClassicRequestBuilder.get()
                 .setPath("/")
                 .build();
 
-        try (ClassicHttpResponse response = httpRequester.execute(target, request, Timeout.ofSeconds(5), coreContext)) {
+        try (ClassicHttpResponse response = httpRequester.execute(target, request, Timeout.ofSeconds(5), context)) {
             System.out.println(request.getUri() + "->" + response.getCode());
 
-            final SSLSession sslSession = coreContext.getSSLSession();
+            final SSLSession sslSession = context.getSSLSession();
             if (sslSession != null) {
                 System.out.println("Peer: " + sslSession.getPeerPrincipal());
                 System.out.println("TLS protocol: " + sslSession.getProtocol());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicFileServerExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicFileServerExample.java
@@ -144,8 +144,9 @@ public class ClassicFileServerExample {
         public void handle(
                 final ClassicHttpRequest request,
                 final ClassicHttpResponse response,
-                final HttpContext context) throws HttpException, IOException {
+                final HttpContext localContext) throws HttpException, IOException {
 
+            final HttpCoreContext context = HttpCoreContext.cast(localContext);
             final String method = request.getMethod();
             if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method) && !Method.POST.isSame(method)) {
                 throw new MethodNotSupportedException(method + " method not supported");
@@ -180,8 +181,7 @@ public class ClassicFileServerExample {
                 System.out.println(msg);
 
             } else {
-                final HttpCoreContext coreContext = HttpCoreContext.adapt(context);
-                final EndpointDetails endpoint = coreContext.getEndpointDetails();
+                final EndpointDetails endpoint = context.getEndpointDetails();
                 response.setCode(HttpStatus.SC_OK);
                 final FileEntity body = new FileEntity(file, ContentType.create("text/html", (Charset) null));
                 response.setEntity(body);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicGetExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicGetExecutionExample.java
@@ -81,7 +81,7 @@ public class ClassicGetExecutionExample {
                         .build())
                 .create();
 
-        final HttpCoreContext coreContext = HttpCoreContext.create();
+        final HttpCoreContext context = HttpCoreContext.create();
         final HttpHost target = new HttpHost("httpbin.org");
         final String[] requestUris = new String[] {"/", "/ip", "/user-agent", "/headers"};
 
@@ -91,7 +91,7 @@ public class ClassicGetExecutionExample {
                     .setHttpHost(target)
                     .setPath(requestUri)
                     .build();
-            try (ClassicHttpResponse response = httpRequester.execute(target, request, Timeout.ofSeconds(5), coreContext)) {
+            try (ClassicHttpResponse response = httpRequester.execute(target, request, Timeout.ofSeconds(5), context)) {
                 System.out.println(requestUri + "->" + response.getCode());
                 System.out.println(EntityUtils.toString(response.getEntity()));
                 System.out.println("==============");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/examples/ClassicPostExecutionExample.java
@@ -85,7 +85,7 @@ public class ClassicPostExecutionExample {
                         .setSoTimeout(5, TimeUnit.SECONDS)
                         .build())
                 .create();
-        final HttpCoreContext coreContext = HttpCoreContext.create();
+        final HttpCoreContext context = HttpCoreContext.create();
         final HttpHost target = new HttpHost("httpbin.org");
 
         final HttpEntity[] requestBodies = {
@@ -111,7 +111,7 @@ public class ClassicPostExecutionExample {
                     .setPath(requestUri)
                     .build();
             request.setEntity(requestBodies[i]);
-            try (ClassicHttpResponse response = httpRequester.execute(target, request, Timeout.ofSeconds(5), coreContext)) {
+            try (ClassicHttpResponse response = httpRequester.execute(target, request, Timeout.ofSeconds(5), context)) {
                 System.out.println(requestUri + "->" + response.getCode());
                 System.out.println(EntityUtils.toString(response.getEntity()));
                 System.out.println("==============");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TesForwardedRequest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TesForwardedRequest.java
@@ -76,7 +76,7 @@ public class TesForwardedRequest {
         // Create a mock HTTP context with the endpoint and protocol version
         final ProtocolVersion version = HttpVersion.HTTP_1_1;
         final HttpCoreContext context = HttpCoreContext.create() ;
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, endpointDetails);
+        context.setEndpointDetails(endpointDetails);
 
         // Process the HTTP request
         processor.process(request, new BasicEntityDetails(1, ContentType.APPLICATION_JSON), context);
@@ -111,7 +111,7 @@ public class TesForwardedRequest {
         // Create a mock HTTP context with the endpoint and protocol version
         final ProtocolVersion version = HttpVersion.HTTP_1_1;
         final HttpCoreContext context = HttpCoreContext.create() ;
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, endpointDetails);
+        context.setEndpointDetails(endpointDetails);
 
         // Process the HTTP request
         processor.process(request, new BasicEntityDetails(1, ContentType.APPLICATION_JSON), context);
@@ -138,7 +138,7 @@ public class TesForwardedRequest {
         // Create a mock HTTP context with the endpoint and protocol version
         final ProtocolVersion version = HttpVersion.HTTP_1_1;
         final HttpCoreContext context = HttpCoreContext.create() ;
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, null);
+        context.setEndpointDetails(null);
 
         // Process the HTTP request
         processor.process(request, new BasicEntityDetails(1, ContentType.APPLICATION_JSON), context);
@@ -162,7 +162,7 @@ public class TesForwardedRequest {
         // Create a mock HTTP context with the endpoint and protocol version
         final ProtocolVersion version = HttpVersion.HTTP_1_1;
         final HttpCoreContext context = HttpCoreContext.create() ;
-        context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, null);
+        context.setEndpointDetails(null);
         final String forwaredHeaderValue = "host=oldhost;port=8855;proto=HTTP";
 
         request.setHeader(new BasicHeader(FORWARDED_HEADER_NAME, forwaredHeaderValue));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestHttpExecutionContext.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestHttpExecutionContext.java
@@ -36,8 +36,8 @@ public class TestHttpExecutionContext {
 
     @Test
     public void testContextOperations() {
-        final HttpContext parentContext = new BasicHttpContext(null);
-        final HttpContext currentContext = new BasicHttpContext(parentContext);
+        final HttpCoreContext parentContext = new HttpCoreContext();
+        final HttpCoreContext currentContext = new HttpCoreContext(parentContext);
 
         parentContext.setAttribute("param1", "1");
         parentContext.setAttribute("param2", "2");
@@ -66,18 +66,10 @@ public class TestHttpExecutionContext {
 
     @Test
     public void testEmptyContextOperations() {
-        final HttpContext currentContext = new BasicHttpContext(null);
+        final HttpCoreContext currentContext = new HttpCoreContext();
         Assertions.assertNull(currentContext.getAttribute("param1"));
         currentContext.removeAttribute("param1");
         Assertions.assertNull(currentContext.getAttribute("param1"));
-    }
-
-    @Test
-    public void testContextInvalidInput() throws Exception {
-        final HttpContext currentContext = new BasicHttpContext(null);
-        Assertions.assertThrows(NullPointerException.class, () -> currentContext.setAttribute(null, null));
-        Assertions.assertThrows(NullPointerException.class, () -> currentContext.getAttribute(null));
-        Assertions.assertThrows(NullPointerException.class, () -> currentContext.removeAttribute(null));
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -507,7 +507,7 @@ public class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null));
         final ResponseConnControl interceptor = new ResponseConnControl();
@@ -534,7 +534,7 @@ public class TestStandardInterceptors {
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final BasicClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null));
@@ -550,7 +550,7 @@ public class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new StringEntity("whatever"));
@@ -565,7 +565,7 @@ public class TestStandardInterceptors {
     public void testResponseConnControlClientRequest2() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new StringEntity("whatever"));
@@ -580,7 +580,7 @@ public class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new StringEntity("whatever"));
@@ -596,7 +596,7 @@ public class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final ResponseConnControl interceptor = new ResponseConnControl();
 
@@ -624,7 +624,7 @@ public class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final ResponseConnControl interceptor = new ResponseConnControl();
 
@@ -641,7 +641,7 @@ public class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "blah, keep-alive, close"));
-        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setRequest(request);
 
         final ResponseConnControl interceptor = new ResponseConnControl();
 
@@ -1073,7 +1073,7 @@ public class TestStandardInterceptors {
     @Test
     public void testRequestConformanceHttps() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
-        context.setAttribute(HttpCoreContext.SSL_SESSION, Mockito.mock(SSLSession.class));
+        context.setSSLSession(Mockito.mock(SSLSession.class));
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setScheme("https");
         request.setAuthority(new URIAuthority("somehost", 8888));
@@ -1085,7 +1085,7 @@ public class TestStandardInterceptors {
     @Test
     public void testRequestConformanceHttpsInsecureConnection() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
-        context.setAttribute(HttpCoreContext.SSL_SESSION, null);
+        context.setSSLSession(null);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setScheme("https");
         request.setAuthority(new URIAuthority("somehost", 8888));


### PR DESCRIPTION
Since the inception HttpComponents used objects maps to represent context and parameters that could also be linked into a hierarchy with a parent map acting as a source of default values when not present in the local map. The use of object maps to represent a bag of all sorts of things was also a very hip (and much abused) concept at that time. Think Servlet attributes. 

A hierarchy of object maps is a very flexible and powerful structure. But it also has it cost in terms of complexity and in terms of performance. While it looked like a good idea in the beginning of HC 4.x development cycle, later it turned out to be causing more harm than good as the project progressed, mainly being unnecessarily complex, lacking proper type safety and adding too much overhead on top of that. In the HC 4.3 configuration The configuration API based on object maps got replaced with a simpler framework based on immutable plain objects.

This PR now refactors `HttpContext` and related classes to use simple attributes for standard, frequently used attributes while still providing map of objects for custom user attributes. 

