### PR TITLE
[HTTPCORE-767] Update JSSEProviderIntegrationTest to skip conscript 

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
@@ -34,6 +34,9 @@ import java.net.URL;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.apache.hc.core5.http.HttpHeaders;
@@ -52,6 +55,7 @@ import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.conscrypt.Conscrypt;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -80,6 +84,9 @@ public abstract class JSSEProviderIntegrationTest {
         @Override
         public void beforeEach(final ExtensionContext context) throws Exception {
             if ("Conscrypt".equalsIgnoreCase(securityProviderName)) {
+                final Set<String> supportedArchitectures = new HashSet<>(Arrays.asList("x86", "x86_64",
+                        "x86-64", "amd64", "aarch64", "armeabi-v7a", "arm64-v8a"));
+                Assumptions.assumeTrue(supportedArchitectures.contains(System.getProperty("os.arch")));
                 try {
                     securityProvider = Conscrypt.newProviderBuilder().provideTrustManager(true).build();
                 } catch (final UnsatisfiedLinkError e) {


### PR DESCRIPTION
Update JSSEProviderIntegrationTest to skip conscript when on ppc64le.

Tested on:

Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)
Maven home: /home/jgoodyear/Documents/x1/maven/apache-maven-3.9.6
Java version: 1.8.0_412, vendor: IBM Corporation, runtime: /home/jgoodyear/Documents/x1/java/jdk8u412-b08/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.14.0-447.el9.ppc64le", arch: "ppc64le", family: "unix"

Apache Maven 3.9.5 (57804ffe001d7215b5e7bcb531cf83df38f93546)
Maven home: /Users/jgoodyear/Documents/x1/maven/apache-maven-3.9.5
Java version: 1.8.0_312, vendor: Azul Systems, Inc., runtime: /Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home/jre
Default locale: en_CA, platform encoding: UTF-8
OS name: "mac os x", version: "14.5", arch: "aarch64", family: "mac"
