### PR TITLE
Avoid unnecessary volatile reads

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2PrefaceHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2PrefaceHandler.java
@@ -104,7 +104,10 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
         ioSession.setEvent(SelectionKey.OP_WRITE);
     }
 
-    private void writeOutPreface(final IOSession session) throws IOException  {
+    /**
+     * @return true if the entire preface has been written out
+     */
+    private boolean writeOutPreface(final IOSession session, ByteBuffer preface) throws IOException  {
         if (preface.hasRemaining()) {
             session.write(preface);
         }
@@ -115,8 +118,9 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
             if (inBuf != null) {
                 inBuf.clear();
             }
-            preface = null;
+            return true;
         }
+        return false;
     }
 
     @Override
@@ -131,8 +135,11 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
         if (initialized.compareAndSet(false, true)) {
             initialize();
         }
+        ByteBuffer preface = this.preface;
         if (preface != null) {
-            writeOutPreface(session);
+            if (writeOutPreface(session, preface)) {
+                this.preface = null;
+            }
         } else {
             throw new ProtocolNegotiationException("Unexpected output");
         }
@@ -146,8 +153,11 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
             }
             inBuf.put(src);
         }
+        ByteBuffer preface = this.preface;
         if (preface != null) {
-            writeOutPreface(session);
+            if (writeOutPreface(session, preface)) {
+                this.preface = null;
+            }
         } else {
             throw new ProtocolNegotiationException("Unexpected input");
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharDataConsumer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/AbstractCharDataConsumer.java
@@ -111,6 +111,7 @@ public abstract class AbstractCharDataConsumer implements AsyncDataConsumer {
     }
 
     private CharsetDecoder getCharsetDecoder() {
+        CharsetDecoder charsetDecoder = this.charsetDecoder;
         if (charsetDecoder == null) {
             Charset charset = this.charset;
             if (charset == null) {
@@ -120,6 +121,7 @@ public abstract class AbstractCharDataConsumer implements AsyncDataConsumer {
                 charset = StandardCharsets.UTF_8;
             }
             charsetDecoder = charset.newDecoder();
+            this.charsetDecoder = charsetDecoder;
             if (charCodingConfig.getMalformedInputAction() != null) {
                 charsetDecoder.onMalformedInput(charCodingConfig.getMalformedInputAction());
             }
@@ -134,6 +136,7 @@ public abstract class AbstractCharDataConsumer implements AsyncDataConsumer {
     public final void consume(final ByteBuffer src) throws IOException {
         final CharsetDecoder charsetDecoder = getCharsetDecoder();
         while (src.hasRemaining()) {
+            ByteBuffer byteBuffer = this.byteBuffer;
             if (byteBuffer != null && byteBuffer.position() > 0) {
                 // There are some left-overs from the previous input operation
                 final int n = byteBuffer.remaining();
@@ -159,6 +162,7 @@ public abstract class AbstractCharDataConsumer implements AsyncDataConsumer {
                     // in case of input underflow src can be expected to be very small (one incomplete UTF8 char)
                     if (byteBuffer == null) {
                         byteBuffer = ByteBuffer.allocate(Math.max(src.remaining(), 1024));
+                        this.byteBuffer = byteBuffer;
                     }
                     byteBuffer.put(src);
                 }


### PR DESCRIPTION
This commit avoids repeatedly reading volatile instance fields in ClientH2PrefaceHandler and AbstractCharDataConsumer. This is important for both performance and correctness, especially in the latter class. If a caller called `setCharset` while `getCharsetDecoder()` was being called on another thread, the second thread could see NullPointerExceptions after the `charsetDecoder` instance was unexpectedly nulled out between the null check and the return of `this.charsetDecoder` in `getCharsetDecoder`.