### PR TITLE
Cleanup test classes

### DIFF
--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/config/H2ConfigTest.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/config/H2ConfigTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class H2ConfigTest {
+class H2ConfigTest {
 
     @Test
     void builder() {

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/frame/TestDefaultFrameFactory.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/frame/TestDefaultFrameFactory.java
@@ -35,10 +35,10 @@ import org.apache.hc.core5.http2.config.H2Setting;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDefaultFrameFactory {
+class TestDefaultFrameFactory {
 
     @Test
-    public void testDataFrame() throws Exception {
+    void testDataFrame() {
 
         final FrameFactory frameFactory = new DefaultFrameFactory();
 
@@ -51,7 +51,7 @@ public class TestDefaultFrameFactory {
     }
 
     @Test
-    public void testSettingFrame() throws Exception {
+    void testSettingFrame() {
 
         final FrameFactory frameFactory = new DefaultFrameFactory();
         final Frame<ByteBuffer> settingsFrame = frameFactory.createSettings(
@@ -67,7 +67,7 @@ public class TestDefaultFrameFactory {
     }
 
     @Test
-    public void testResetStreamFrame() throws Exception {
+    void testResetStreamFrame() {
 
         final FrameFactory frameFactory = new DefaultFrameFactory();
         final Frame<ByteBuffer> rstStreamFrame = frameFactory.createResetStream(12, H2Error.INTERNAL_ERROR);
@@ -82,7 +82,7 @@ public class TestDefaultFrameFactory {
     }
 
     @Test
-    public void testGoAwayFrame() throws Exception {
+    void testGoAwayFrame() {
 
         final FrameFactory frameFactory = new DefaultFrameFactory();
         final Frame<ByteBuffer> goAwayFrame = frameFactory.createGoAway(13, H2Error.INTERNAL_ERROR, "Oopsie");

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/frame/TestFrameFlag.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/frame/TestFrameFlag.java
@@ -29,10 +29,10 @@ package org.apache.hc.core5.http2.frame;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestFrameFlag {
+class TestFrameFlag {
 
     @Test
-    public void testFrameFlagBasics() throws Exception {
+    void testFrameFlagBasics() {
 
         final int flags = FrameFlag.of(FrameFlag.END_STREAM, FrameFlag.PADDED, FrameFlag.PRIORITY);
         Assertions.assertEquals(0x01 | 0x08 | 0x20, flags);

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/frame/TestH2Settings.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/frame/TestH2Settings.java
@@ -31,10 +31,10 @@ import org.apache.hc.core5.http2.config.H2Setting;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestH2Settings {
+class TestH2Settings {
 
     @Test
-    public void testH2ParamBasics() throws Exception {
+    void testH2ParamBasics() {
         for (final H2Param param: H2Param.values()) {
             Assertions.assertEquals(param, H2Param.valueOf(param.getCode()));
             Assertions.assertEquals(param.name(), H2Param.toString(param.getCode()));
@@ -46,7 +46,7 @@ public class TestH2Settings {
     }
 
     @Test
-    public void testH2SettingBasics() throws Exception {
+    void testH2SettingBasics() {
 
         final H2Setting setting1 = new H2Setting(H2Param.ENABLE_PUSH, 0);
         final H2Setting setting2 = new H2Setting(H2Param.INITIAL_WINDOW_SIZE, 1024);

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestFifoBuffer.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestFifoBuffer.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.http2.hpack;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestFifoBuffer {
+class TestFifoBuffer {
 
     @Test
-    public void testAddRemoveCycle() throws Exception {
+    void testAddRemoveCycle() {
 
         final FifoBuffer fifoBuffer = new FifoBuffer(5);
 
@@ -88,7 +88,7 @@ public class TestFifoBuffer {
     }
 
     @Test
-    public void testExpand() throws Exception {
+    void testExpand() {
 
         final HPackHeader h1 = new HPackHeader("h", "1");
         final HPackHeader h2 = new HPackHeader("h", "2");

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestFifoLinkedList.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestFifoLinkedList.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.http2.hpack;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestFifoLinkedList {
+class TestFifoLinkedList {
 
     @Test
-    public void testAddRemoveCycle() throws Exception {
+    void testAddRemoveCycle() {
 
         final FifoLinkedList fifoLinkedList = new FifoLinkedList();
 
@@ -90,7 +90,7 @@ public class TestFifoLinkedList {
     }
 
     @Test
-    public void testGetIndex() throws Exception {
+    void testGetIndex() {
 
         final FifoLinkedList fifoLinkedList = new FifoLinkedList();
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestHPackCoding.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestHPackCoding.java
@@ -154,7 +154,7 @@ class TestHPackCoding {
 
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
         HPackDecoder.decodePlainString(buffer, src);
-        Assertions.assertEquals(new String(buffer.array(), 0, buffer.length(), StandardCharsets.US_ASCII), "custom-key");
+        Assertions.assertEquals("custom-key", new String(buffer.array(), 0, buffer.length(), StandardCharsets.US_ASCII));
         Assertions.assertEquals(4, src.remaining());
     }
 
@@ -188,7 +188,8 @@ class TestHPackCoding {
 
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
         HPackDecoder.decodeHuffman(buffer, src);
-        Assertions.assertEquals(new String(buffer.array(), 0, buffer.length(), StandardCharsets.US_ASCII), "www.example.com");
+        Assertions.assertEquals("www.example.com",
+                new String(buffer.array(), 0, buffer.length(), StandardCharsets.US_ASCII));
         Assertions.assertFalse(src.hasRemaining(), "Decoding completed");
     }
 
@@ -240,7 +241,7 @@ class TestHPackCoding {
             decoder.decodeString(wrap(buffer), strBuf);
             strBuf.delete(0,strBuf.length());
         }
-        Assertions.assertEquals(decoder.getTmpBufSize(), 256);
+        Assertions.assertEquals(256, decoder.getTmpBufSize());
     }
 
     static final int SWISS_GERMAN_HELLO[] = {

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestHPackCoding.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestHPackCoding.java
@@ -42,10 +42,10 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestHPackCoding {
+class TestHPackCoding {
 
     @Test
-    public void testIntegerEncodingRFC7541Examples() throws Exception {
+    void testIntegerEncodingRFC7541Examples() {
 
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
         HPackEncoder.encodeInt(buffer, 5, 10, 0x0);
@@ -82,7 +82,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testIntegerCoding() throws Exception {
+    void testIntegerCoding() throws Exception {
 
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
 
@@ -107,7 +107,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testIntegerCodingLimit() throws Exception {
+    void testIntegerCodingLimit() throws Exception {
 
         final ByteBuffer src1 = createByteBuffer(0x7f, 0x80, 0xff, 0xff, 0xff, 0x07);
         Assertions.assertEquals(Integer.MAX_VALUE, HPackDecoder.decodeInt(src1, 7));
@@ -135,7 +135,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testPlainStringDecoding() throws Exception {
+    void testPlainStringDecoding() throws Exception {
 
         final ByteBuffer src = createByteBuffer(
                 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79);
@@ -147,7 +147,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testPlainStringDecodingRemainingContent() throws Exception {
+    void testPlainStringDecodingRemainingContent() throws Exception {
 
         final ByteBuffer src = createByteBuffer(
                 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x01, 0x01, 0x01, 0x01);
@@ -159,7 +159,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testPlainStringDecodingReadOnly() throws Exception {
+    void testPlainStringDecodingReadOnly() throws Exception {
 
         final ByteBuffer src = createByteBuffer(
                 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x50, 0x50, 0x50, 0x50);
@@ -172,7 +172,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testPlainStringDecodingTruncated() throws Exception {
+    void testPlainStringDecodingTruncated() {
 
         final ByteBuffer src = createByteBuffer(
                 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65);
@@ -182,7 +182,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testHuffmanDecodingRFC7541Examples() throws Exception {
+    void testHuffmanDecodingRFC7541Examples() throws Exception {
         final ByteBuffer src = createByteBuffer(
                 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff);
 
@@ -198,7 +198,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testHuffmanEncoding() throws Exception {
+    void testHuffmanEncoding() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
         HPackEncoder.encodeHuffman(buffer, createByteBuffer("www.example.com", StandardCharsets.US_ASCII));
         final ByteBuffer expected = createByteBuffer(
@@ -207,7 +207,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testBasicStringCoding() throws Exception {
+    void testBasicStringCoding() throws Exception {
 
         final HPackEncoder encoder = new HPackEncoder(StandardCharsets.US_ASCII);
         final HPackDecoder decoder = new HPackDecoder(StandardCharsets.US_ASCII);
@@ -227,7 +227,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testEnsureCapacity() throws Exception {
+    void testEnsureCapacity() throws Exception {
 
         final HPackEncoder encoder = new HPackEncoder(StandardCharsets.US_ASCII);
         final HPackDecoder decoder = new HPackDecoder(StandardCharsets.UTF_8);
@@ -266,7 +266,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testComplexStringCoding1() throws Exception {
+    void testComplexStringCoding1() throws Exception {
 
         for (final Charset charset : new Charset[]{StandardCharsets.ISO_8859_1, StandardCharsets.UTF_8, StandardCharsets.UTF_16}) {
 
@@ -294,7 +294,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testComplexStringCoding2() throws Exception {
+    void testComplexStringCoding2() throws Exception {
 
         for (final Charset charset : new Charset[]{Charset.forName("KOI8-R"), StandardCharsets.UTF_8, StandardCharsets.UTF_16}) {
 
@@ -330,7 +330,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testLiteralHeaderWithIndexingDecodingRFC7541Examples() throws Exception {
+    void testLiteralHeaderWithIndexingDecodingRFC7541Examples() throws Exception {
 
         final ByteBuffer src = createByteBuffer(
                 0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x0d, 0x63, 0x75, 0x73,
@@ -347,7 +347,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testLiteralHeaderWithoutIndexingDecodingRFC7541Examples() throws Exception {
+    void testLiteralHeaderWithoutIndexingDecodingRFC7541Examples() throws Exception {
 
         final ByteBuffer src = createByteBuffer(
                 0x04, 0x0c, 0x2f, 0x73, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x70, 0x61, 0x74, 0x68);
@@ -362,7 +362,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testLiteralHeaderNeverIndexedDecodingRFC7541Examples() throws Exception {
+    void testLiteralHeaderNeverIndexedDecodingRFC7541Examples() throws Exception {
 
         final ByteBuffer src = createByteBuffer(
                 0x10, 0x08, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x06, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74);
@@ -377,7 +377,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testIndexedHeaderDecodingRFC7541Examples() throws Exception {
+    void testIndexedHeaderDecodingRFC7541Examples() throws Exception {
 
         final ByteBuffer src = createByteBuffer(0x82);
 
@@ -391,7 +391,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testRequestDecodingWithoutHuffmanRFC7541Examples() throws Exception {
+    void testRequestDecodingWithoutHuffmanRFC7541Examples() throws Exception {
 
         final ByteBuffer src1 = createByteBuffer(
                 0x82, 0x86, 0x84, 0x41, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e,
@@ -449,7 +449,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testRequestDecodingWithHuffmanRFC7541Examples() throws Exception {
+    void testRequestDecodingWithHuffmanRFC7541Examples() throws Exception {
 
         final ByteBuffer src1 = createByteBuffer(
                 0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff);
@@ -506,7 +506,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testResponseDecodingWithoutHuffmanRFC7541Examples() throws Exception {
+    void testResponseDecodingWithoutHuffmanRFC7541Examples() throws Exception {
 
         final ByteBuffer src1 = createByteBuffer(
                 0x48, 0x03, 0x33, 0x30, 0x32, 0x58, 0x07, 0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x61, 0x1d, 0x4d,
@@ -579,7 +579,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testResponseDecodingWithHuffmanRFC7541Examples() throws Exception {
+    void testResponseDecodingWithHuffmanRFC7541Examples() throws Exception {
 
         final ByteBuffer src1 = createByteBuffer(
                 0x48, 0x82, 0x64, 0x02, 0x58, 0x85, 0xae, 0xc3, 0x77, 0x1a, 0x4b, 0x61, 0x96, 0xd0, 0x7a, 0xbe, 0x94,
@@ -658,7 +658,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testLiteralHeaderWithIndexingEncodingRFC7541Examples() throws Exception {
+    void testLiteralHeaderWithIndexingEncodingRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         final HPackEncoder encoder = new HPackEncoder(dynamicTable, StandardCharsets.US_ASCII);
@@ -676,7 +676,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testLiteralHeaderWithoutIndexingEncodingRFC7541Examples() throws Exception {
+    void testLiteralHeaderWithoutIndexingEncodingRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         final HPackEncoder encoder = new HPackEncoder(dynamicTable, StandardCharsets.US_ASCII);
@@ -702,7 +702,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testLiteralHeaderNeverIndexedEncodingRFC7541Examples() throws Exception {
+    void testLiteralHeaderNeverIndexedEncodingRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         final HPackEncoder encoder = new HPackEncoder(dynamicTable, StandardCharsets.US_ASCII);
@@ -718,7 +718,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testIndexedHeaderEncodingRFC7541Examples() throws Exception {
+    void testIndexedHeaderEncodingRFC7541Examples() {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         final HPackEncoder encoder = new HPackEncoder(dynamicTable, StandardCharsets.US_ASCII);
@@ -731,7 +731,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testRequestEncodingWithoutHuffmanRFC7541Examples() throws Exception {
+    void testRequestEncodingWithoutHuffmanRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         final HPackEncoder encoder = new HPackEncoder(dynamicTable, StandardCharsets.US_ASCII);
@@ -796,7 +796,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testRequestEncodingWithHuffmanRFC7541Examples() throws Exception {
+    void testRequestEncodingWithHuffmanRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         final HPackEncoder encoder = new HPackEncoder(dynamicTable, StandardCharsets.US_ASCII);
@@ -860,7 +860,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testResponseEncodingWithoutHuffmanRFC7541Examples() throws Exception {
+    void testResponseEncodingWithoutHuffmanRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         dynamicTable.setMaxSize(256);
@@ -940,7 +940,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testResponseEncodingWithHuffmanRFC7541Examples() throws Exception {
+    void testResponseEncodingWithHuffmanRFC7541Examples() throws Exception {
 
         final OutboundDynamicTable dynamicTable = new OutboundDynamicTable();
         dynamicTable.setMaxSize(256);
@@ -1018,7 +1018,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testHeaderEntrySizeNonAscii() throws Exception {
+    void testHeaderEntrySizeNonAscii() throws Exception {
 
         final ByteArrayBuffer buffer = new ByteArrayBuffer(128);
         final Header header = new BasicHeader("hello", constructHelloString(SWISS_GERMAN_HELLO, 1));
@@ -1058,7 +1058,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testHeaderSizeLimit() throws Exception {
+    void testHeaderSizeLimit() throws Exception {
 
         final HPackEncoder encoder = new HPackEncoder(StandardCharsets.US_ASCII);
         final HPackDecoder decoder = new HPackDecoder(StandardCharsets.US_ASCII);
@@ -1083,7 +1083,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testHeaderEmptyASCII() throws Exception {
+    void testHeaderEmptyASCII() throws Exception {
 
         final HPackEncoder encoder = new HPackEncoder(StandardCharsets.US_ASCII);
         final HPackDecoder decoder = new HPackDecoder(StandardCharsets.US_ASCII);
@@ -1097,7 +1097,7 @@ public class TestHPackCoding {
     }
 
     @Test
-    public void testHeaderEmptyUTF8() throws Exception {
+    void testHeaderEmptyUTF8() throws Exception {
 
         final HPackEncoder encoder = new HPackEncoder(StandardCharsets.UTF_8);
         final HPackDecoder decoder = new HPackDecoder(StandardCharsets.UTF_8);

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestInboundDynamicTable.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestInboundDynamicTable.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.http2.hpack;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestInboundDynamicTable {
+class TestInboundDynamicTable {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
 
         final InboundDynamicTable table = new InboundDynamicTable();
         Assertions.assertEquals(Integer.MAX_VALUE, table.getMaxSize());
@@ -49,7 +49,7 @@ public class TestInboundDynamicTable {
     }
 
     @Test
-    public void testEviction() throws Exception {
+    void testEviction() {
 
         final InboundDynamicTable table = new InboundDynamicTable();
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestOutboundDynamicTable.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/hpack/TestOutboundDynamicTable.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.http2.hpack;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestOutboundDynamicTable {
+class TestOutboundDynamicTable {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
 
         final OutboundDynamicTable table = new OutboundDynamicTable();
         Assertions.assertEquals(Integer.MAX_VALUE, table.getMaxSize());
@@ -49,7 +49,7 @@ public class TestOutboundDynamicTable {
     }
 
     @Test
-    public void testEviction() throws Exception {
+    void testEviction() {
 
         final OutboundDynamicTable table = new OutboundDynamicTable();
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/TestDefaultH2RequestConverter.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/TestDefaultH2RequestConverter.java
@@ -41,10 +41,10 @@ import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDefaultH2RequestConverter {
+class TestDefaultH2RequestConverter {
 
     @Test
-    public void testConvertFromFieldsBasic() throws Exception {
+    void testConvertFromFieldsBasic() throws Exception {
 
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
@@ -67,7 +67,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsUpperCaseHeaderName() throws Exception {
+    void testConvertFromFieldsUpperCaseHeaderName() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -81,7 +81,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsConnectionHeader() throws Exception {
+    void testConvertFromFieldsConnectionHeader() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -95,7 +95,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsPseudoHeaderSequence() throws Exception {
+    void testConvertFromFieldsPseudoHeaderSequence() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -109,7 +109,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMissingMethod() throws Exception {
+    void testConvertFromFieldsMissingMethod() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":scheme", "http"),
                 new BasicHeader(":authority", "www.example.com"),
@@ -122,7 +122,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMissingScheme() throws Exception {
+    void testConvertFromFieldsMissingScheme() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":authority", "www.example.com"),
@@ -135,7 +135,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMissingPath() throws Exception {
+    void testConvertFromFieldsMissingPath() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -148,7 +148,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsUnknownPseudoHeader() throws Exception {
+    void testConvertFromFieldsUnknownPseudoHeader() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -162,7 +162,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMultipleMethod() throws Exception {
+    void testConvertFromFieldsMultipleMethod() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":method", "GET"),
@@ -177,7 +177,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMultipleScheme() throws Exception {
+    void testConvertFromFieldsMultipleScheme() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -192,7 +192,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMultiplePath() throws Exception {
+    void testConvertFromFieldsMultiplePath() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "https"),
@@ -207,7 +207,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsConnect() throws Exception {
+    void testConvertFromFieldsConnect() throws Exception {
 
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "CONNECT"),
@@ -219,7 +219,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsConnectMissingAuthority() throws Exception {
+    void testConvertFromFieldsConnectMissingAuthority() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "CONNECT"),
                 new BasicHeader("custom", "value"));
@@ -230,7 +230,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsConnectPresentScheme() throws Exception {
+    void testConvertFromFieldsConnectPresentScheme() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "CONNECT"),
                 new BasicHeader(":scheme", "http"),
@@ -243,7 +243,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsConnectPresentPath() throws Exception {
+    void testConvertFromFieldsConnectPresentPath() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "CONNECT"),
                 new BasicHeader(":authority", "www.example.com"),
@@ -256,7 +256,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageBasic() throws Exception {
+    void testConvertFromMessageBasic() throws Exception {
 
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("custom123", "Value");
@@ -284,7 +284,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageMissingScheme() throws Exception {
+    void testConvertFromMessageMissingScheme() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Custom123", "Value");
         request.setScheme(null);
@@ -294,7 +294,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageMissingPath() throws Exception {
+    void testConvertFromMessageMissingPath() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Custom123", "Value");
         request.setPath(null);
@@ -304,7 +304,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageConnect() throws Exception {
+    void testConvertFromMessageConnect() throws Exception {
 
         final HttpRequest request = new BasicHttpRequest("CONNECT", new HttpHost("host:80"), null);
         request.addHeader("custom123", "Value");
@@ -326,7 +326,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageConnectMissingAuthority() throws Exception {
+    void testConvertFromMessageConnectMissingAuthority() {
         final HttpRequest request = new BasicHttpRequest("CONNECT", null, null);
         request.addHeader("Custom123", "Value");
 
@@ -336,7 +336,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageConnectWithPath() throws Exception {
+    void testConvertFromMessageConnectWithPath() {
         final HttpRequest request = new BasicHttpRequest("CONNECT", "/");
         request.setAuthority(new URIAuthority("host"));
         request.addHeader("Custom123", "Value");
@@ -347,7 +347,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageConnectionHeader() throws Exception {
+    void testConvertFromMessageConnectionHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Connection", "Keep-Alive");
 
@@ -357,7 +357,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsKeepAliveHeader() throws Exception {
+    void testConvertFromFieldsKeepAliveHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Keep-Alive", "timeout=5, max=1000");
 
@@ -367,7 +367,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsProxyConnectionHeader() throws Exception {
+    void testConvertFromFieldsProxyConnectionHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Proxy-Connection", "keep-alive");
 
@@ -377,7 +377,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsTransferEncodingHeader() throws Exception {
+    void testConvertFromFieldsTransferEncodingHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Transfer-Encoding", "gzip");
 
@@ -387,7 +387,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsHostHeader() throws Exception {
+    void testConvertFromFieldsHostHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Host", "host");
 
@@ -397,7 +397,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsUpgradeHeader() throws Exception {
+    void testConvertFromFieldsUpgradeHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("Upgrade", "example/1, foo/2");
 
@@ -407,7 +407,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsTEHeader() throws Exception {
+    void testConvertFromFieldsTEHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader("TE", "gzip");
 
@@ -417,7 +417,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromFieldsTETrailerHeader() throws Exception {
+    void testConvertFromFieldsTETrailerHeader() throws Exception {
 
         final List<Header> headers = Arrays.asList(
             new BasicHeader(":method", "GET"),
@@ -440,7 +440,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testConvertFromMessageInvalidHeader() throws Exception {
+    void testConvertFromMessageInvalidHeader() {
         final HttpRequest request = new BasicHttpRequest("GET", new HttpHost("host"), "/");
         request.addHeader(":custom", "stuff");
 
@@ -451,7 +451,7 @@ public class TestDefaultH2RequestConverter {
 
 
     @Test
-    public void testValidPath() throws Exception {
+    void testValidPath() throws Exception {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -469,7 +469,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testInvalidPathEmpty() {
+    void testInvalidPathEmpty() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -483,7 +483,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testInvalidPathNoSlash() {
+    void testInvalidPathNoSlash() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "GET"),
                 new BasicHeader(":scheme", "http"),
@@ -497,7 +497,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testValidOptionsAsterisk() throws Exception {
+    void testValidOptionsAsterisk() throws Exception {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "OPTIONS"),
                 new BasicHeader(":scheme", "http"),
@@ -513,7 +513,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testValidOptionsWithRootPath() throws HttpException {
+    void testValidOptionsWithRootPath() throws HttpException {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "OPTIONS"),
                 new BasicHeader(":scheme", "http"),
@@ -529,7 +529,7 @@ public class TestDefaultH2RequestConverter {
     }
 
     @Test
-    public void testInvalidOptionsNeitherAsteriskNorRoot() {
+    void testInvalidOptionsNeitherAsteriskNorRoot() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":method", "OPTIONS"),
                 new BasicHeader(":scheme", "http"),

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/TestDefaultH2ResponseConverter.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/TestDefaultH2ResponseConverter.java
@@ -38,10 +38,10 @@ import org.apache.hc.core5.http.message.BasicHttpResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDefaultH2ResponseConverter {
+class TestDefaultH2ResponseConverter {
 
     @Test
-    public void testConvertFromFieldsBasic() throws Exception {
+    void testConvertFromFieldsBasic() throws Exception {
 
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":status", "200"),
@@ -61,7 +61,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsUpperCaseHeaderName() throws Exception {
+    void testConvertFromFieldsUpperCaseHeaderName() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":Status", "200"),
                 new BasicHeader("location", "http://www.example.com/"),
@@ -73,7 +73,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsInvalidStatusCode() throws Exception {
+    void testConvertFromFieldsInvalidStatusCode() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":status", "boom"),
                 new BasicHeader("location", "http://www.example.com/"),
@@ -84,7 +84,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsConnectionHeader() throws Exception {
+    void testConvertFromFieldsConnectionHeader() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":status", "200"),
                 new BasicHeader("location", "http://www.example.com/"),
@@ -96,7 +96,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsKeepAliveHeader() throws Exception {
+    void testConvertFromFieldsKeepAliveHeader() {
         final List<Header> headers = Arrays.asList(
             new BasicHeader(":status", "200"),
             new BasicHeader("location", "http://www.example.com/"),
@@ -108,7 +108,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsTransferEncodingHeader() throws Exception {
+    void testConvertFromFieldsTransferEncodingHeader() {
         final List<Header> headers = Arrays.asList(
             new BasicHeader(":status", "200"),
             new BasicHeader("location", "http://www.example.com/"),
@@ -120,7 +120,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsUpgradeHeader() throws Exception {
+    void testConvertFromFieldsUpgradeHeader() {
         final List<Header> headers = Arrays.asList(
             new BasicHeader(":status", "200"),
             new BasicHeader("location", "http://www.example.com/"),
@@ -132,7 +132,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMissingStatus() throws Exception {
+    void testConvertFromFieldsMissingStatus() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader("location", "http://www.example.com/"),
                 new BasicHeader("custom", "value"));
@@ -143,7 +143,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsUnknownPseudoHeader() throws Exception {
+    void testConvertFromFieldsUnknownPseudoHeader() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":status", "200"),
                 new BasicHeader(":custom", "200"),
@@ -156,7 +156,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromFieldsMultipleStatus() throws Exception {
+    void testConvertFromFieldsMultipleStatus() {
         final List<Header> headers = Arrays.asList(
                 new BasicHeader(":status", "200"),
                 new BasicHeader(":status", "200"),
@@ -169,7 +169,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromMessageBasic() throws Exception {
+    void testConvertFromMessageBasic() throws Exception {
 
         final HttpResponse response = new BasicHttpResponse(200);
         response.addHeader("custom123", "Value");
@@ -188,7 +188,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromMessageInvalidStatus() throws Exception {
+    void testConvertFromMessageInvalidStatus() {
         final HttpResponse response = new BasicHttpResponse(99);
         response.addHeader("Custom123", "Value");
 
@@ -198,7 +198,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromMessageConnectionHeader() throws Exception {
+    void testConvertFromMessageConnectionHeader() {
         final HttpResponse response = new BasicHttpResponse(200);
         response.addHeader("Connection", "Keep-Alive");
 
@@ -208,7 +208,7 @@ public class TestDefaultH2ResponseConverter {
     }
 
     @Test
-    public void testConvertFromMessageInvalidHeader() throws Exception {
+    void testConvertFromMessageInvalidHeader() {
         final HttpResponse response = new BasicHttpResponse(200);
         response.addHeader(":custom", "stuff");
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/io/TestFrameInOutBuffers.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/io/TestFrameInOutBuffers.java
@@ -42,10 +42,10 @@ import org.apache.hc.core5.http2.impl.BasicH2TransportMetrics;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestFrameInOutBuffers {
+class TestFrameInOutBuffers {
 
     @Test
-    public void testReadWriteFrame() throws Exception {
+    void testReadWriteFrame() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(16 * 1024);
 
@@ -80,7 +80,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameMultiple() throws Exception {
+    void testReadFrameMultiple() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(
                 new byte[] {
@@ -118,7 +118,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameMultipleSmallBuffer() throws Exception {
+    void testReadFrameMultipleSmallBuffer() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(new BasicH2TransportMetrics(), 20, 10);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(
                 new byte[] {
@@ -170,7 +170,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFramePartialReads() throws Exception {
+    void testReadFramePartialReads() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final MultiByteArrayInputStream inputStream = new MultiByteArrayInputStream(
                 new byte[] {0,0},
@@ -197,7 +197,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadEmptyFrame() throws Exception {
+    void testReadEmptyFrame() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {0,0,0,0,0,0,0,0,0});
 
@@ -210,7 +210,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameConnectionClosed() throws Exception {
+    void testReadFrameConnectionClosed() {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {});
 
@@ -218,7 +218,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameCorruptFrame() throws Exception {
+    void testReadFrameCorruptFrame() {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {0,0});
 
@@ -226,7 +226,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testWriteFrameExceedingLimit() throws Exception {
+    void testWriteFrameExceedingLimit() {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(1024);
 
@@ -236,7 +236,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameExceedingLimit() throws Exception {
+    void testReadFrameExceedingLimit() {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(
                 new byte[] {0,-128,-128,0,0,0,0,0,1});

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/TestAbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/TestAbstractH2StreamMultiplexer.java
@@ -53,7 +53,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class TestAbstractH2StreamMultiplexer {
+class TestAbstractH2StreamMultiplexer {
 
     @Mock
     ProtocolIOSession protocolIOSession;
@@ -63,7 +63,7 @@ public class TestAbstractH2StreamMultiplexer {
     H2StreamListener h2StreamListener;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
     }
 
@@ -112,7 +112,7 @@ public class TestAbstractH2StreamMultiplexer {
     }
 
     @Test
-    public void testInputOneFrame() throws Exception {
+    void testInputOneFrame() throws Exception {
         final WritableByteChannelMock writableChannel = new WritableByteChannelMock(1024);
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(16 * 1024);
 
@@ -161,7 +161,7 @@ public class TestAbstractH2StreamMultiplexer {
     }
 
     @Test
-    public void testInputMultipleFrames() throws Exception {
+    void testInputMultipleFrames() throws Exception {
         final WritableByteChannelMock writableChannel = new WritableByteChannelMock(1024);
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(16 * 1024);
 

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/TestFrameInOutBuffers.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/TestFrameInOutBuffers.java
@@ -42,10 +42,10 @@ import org.apache.hc.core5.http2.impl.BasicH2TransportMetrics;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestFrameInOutBuffers {
+class TestFrameInOutBuffers {
 
     @Test
-    public void testReadWriteFrame() throws Exception {
+    void testReadWriteFrame() throws Exception {
         final WritableByteChannelMock writableChannel = new WritableByteChannelMock(1024);
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(16 * 1024);
 
@@ -96,7 +96,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testPartialFrameWrite() throws Exception {
+    void testPartialFrameWrite() throws Exception {
         final WritableByteChannelMock writableChannel = new WritableByteChannelMock(1024, FrameConsts.HEAD_LEN + 10);
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(16 * 1024);
         final RawFrame frame = new RawFrame(FrameType.DATA.getValue(), FrameFlag.END_STREAM.getValue(), 5,
@@ -118,7 +118,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameMultiple() throws Exception {
+    void testReadFrameMultiple() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(
                 new byte[] {
@@ -156,7 +156,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameMultipleSmallBuffer() throws Exception {
+    void testReadFrameMultipleSmallBuffer() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(new BasicH2TransportMetrics(), 20, 10);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(
                 new byte[] {
@@ -208,7 +208,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFramePartialReads() throws Exception {
+    void testReadFramePartialReads() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(
                 new byte[] {0,0},
@@ -236,7 +236,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadEmptyFrame() throws Exception {
+    void testReadEmptyFrame() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(
                 new byte[] {0,0,0,0,0,0,0,0,0});
@@ -250,7 +250,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameConnectionClosed() throws Exception {
+    void testReadFrameConnectionClosed() throws Exception {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(new byte[] {});
 
@@ -260,7 +260,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameCorruptFrame() throws Exception {
+    void testReadFrameCorruptFrame() {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(new byte[] {0,0});
 
@@ -269,7 +269,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testWriteFrameExceedingLimit() throws Exception {
+    void testWriteFrameExceedingLimit() {
         final WritableByteChannelMock writableChannel = new WritableByteChannelMock(1024);
         final FrameOutputBuffer outbuffer = new FrameOutputBuffer(1024);
 
@@ -280,7 +280,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testReadFrameExceedingLimit() throws Exception {
+    void testReadFrameExceedingLimit() {
         final FrameInputBuffer inBuffer = new FrameInputBuffer(16 * 1024);
         final ReadableByteChannelMock readableChannel = new ReadableByteChannelMock(
                 new byte[] {0,-128,-128,0,0,0,0,0,1});
@@ -290,7 +290,7 @@ public class TestFrameInOutBuffers {
     }
 
     @Test
-    public void testOutputBufferResize() throws Exception {
+    void testOutputBufferResize() {
         final FrameOutputBuffer outBuffer = new FrameOutputBuffer(16 * 1024);
         Assertions.assertEquals(16 * 1024, outBuffer.getMaxFramePayloadSize());
         outBuffer.resize(1024);

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/protocol/TestH2Interceptors.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/protocol/TestH2Interceptors.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestH2Interceptors {
+class TestH2Interceptors {
 
     /**
      * HTTP context.
@@ -53,13 +53,13 @@ public class TestH2Interceptors {
 
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_2);
     }
 
     @Test
-    public void testH2RequestContentProtocolException() {
+    void testH2RequestContentProtocolException() {
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.TRACE, "/");
         request.addHeader(new BasicHeader(HttpHeaders.TRANSFER_ENCODING, "chunked"));
         request.setEntity(new StringEntity("whatever", StandardCharsets.US_ASCII));
@@ -70,7 +70,7 @@ public class TestH2Interceptors {
     }
 
     @Test
-    public void testH2RequestContentNullEntity() throws Exception {
+    void testH2RequestContentNullEntity() throws Exception {
 
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         final HttpRequestInterceptor interceptor = H2RequestContent.INSTANCE;
@@ -82,7 +82,7 @@ public class TestH2Interceptors {
 
 
     @Test
-    public void testH2RequestContentValid() throws Exception {
+    void testH2RequestContentValid() throws Exception {
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
 
         // Create a mock entity with ContentType, ContentEncoding, and TrailerNames
@@ -101,7 +101,7 @@ public class TestH2Interceptors {
     }
 
     @Test
-    public void testH2RequestContentOptionMethodNullContentTypeProtocolException() {
+    void testH2RequestContentOptionMethodNullContentTypeProtocolException() {
         final H2RequestContent interceptor = new H2RequestContent();
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.OPTIONS, "/");
@@ -113,7 +113,7 @@ public class TestH2Interceptors {
     }
 
     @Test
-    public void testH2RequestContentOptionMethodInvalidContentTypeProtocolException() {
+    void testH2RequestContentOptionMethodInvalidContentTypeProtocolException() {
         final H2RequestContent interceptor = new H2RequestContent();
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.OPTIONS, "/");
@@ -126,7 +126,7 @@ public class TestH2Interceptors {
     }
 
     @Test
-    public void testH2RequestContentValidOptionsMethod() throws Exception {
+    void testH2RequestContentValidOptionsMethod() throws Exception {
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.OPTIONS, "/");
 
         // Create a mock entity with ContentType, ContentEncoding, and TrailerNames

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/ssl/ConscryptClientTlsStrategyTest.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/ssl/ConscryptClientTlsStrategyTest.java
@@ -41,7 +41,7 @@ class ConscryptClientTlsStrategyTest {
     private SSLSessionVerifier sslSessionVerifier;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
     }
 

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
@@ -46,10 +46,10 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-public class TestReactiveDataConsumer {
+class TestReactiveDataConsumer {
 
     @Test
-    public void testStreamThatEndsNormally() throws Exception {
+    void testStreamThatEndsNormally() throws Exception {
         final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
 
         final List<ByteBuffer> output = Collections.synchronizedList(new ArrayList<>());
@@ -80,7 +80,7 @@ public class TestReactiveDataConsumer {
     }
 
     @Test
-    public void testStreamThatEndsWithError() {
+    void testStreamThatEndsWithError() {
         final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
         final Single<List<Notification<ByteBuffer>>> single = Observable.fromPublisher(consumer)
             .materialize()
@@ -93,7 +93,7 @@ public class TestReactiveDataConsumer {
     }
 
     @Test
-    public void testCancellation() throws Exception {
+    void testCancellation() {
         final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
         consumer.subscribe(new Subscriber<ByteBuffer>() {
             @Override
@@ -119,7 +119,7 @@ public class TestReactiveDataConsumer {
     }
 
     @Test
-    public void testCapacityIncrements() throws Exception {
+    void testCapacityIncrements() throws Exception {
         final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
         final ByteBuffer data = ByteBuffer.wrap(new byte[1024]);
 
@@ -166,7 +166,7 @@ public class TestReactiveDataConsumer {
     }
 
     @Test
-    public void testFullResponseBuffering() throws Exception {
+    void testFullResponseBuffering() throws Exception {
         // Due to inherent race conditions, is possible for the entire response to be buffered and completed before
         // the Subscriber shows up. This must be handled correctly.
         final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
@@ -181,7 +181,7 @@ public class TestReactiveDataConsumer {
     }
 
     @Test
-    public void testErrorBuffering() throws Exception {
+    void testErrorBuffering() throws Exception {
         final ReactiveDataConsumer consumer = new ReactiveDataConsumer();
         final ByteBuffer data = ByteBuffer.wrap(new byte[1024]);
 
@@ -199,7 +199,7 @@ public class TestReactiveDataConsumer {
     }
 
     @Test
-    public void testFailAfterCompletion() {
+    void testFailAfterCompletion() {
         // Calling consumer.failed() after consumer.streamEnd() must be a no-op.
         // The exception must be discarded, and the subscriber must see that
         // the stream was successfully completed.

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataConsumer.java
@@ -177,7 +177,7 @@ class TestReactiveDataConsumer {
         consumer.consume(data.duplicate());
         consumer.streamEnd(null);
 
-        Assertions.assertEquals(Flowable.fromPublisher(consumer).count().blockingGet().longValue(), 3L);
+        Assertions.assertEquals(3L, Flowable.fromPublisher(consumer).count().blockingGet().longValue());
     }
 
     @Test

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataProducer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveDataProducer.java
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava3.core.Flowable;
 
-public class TestReactiveDataProducer {
+class TestReactiveDataProducer {
     @Test
-    public void testStreamThatEndsNormally() throws Exception {
+    void testStreamThatEndsNormally() throws Exception {
         final Flowable<ByteBuffer> publisher = Flowable.just(
             ByteBuffer.wrap(new byte[]{ '1', '2', '3' }),
             ByteBuffer.wrap(new byte[]{ '4', '5', '6' }));
@@ -59,7 +59,7 @@ public class TestReactiveDataProducer {
     }
 
     @Test
-    public void testStreamThatEndsWithError() throws Exception {
+    void testStreamThatEndsWithError() throws Exception {
         final Flowable<ByteBuffer> publisher = Flowable.concatArray(
             Flowable.just(
                 ByteBuffer.wrap(new byte[]{ '1' }),

--- a/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveEntityProducer.java
+++ b/httpcore5-reactive/src/test/java/org/apache/hc/core5/reactive/TestReactiveEntityProducer.java
@@ -38,14 +38,14 @@ import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava3.core.Flowable;
 
-public class TestReactiveEntityProducer {
+class TestReactiveEntityProducer {
 
     private static final long CONTENT_LENGTH = 1;
     private static final ContentType CONTENT_TYPE = ContentType.APPLICATION_JSON;
     private static final String GZIP_CONTENT_ENCODING = "gzip";
 
     @Test
-    public void testStreamThatEndsNormally() throws Exception {
+    void testStreamThatEndsNormally() throws Exception {
         final Flowable<ByteBuffer> publisher = Flowable.just(
                 ByteBuffer.wrap(new byte[]{'1', '2', '3'}),
                 ByteBuffer.wrap(new byte[]{'4', '5', '6'}));
@@ -76,7 +76,7 @@ public class TestReactiveEntityProducer {
 
     @Test
 
-    public void testStreamThatEndsWithError() throws Exception {
+    void testStreamThatEndsWithError() throws Exception {
         final Flowable<ByteBuffer> publisher = Flowable.concatArray(
                 Flowable.just(
                         ByteBuffer.wrap(new byte[]{'1'}),

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/BenchmarkToolTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/BenchmarkToolTest.java
@@ -61,7 +61,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class BenchmarkToolTest {
+class BenchmarkToolTest {
 
     public static Stream<Arguments> protocols() {
         return Stream.of(
@@ -73,7 +73,7 @@ public class BenchmarkToolTest {
     private HttpAsyncServer server;
     private InetSocketAddress address;
 
-    public void setup(final HttpVersionPolicy versionPolicy) throws Exception {
+    void setup(final HttpVersionPolicy versionPolicy) throws Exception {
         server = H2ServerBootstrap.bootstrap()
                 .setRequestRouter(RequestRouter.<Supplier<AsyncServerExchangeHandler>>builder()
                         .addRoute(RequestRouter.LOCAL_AUTHORITY, "*", () -> new BasicServerExchangeHandler<>(
@@ -111,7 +111,7 @@ public class BenchmarkToolTest {
     }
 
     @AfterEach
-    public void shutdown() throws Exception {
+    void shutdown() {
         if (server != null) {
             server.close(CloseMode.IMMEDIATE);
         }
@@ -120,7 +120,7 @@ public class BenchmarkToolTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("protocols")
-    public void testBasics(final HttpVersionPolicy versionPolicy) throws Exception {
+    void testBasics(final HttpVersionPolicy versionPolicy) throws Exception {
         setup(versionPolicy);
         final BenchmarkConfig config = BenchmarkConfig.custom()
                 .setKeepAlive(true)

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/ResultFormatterTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/ResultFormatterTest.java
@@ -36,10 +36,10 @@ import org.apache.hc.core5.http.HttpVersion;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
-public class ResultFormatterTest {
+class ResultFormatterTest {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final Results results = new Results(
                 "TestServer/1.1",
                 HttpVersion.HTTP_1_1,

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicAuthenticationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicAuthenticationTest.java
@@ -65,7 +65,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class ClassicAuthenticationTest {
+abstract class ClassicAuthenticationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -124,7 +124,7 @@ public abstract class ClassicAuthenticationTest {
     }
 
     @Test
-    public void testGetRequestAuthentication() throws Exception {
+    void testGetRequestAuthentication() throws Exception {
         final HttpServer server = serverResource.start();
         final HttpRequester requester = clientResource.start();
 
@@ -146,7 +146,7 @@ public abstract class ClassicAuthenticationTest {
     }
 
     @Test
-    public void testPostRequestAuthentication() throws Exception {
+    void testPostRequestAuthentication() throws Exception {
         final HttpServer server = serverResource.start();
         final HttpRequester requester = clientResource.start();
 
@@ -175,7 +175,7 @@ public abstract class ClassicAuthenticationTest {
     }
 
     @Test
-    public void testPostRequestAuthenticationNoExpectContinue() throws Exception {
+    void testPostRequestAuthenticationNoExpectContinue() throws Exception {
         final HttpServer server = serverResource.start();
         final HttpRequester requester = clientResource.start();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicHttp1CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicHttp1CoreTransportTest.java
@@ -46,7 +46,7 @@ import org.apache.hc.core5.testing.extension.classic.HttpServerResource;
 import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class ClassicHttp1CoreTransportTest extends ClassicHttpCoreTransportTest {
+abstract class ClassicHttp1CoreTransportTest extends ClassicHttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicHttp1SocksProxyCoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicHttp1SocksProxyCoreTransportTest.java
@@ -48,7 +48,7 @@ import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class ClassicHttp1SocksProxyCoreTransportTest extends ClassicHttpCoreTransportTest {
+abstract class ClassicHttp1SocksProxyCoreTransportTest extends ClassicHttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicHttpCoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicHttpCoreTransportTest.java
@@ -55,7 +55,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public abstract class ClassicHttpCoreTransportTest {
+abstract class ClassicHttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -70,7 +70,7 @@ public abstract class ClassicHttpCoreTransportTest {
     abstract HttpRequester clientStart() throws IOException;
 
     @Test
-    public void testSequentialRequests() throws Exception {
+    void testSequentialRequests() throws Exception {
         final HttpServer server = serverStart();
         final HttpRequester requester = clientStart();
 
@@ -100,7 +100,7 @@ public abstract class ClassicHttpCoreTransportTest {
     }
 
     @Test
-    public void testSequentialRequestsNonPersistentConnection() throws Exception {
+    void testSequentialRequestsNonPersistentConnection() throws Exception {
         final HttpServer server = serverStart();
         final HttpRequester requester = clientStart();
 
@@ -130,7 +130,7 @@ public abstract class ClassicHttpCoreTransportTest {
     }
 
     @Test
-    public void testMultiThreadedRequests() throws Exception {
+    void testMultiThreadedRequests() throws Exception {
         final HttpServer server = serverStart();
         final HttpRequester requester = clientStart();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicIntegrationTest.java
@@ -73,7 +73,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class ClassicIntegrationTest {
+abstract class ClassicIntegrationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -90,7 +90,7 @@ public abstract class ClassicIntegrationTest {
      * This test case executes a series of simple GET requests
      */
     @Test
-    public void testSimpleBasicHttpRequests() throws Exception {
+    void testSimpleBasicHttpRequests() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -146,7 +146,7 @@ public abstract class ClassicIntegrationTest {
      * delimited content.
      */
     @Test
-    public void testSimpleHttpPostsWithContentLength() throws Exception {
+    void testSimpleHttpPostsWithContentLength() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -201,7 +201,7 @@ public abstract class ClassicIntegrationTest {
      * coded content content.
      */
     @Test
-    public void testSimpleHttpPostsChunked() throws Exception {
+    void testSimpleHttpPostsChunked() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -255,7 +255,7 @@ public abstract class ClassicIntegrationTest {
      * This test case executes a series of simple HTTP/1.0 POST requests.
      */
     @Test
-    public void testSimpleHttpPostsHTTP10() throws Exception {
+    void testSimpleHttpPostsHTTP10() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -312,7 +312,7 @@ public abstract class ClassicIntegrationTest {
      * HTTP/1.0 compatible requests.
      */
     @Test
-    public void testHTTP11FeaturesDisabledWithHTTP10Requests() throws Exception {
+    void testHTTP11FeaturesDisabledWithHTTP10Requests() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -338,7 +338,7 @@ public abstract class ClassicIntegrationTest {
      * the 'expect: continue' handshake.
      */
     @Test
-    public void testHttpPostsWithExpectContinue() throws Exception {
+    void testHttpPostsWithExpectContinue() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -393,7 +393,7 @@ public abstract class ClassicIntegrationTest {
      * meet the target server expectations.
      */
     @Test
-    public void testHttpPostsWithExpectationVerification() throws Exception {
+    void testHttpPostsWithExpectationVerification() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -504,7 +504,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testHttpContent() throws Exception {
+    void testHttpContent() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -590,7 +590,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testHttpPostNoEntity() throws Exception {
+    void testHttpPostNoEntity() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -620,7 +620,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testHttpPostNoContentLength() throws Exception {
+    void testHttpPostNoContentLength() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -655,7 +655,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testHttpPostIdentity() throws Exception {
+    void testHttpPostIdentity() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -689,7 +689,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testNoContentResponse() throws Exception {
+    void testNoContentResponse() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -713,7 +713,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testHeaderTooLarge() throws Exception {
+    void testHeaderTooLarge() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 
@@ -739,7 +739,7 @@ public abstract class ClassicIntegrationTest {
     }
 
     @Test
-    public void testHeaderTooLargePost() throws Exception {
+    void testHeaderTooLargePost() throws Exception {
         final ClassicTestServer server = testResources.server();
         final ClassicTestClient client = testResources.client();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicIntegrationTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicIntegrationTests.java
@@ -31,11 +31,11 @@ import org.apache.hc.core5.http.URIScheme;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
-public class ClassicIntegrationTests {
+class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Core transport")
-    public class CoreTransport extends ClassicHttp1CoreTransportTest {
+    class CoreTransport extends ClassicHttp1CoreTransportTest {
 
         public CoreTransport() {
             super(URIScheme.HTTP);
@@ -45,7 +45,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (TLS)")
-    public class CoreTransportTls extends ClassicHttp1CoreTransportTest {
+    class CoreTransportTls extends ClassicHttp1CoreTransportTest {
 
         public CoreTransportTls() {
             super(URIScheme.HTTPS);
@@ -55,7 +55,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Authentication")
-    public class Authentication extends ClassicAuthenticationTest {
+    class Authentication extends ClassicAuthenticationTest {
 
         public Authentication() {
             super(false);
@@ -65,7 +65,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Authentication (immediate response)")
-    public class AuthenticationImmediateResponse extends ClassicAuthenticationTest {
+    class AuthenticationImmediateResponse extends ClassicAuthenticationTest {
 
         public AuthenticationImmediateResponse() {
             super(true);
@@ -75,7 +75,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Out-of-order response monitoring")
-    public class MonitoringResponseOutOfOrderStrategy extends MonitoringResponseOutOfOrderStrategyIntegrationTest {
+    class MonitoringResponseOutOfOrderStrategy extends MonitoringResponseOutOfOrderStrategyIntegrationTest {
 
         public MonitoringResponseOutOfOrderStrategy() {
             super(URIScheme.HTTP);
@@ -85,7 +85,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Out-of-order response monitoring (TLS)")
-    public class MonitoringResponseOutOfOrderStrategyTls extends MonitoringResponseOutOfOrderStrategyIntegrationTest {
+    class MonitoringResponseOutOfOrderStrategyTls extends MonitoringResponseOutOfOrderStrategyIntegrationTest {
 
         public MonitoringResponseOutOfOrderStrategyTls() {
             super(URIScheme.HTTPS);
@@ -95,7 +95,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Server filters")
-    public class HttpFilters extends ClassicServerBootstrapFilterTest {
+    class HttpFilters extends ClassicServerBootstrapFilterTest {
 
         public HttpFilters() {
             super(URIScheme.HTTP);
@@ -105,7 +105,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (SOCKS)")
-    public class CoreTransportSocksProxy extends ClassicHttp1SocksProxyCoreTransportTest {
+    class CoreTransportSocksProxy extends ClassicHttp1SocksProxyCoreTransportTest {
 
         public CoreTransportSocksProxy() {
             super(URIScheme.HTTP);
@@ -115,7 +115,7 @@ public class ClassicIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (TLS, SOCKS)")
-    public class CoreTransportSocksProxyTls extends ClassicHttp1SocksProxyCoreTransportTest {
+    class CoreTransportSocksProxyTls extends ClassicHttp1SocksProxyCoreTransportTest {
 
         public CoreTransportSocksProxyTls() {
             super(URIScheme.HTTPS);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicProtocolTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicProtocolTests.java
@@ -31,11 +31,11 @@ import org.apache.hc.core5.http.URIScheme;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
-public class ClassicProtocolTests {
+class ClassicProtocolTests {
 
     @Nested
     @DisplayName("Classic HTTP/1.1 (plain)")
-    public class Http1 extends ClassicIntegrationTest {
+    class Http1 extends ClassicIntegrationTest {
 
         public Http1() {
             super(URIScheme.HTTP);
@@ -45,7 +45,7 @@ public class ClassicProtocolTests {
 
     @Nested
     @DisplayName("Classic HTTP/1.1 (TLS)")
-    public class Http1Tls extends ClassicIntegrationTest {
+    class Http1Tls extends ClassicIntegrationTest {
 
         public Http1Tls() {
             super(URIScheme.HTTPS);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicServerBootstrapFilterTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicServerBootstrapFilterTest.java
@@ -56,7 +56,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class ClassicServerBootstrapFilterTest {
+abstract class ClassicServerBootstrapFilterTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -103,7 +103,7 @@ public abstract class ClassicServerBootstrapFilterTest {
     }
 
     @Test
-    public void testFilters() throws Exception {
+    void testFilters() throws Exception {
         final HttpServer server = serverResource.start();
         final HttpRequester requester = clientResource.start();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicTLSIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicTLSIntegrationTest.java
@@ -66,7 +66,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ClassicTLSIntegrationTest {
+class ClassicTLSIntegrationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofSeconds(30);
 
@@ -105,7 +105,7 @@ public class ClassicTLSIntegrationTest {
     };
 
     @Test
-    public void testTLSSuccess() throws Exception {
+    void testTLSSuccess() throws Exception {
         server = ServerBootstrap.bootstrap()
                 .setSocketConfig(SocketConfig.custom()
                         .setSoTimeout(TIMEOUT)
@@ -150,7 +150,7 @@ public class ClassicTLSIntegrationTest {
     }
 
     @Test
-    public void testTLSTrustFailure() throws Exception {
+    void testTLSTrustFailure() throws Exception {
         server = ServerBootstrap.bootstrap()
                 .setSocketConfig(SocketConfig.custom()
                         .setSoTimeout(TIMEOUT)
@@ -183,7 +183,7 @@ public class ClassicTLSIntegrationTest {
     }
 
     @Test
-    public void testTLSClientAuthFailure() throws Exception {
+    void testTLSClientAuthFailure() throws Exception {
         server = ServerBootstrap.bootstrap()
                 .setSslContext(SSLTestContexts.createClientSSLContext())
                 .setSocketConfig(SocketConfig.custom()
@@ -218,7 +218,7 @@ public class ClassicTLSIntegrationTest {
     }
 
     @Test
-    public void testSSLDisabledByDefault() throws Exception {
+    void testSSLDisabledByDefault() throws Exception {
         server = ServerBootstrap.bootstrap()
                 .setSslContext(SSLTestContexts.createServerSSLContext())
                 .setSslSetupHandler(sslParameters -> sslParameters.setProtocols(new String[]{"SSLv3"}))
@@ -247,7 +247,7 @@ public class ClassicTLSIntegrationTest {
     }
 
     @Test
-    public void testWeakCiphersDisabledByDefault() throws Exception {
+    void testWeakCiphersDisabledByDefault() throws Exception {
 
         requester = RequesterBootstrap.bootstrap()
                 .setSslContext(SSLTestContexts.createClientSSLContext())
@@ -300,7 +300,7 @@ public class ClassicTLSIntegrationTest {
     }
 
     @Test
-    public void testHostNameVerification() throws Exception {
+    void testHostNameVerification() throws Exception {
         server = ServerBootstrap.bootstrap()
                 .setSslContext(SSLTestContexts.createServerSSLContext())
                 .setRequestRouter((r, c) -> null)

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/MonitoringResponseOutOfOrderStrategyIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/MonitoringResponseOutOfOrderStrategyIntegrationTest.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class MonitoringResponseOutOfOrderStrategyIntegrationTest {
+abstract class MonitoringResponseOutOfOrderStrategyIntegrationTest {
 
     // Use a 16k buffer for consistent results across systems
     private static final int BUFFER_SIZE = 16 * 1024;
@@ -102,7 +102,7 @@ public abstract class MonitoringResponseOutOfOrderStrategyIntegrationTest {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 1, unit = TimeUnit.MINUTES)// Failures may hang
-    public void testResponseOutOfOrderWithDefaultStrategy() throws Exception {
+    void testResponseOutOfOrderWithDefaultStrategy() throws Exception {
         final HttpServer server = serverResource.start();
         final HttpRequester requester = clientResource.start();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/H2CompatibilityTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/H2CompatibilityTest.java
@@ -96,7 +96,7 @@ public class H2CompatibilityTest {
         }
     }
 
-    H2CompatibilityTest() throws Exception {
+    H2CompatibilityTest() {
         this.client = H2RequesterBootstrap.bootstrap()
                 .setIOReactorConfig(IOReactorConfig.custom()
                         .setSoTimeout(TIMEOUT)
@@ -113,11 +113,11 @@ public class H2CompatibilityTest {
                 .create();
     }
 
-    void start() throws Exception {
+    void start() {
         client.start();
     }
 
-    void shutdown() throws Exception {
+    void shutdown() {
         client.close(CloseMode.GRACEFUL);
     }
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/HttpBinIT.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/http2/HttpBinIT.java
@@ -32,22 +32,22 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class HttpBinIT {
+class HttpBinIT {
     private H2CompatibilityTest h2CompatibilityTest;
 
     @BeforeEach
-    public void start() throws Exception {
+    void start() throws Exception {
         h2CompatibilityTest = new H2CompatibilityTest();
         h2CompatibilityTest.start();
     }
 
     @AfterEach
-    public void shutdown() throws Exception {
+    void shutdown() throws Exception {
         h2CompatibilityTest.shutdown();
     }
 
     @Test
-    public void executeHttpBin() throws Exception {
+    void executeHttpBin() throws Exception {
         h2CompatibilityTest.executeHttpBin(new HttpHost("http", "localhost", 8082));
     }
 }

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/extension/nio/H2AsyncServerResource.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/extension/nio/H2AsyncServerResource.java
@@ -27,7 +27,6 @@
 
 package org.apache.hc.core5.testing.extension.nio;
 
-import java.io.IOException;
 import java.util.function.Consumer;
 
 import org.apache.hc.core5.http.impl.bootstrap.HttpAsyncServer;
@@ -85,7 +84,7 @@ public class H2AsyncServerResource implements BeforeEachCallback, AfterEachCallb
         }
     }
 
-    public HttpAsyncServer start() throws IOException {
+    public HttpAsyncServer start() {
         Assertions.assertNotNull(server);
         server.start();
         return server;

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/extension/nio/HttpAsyncServerResource.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/extension/nio/HttpAsyncServerResource.java
@@ -27,7 +27,6 @@
 
 package org.apache.hc.core5.testing.extension.nio;
 
-import java.io.IOException;
 import java.util.function.Consumer;
 
 import org.apache.hc.core5.http.impl.bootstrap.AsyncServerBootstrap;
@@ -83,7 +82,7 @@ public class HttpAsyncServerResource implements BeforeEachCallback, AfterEachCal
         }
     }
 
-    public HttpAsyncServer start() throws IOException {
+    public HttpAsyncServer start() {
         Assertions.assertNotNull(server);
         server.start();
         return server;

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClassicTestClientTestingAdapter.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClassicTestClientTestingAdapter.java
@@ -217,7 +217,7 @@ class TestClassicTestClientTestingAdapter {
             public void handle(final ClassicHttpRequest request, final ClassicHttpResponse response, final HttpContext context)
                     throws HttpException, IOException {
                 try {
-                    Assertions.assertEquals("method not expected", "junk", request.getMethod());
+                    Assertions.assertEquals("junk", request.getMethod(), "method not expected");
                 } catch (final Throwable t) {
                     thrown = t;
                 }

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClassicTestClientTestingAdapter.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClassicTestClientTestingAdapter.java
@@ -54,27 +54,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestClassicTestClientTestingAdapter {
+class TestClassicTestClientTestingAdapter {
     private static final String ECHO_PATH = "echo/something";
     private static final String CUSTOM_PATH = "custom/something";
 
     private ClassicTestServer server;
 
-   @BeforeEach
-    public void initServer() throws Exception {
+    @BeforeEach
+    void initServer() {
        this.server = new ClassicTestServer(SocketConfig.custom()
                .setSoTimeout(5, TimeUnit.SECONDS).build());
     }
 
     @AfterEach
-    public void shutDownServer() throws Exception {
+    void shutDownServer() {
         if (this.server != null) {
             this.server.shutdown(CloseMode.IMMEDIATE);
         }
     }
 
     @Test
-    public void nullDefaultURI() throws Exception {
+    void nullDefaultURI() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = null;
@@ -87,7 +87,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void nullRequest() throws Exception {
+    void nullRequest() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = "";
@@ -100,7 +100,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void nullRequestHandler() throws Exception {
+    void nullRequestHandler() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = "";
@@ -113,7 +113,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void nullResponseExpectations() throws Exception {
+    void nullResponseExpectations() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = "";
@@ -126,7 +126,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void noPath() throws Exception {
+    void noPath() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = "";
@@ -139,7 +139,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void noMethod() throws Exception {
+    void noMethod() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = "";
@@ -155,7 +155,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void invalidMethod() throws Exception {
+    void invalidMethod() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final String defaultURI = "";
@@ -172,7 +172,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void withLiveServerEcho() throws Exception {
+    void withLiveServerEcho() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         // Initialize the server-side request handler
@@ -209,7 +209,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void withLiveServerCustomRequestHandler() throws Exception {
+    void withLiveServerCustomRequestHandler() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final TestingFrameworkRequestHandler requestHandler = new TestingFrameworkRequestHandler() {
@@ -241,7 +241,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void modifyRequest() {
+    void modifyRequest() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final Map<String, Object> request = new HashMap<>();
@@ -251,7 +251,7 @@ public class TestClassicTestClientTestingAdapter {
     }
 
     @Test
-    public void modifyResponseExpectations() {
+    void modifyResponseExpectations() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final Map<String, Object> responseExpectations = new HashMap<>();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClientPojoAdapter.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClientPojoAdapter.java
@@ -32,9 +32,9 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestClientPojoAdapter {
+class TestClientPojoAdapter {
     @Test
-    public void modifyRequest() throws Exception {
+    void modifyRequest() {
         final ClientPOJOAdapter adapter = new ClassicTestClientAdapter();
         final Map<String, Object> request = new HashMap<>();
         final Map<String, Object> request2 = adapter.modifyRequest(request);
@@ -43,7 +43,7 @@ public class TestClientPojoAdapter {
     }
 
     @Test
-    public void checkRequestSupport() throws Exception {
+    void checkRequestSupport() throws Exception {
         final ClientPOJOAdapter adapter = new ClassicTestClientAdapter();
         final String reason = adapter.checkRequestSupport(null);
 
@@ -53,7 +53,7 @@ public class TestClientPojoAdapter {
     }
 
     @Test
-    public void checkRequestSupportThrows() throws Exception {
+    void checkRequestSupportThrows() {
         final ClientPOJOAdapter adapter = new ClientPOJOAdapter() {
 
             @Override

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClientTestingAdapter.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestClientTestingAdapter.java
@@ -31,10 +31,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestClientTestingAdapter {
+class TestClientTestingAdapter {
 
     @Test
-    public void getHttpClientPOJOAdapter() throws Exception {
+    void getHttpClientPOJOAdapter() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final ClientPOJOAdapter pojoAdapter = adapter.getClientPOJOAdapter();
@@ -43,7 +43,7 @@ public class TestClientTestingAdapter {
     }
 
     @Test
-    public void isRequestSupported() throws Exception {
+    void isRequestSupported() {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final Map<String, Object> request = null;

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestFrameworkTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestFrameworkTest.java
@@ -43,9 +43,9 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestFrameworkTest {
+class TestFrameworkTest {
     @Test
-    public void defaults() throws Exception {
+    void defaults() throws Exception {
         final FrameworkTest test = new FrameworkTest();
         final Map<String, Object> request = test.initRequest();
 
@@ -83,7 +83,7 @@ public class TestFrameworkTest {
     }
 
     @Test
-    public void changeStatus() throws Exception {
+    void changeStatus() {
         final Map<String, Object> testMap = new HashMap<>();
         final Map<String, Object> response = new HashMap<>();
         testMap.put(RESPONSE, response);
@@ -96,7 +96,7 @@ public class TestFrameworkTest {
     }
 
     @Test
-    public void changeMethod() throws Exception {
+    void changeMethod() throws Exception {
         final Map<String, Object> testMap = new HashMap<>();
         final Map<String, Object> request = new HashMap<>();
         testMap.put(REQUEST, request);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestFrameworkTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestFrameworkTest.java
@@ -50,7 +50,7 @@ class TestFrameworkTest {
         final Map<String, Object> request = test.initRequest();
 
         Assertions.assertNotNull(request, "request should not be null");
-        Assertions.assertEquals(request.get(METHOD), "GET", "Default method should be GET");
+        Assertions.assertEquals("GET", request.get(METHOD), "Default method should be GET");
 
         Assertions.assertEquals(TestingFramework.DEFAULT_REQUEST_BODY,
                 request.get(BODY), "Default request body expected.");

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFramework.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFramework.java
@@ -53,10 +53,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestTestingFramework {
+class TestTestingFramework {
 
     @Test
-    public void ensureDefaultMapsUnmodifiable() throws Exception {
+    void ensureDefaultMapsUnmodifiable() {
         assertUnmodifiable(TestingFramework.DEFAULT_REQUEST_QUERY);
         assertUnmodifiable(TestingFramework.DEFAULT_RESPONSE_HEADERS);
     }
@@ -80,13 +80,13 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void runTestsWithoutSettingAdapterThrows() throws Exception {
+    void runTestsWithoutSettingAdapterThrows() throws Exception {
         final TestingFramework framework = newWebServerTestingFramework();
         Assertions.assertThrows(TestingFrameworkException.class, () -> framework.runTests());
     }
 
     @Test
-    public void nullAdapterThrows() throws Exception {
+    void nullAdapterThrows() throws Exception {
         final ClientTestingAdapter adapter = null;
 
         final TestingFramework framework = newWebServerTestingFramework(adapter);
@@ -94,7 +94,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void nullSetAdapterThrows() throws Exception {
+    void nullSetAdapterThrows() throws Exception {
         final ClientTestingAdapter adapter = null;
 
         final TestingFramework framework = newWebServerTestingFramework(adapter);
@@ -103,7 +103,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void goodAdapterWithConstructor() throws Exception {
+    void goodAdapterWithConstructor() throws Exception {
         final ClientTestingAdapter adapter = Mockito.mock(ClientTestingAdapter.class);
 
         // Have isRequestSupported() return false so no test will run.
@@ -135,7 +135,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void goodAdapterWithSetter() throws Exception {
+    void goodAdapterWithSetter() throws Exception {
         final ClientTestingAdapter adapter = Mockito.mock(ClientTestingAdapter.class);
 
         final TestingFramework framework = newFrameworkAndSetAdapter(adapter);
@@ -147,7 +147,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void addTest() throws Exception {
+    void addTest() throws Exception {
         final TestingFrameworkRequestHandler mockRequestHandler = Mockito.mock(TestingFrameworkRequestHandler.class);
 
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
@@ -210,7 +210,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void statusCheck() throws Exception {
+    void statusCheck() throws Exception {
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -246,7 +246,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void responseAlreadyChecked() throws Exception {
+    void responseAlreadyChecked() throws Exception {
             final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -267,7 +267,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void bodyCheck() throws Exception {
+    void bodyCheck() throws Exception {
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -295,7 +295,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void responseContentTypeCheck() throws Exception {
+    void responseContentTypeCheck() throws Exception {
        final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -326,7 +326,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void deepcopy() throws Exception {
+    void deepcopy() throws Exception {
         // save a copy of the headers to make sure they haven't changed at the end of this test.
         @SuppressWarnings("unchecked")
         final Map<String, String> headersCopy = (Map<String, String>) TestingFramework.deepcopy(TestingFramework.DEFAULT_RESPONSE_HEADERS);
@@ -348,7 +348,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void removedHeaderCheck() throws Exception {
+    void removedHeaderCheck() throws Exception {
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -384,7 +384,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changedHeaderCheck() throws Exception {
+    void changedHeaderCheck() throws Exception {
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -429,7 +429,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void requestMethodUnexpected() throws Exception {
+    void requestMethodUnexpected() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -467,7 +467,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void status201() throws Exception {
+    void status201() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         final TestingFramework framework = newFrameworkAndSetAdapter(adapter);
@@ -483,7 +483,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void deepcopyOfTest() throws Exception {
+    void deepcopyOfTest() throws Exception {
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
 
             @Override
@@ -515,7 +515,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void removeParameter() throws Exception {
+    void removeParameter() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -540,7 +540,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changeParameter() throws Exception {
+    void changeParameter() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -565,7 +565,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void removeHeader() throws Exception {
+    void removeHeader() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -590,7 +590,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changeHeader() throws Exception {
+    void changeHeader() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -615,7 +615,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changeBody() throws Exception {
+    void changeBody() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -639,7 +639,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changeContentType() throws Exception {
+    void changeContentType() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -663,7 +663,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changeResponseExpectationsFails() throws Exception {
+    void changeResponseExpectationsFails() throws Exception {
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -691,7 +691,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void changeResponseStatus() throws Exception {
+    void changeResponseStatus() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(
@@ -722,7 +722,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void modifyRequestCalled() throws Exception {
+    void modifyRequestCalled() throws Exception {
         final TestingFrameworkRequestHandler mockRequestHandler = Mockito.mock(TestingFrameworkRequestHandler.class);
         final String UNLIKELY_ITEM = "something_unlikely_to_be_in_a_real_request";
 
@@ -764,7 +764,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void modifyResponseExpectationsCalled() throws Exception {
+    void modifyResponseExpectationsCalled() throws Exception {
         final TestingFrameworkRequestHandler mockRequestHandler = Mockito.mock(TestingFrameworkRequestHandler.class);
         final String UNLIKELY_ITEM = "something_unlikely_to_be_in_a_real_response";
 
@@ -808,7 +808,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void adapterDoesNotSupport() throws Exception {
+    void adapterDoesNotSupport() throws Exception {
 
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
             @Override
@@ -836,7 +836,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void defaultTestsWithMockedAdapter() throws Exception {
+    void defaultTestsWithMockedAdapter() throws Exception {
         final Set<String> calledMethodSet = new HashSet<>();
 
         final ClientTestingAdapter adapter = new ClientTestingAdapter() {
@@ -864,7 +864,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void defaultTests() throws Exception {
+    void defaultTests() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter();
 
         // create the framework without deleting the default tests.
@@ -876,7 +876,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void addTestNoMocks() throws TestingFrameworkException {
+    void addTestNoMocks() throws TestingFrameworkException {
 
         final TestingFramework framework = new TestingFramework(new ClassicTestClientTestingAdapter());
 
@@ -945,7 +945,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void nulls() throws TestingFrameworkException {
+    void nulls() throws TestingFrameworkException {
 
         final TestingFramework framework = new TestingFramework(new ClassicTestClientTestingAdapter());
 
@@ -1005,7 +1005,7 @@ public class TestTestingFramework {
     }
 
     @Test
-    public void parameterInPath() throws Exception {
+    void parameterInPath() throws Exception {
         final ClientTestingAdapter adapter = new ClassicTestClientTestingAdapter() {
             @Override
             public Map<String, Object> execute(final String defaultURI, final Map<String, Object> request,

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFrameworkRequestHandler.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/framework/TestTestingFrameworkRequestHandler.java
@@ -36,9 +36,9 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestTestingFrameworkRequestHandler {
+class TestTestingFrameworkRequestHandler {
     @Test
-    public void assertNothingThrown() throws Exception {
+    void assertNothingThrown() throws Exception {
         final TestingFrameworkRequestHandler handler = new TestingFrameworkRequestHandler() {
 
             @Override
@@ -51,7 +51,7 @@ public class TestTestingFrameworkRequestHandler {
     }
 
     @Test
-    public void assertNothingThrownThrows() throws Exception {
+    void assertNothingThrownThrows() throws Exception {
         final String errorMessage = "thrown intentionally";
 
         final TestingFrameworkRequestHandler handler = new TestingFrameworkRequestHandler() {

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/AsyncServerBootstrapFilterTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/AsyncServerBootstrapFilterTest.java
@@ -105,7 +105,7 @@ abstract class AsyncServerBootstrapFilterTest {
                     })));
 
     @RegisterExtension
-    private final HttpAsyncRequesterResource clientResource = new HttpAsyncRequesterResource((bootstrap) -> bootstrap
+    private final HttpAsyncRequesterResource clientResource = new HttpAsyncRequesterResource(bootstrap -> bootstrap
             .setIOReactorConfig(IOReactorConfig.custom()
                     .setSoTimeout(TIMEOUT)
                     .build()));

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/AsyncServerBootstrapFilterTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/AsyncServerBootstrapFilterTest.java
@@ -64,7 +64,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class AsyncServerBootstrapFilterTest {
+abstract class AsyncServerBootstrapFilterTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -112,7 +112,7 @@ public abstract class AsyncServerBootstrapFilterTest {
 
 
     @Test
-    public void testFilters() throws Exception {
+    void testFilters() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTP);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2AlpnTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2AlpnTest.java
@@ -67,7 +67,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class H2AlpnTest {
+abstract class H2AlpnTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -111,7 +111,7 @@ public abstract class H2AlpnTest {
     }
 
     @Test
-    public void testALPN() throws Exception {
+    void testALPN() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTPS);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2AlpnTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2AlpnTests.java
@@ -30,11 +30,11 @@ package org.apache.hc.core5.testing.nio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
-public class H2AlpnTests {
+class H2AlpnTests {
 
     @Nested
     @DisplayName("Strict h2 ALPN, h2 allowed")
-    public class StrictH2AlpnH2Allowed extends H2AlpnTest {
+    class StrictH2AlpnH2Allowed extends H2AlpnTest {
 
         public StrictH2AlpnH2Allowed() throws Exception {
             super(true, true);
@@ -44,9 +44,9 @@ public class H2AlpnTests {
 
     @Nested
     @DisplayName("Strict h2 ALPN, h2 disallowed")
-    public class StrictH2AlpnH2Disllowed extends H2AlpnTest {
+    class StrictH2AlpnH2Disallowed extends H2AlpnTest {
 
-        public StrictH2AlpnH2Disllowed() throws Exception {
+        public StrictH2AlpnH2Disallowed() throws Exception {
             super(true, false);
         }
 
@@ -54,9 +54,9 @@ public class H2AlpnTests {
 
     @Nested
     @DisplayName("Non-strict h2 ALPN, h2 allowed")
-    public class NonStrictH2AlpnH2Disllowed extends H2AlpnTest {
+    class NonStrictH2AlpnH2Disallowed extends H2AlpnTest {
 
-        public NonStrictH2AlpnH2Disllowed() throws Exception {
+        public NonStrictH2AlpnH2Disallowed() throws Exception {
             super(false, true);
         }
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ConnPoolTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ConnPoolTest.java
@@ -28,7 +28,6 @@
 package org.apache.hc.core5.testing.nio;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
@@ -155,7 +154,7 @@ class H2ConnPoolTest {
         final H2MultiplexingRequester requester = clientResource.start();
         final H2ConnPool connPool = requester.getConnPool();
         final CountDownLatch latch = new CountDownLatch(n);
-        final ConcurrentLinkedQueue<Long> concurrentConnections = new ConcurrentLinkedQueue<>();
+
         for (int i = 0; i < n; i++) {
             connPool.getSession(target, TIMEOUT, new FutureCallback<IOSession>() {
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ConnPoolTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ConnPoolTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class H2ConnPoolTest {
+class H2ConnPoolTest {
 
     private static final Timeout TIMEOUT = Timeout.ofSeconds(30);
 
@@ -98,12 +98,12 @@ public class H2ConnPoolTest {
     }
 
     @BeforeEach
-    public void resetCounts() {
+    void resetCounts() {
         clientConnCount.set(0);
     }
 
     @Test
-    public void testManyGetSession() throws Exception {
+    void testManyGetSession() throws Exception {
         final int n = 200;
 
         final HttpAsyncServer server = serverResource.start();
@@ -147,7 +147,7 @@ public class H2ConnPoolTest {
     }
 
     @Test
-    public void testManyGetSessionFailures() throws Exception {
+    void testManyGetSessionFailures() throws Exception {
         final int n = 200;
 
         final HttpHost target = new HttpHost(URIScheme.HTTP.id, "pampa.invalid", 8888);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportMultiplexingTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportMultiplexingTest.java
@@ -67,7 +67,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class H2CoreTransportMultiplexingTest {
+abstract class H2CoreTransportMultiplexingTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -98,7 +98,7 @@ public abstract class H2CoreTransportMultiplexingTest {
     }
 
     @Test
-    public void testSequentialRequests() throws Exception {
+    void testSequentialRequests() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -141,7 +141,7 @@ public abstract class H2CoreTransportMultiplexingTest {
     }
 
     @Test
-    public void testMultiplexedRequests() throws Exception {
+    void testMultiplexedRequests() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -176,7 +176,7 @@ public abstract class H2CoreTransportMultiplexingTest {
     }
 
     @Test
-    public void testValidityCheck() throws Exception {
+    void testValidityCheck() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -224,7 +224,7 @@ public abstract class H2CoreTransportMultiplexingTest {
     }
 
     @Test
-    public void testMultiplexedRequestCancellation() throws Exception {
+    void testMultiplexedRequestCancellation() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportTest.java
@@ -42,7 +42,7 @@ import org.apache.hc.core5.testing.extension.nio.H2AsyncServerResource;
 import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class H2CoreTransportTest extends HttpCoreTransportTest {
+abstract class H2CoreTransportTest extends HttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2IntegrationTest.java
@@ -123,7 +123,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class H2IntegrationTest {
+abstract class H2IntegrationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
     private static final Timeout LONG_TIMEOUT = Timeout.ofMinutes(2);
@@ -139,7 +139,7 @@ public abstract class H2IntegrationTest {
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         resources.server().configure(H2Config.DEFAULT);
         resources.client().configure(H2Config.DEFAULT);
     }
@@ -153,7 +153,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testSimpleGet() throws Exception {
+    void testSimpleGet() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -185,7 +185,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testSimpleHead() throws Exception {
+    void testSimpleHead() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -211,7 +211,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testLargeGet() throws Exception {
+    void testLargeGet() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -257,7 +257,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testBasicPost() throws Exception {
+    void testBasicPost() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -290,7 +290,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testLargePost() throws Exception {
+    void testLargePost() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -320,7 +320,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testSlowResponseConsumer() throws Exception {
+    void testSlowResponseConsumer() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -376,7 +376,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testSlowRequestProducer() throws Exception {
+    void testSlowRequestProducer() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -425,7 +425,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testSlowResponseProducer() throws Exception {
+    void testSlowResponseProducer() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -505,7 +505,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testPush() throws Exception {
+    void testPush() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -579,7 +579,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testPushRefused() throws Exception {
+    void testPushRefused() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -660,7 +660,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testExcessOfConcurrentStreams() throws Exception {
+    void testExcessOfConcurrentStreams() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -699,7 +699,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testExpectationFailed() throws Exception {
+    void testExpectationFailed() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -769,7 +769,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testPrematureResponse() throws Exception {
+    void testPrematureResponse() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -854,7 +854,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testMessageWithTrailers() throws Exception {
+    void testMessageWithTrailers() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -912,7 +912,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testConnectionPing() throws Exception {
+    void testConnectionPing() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -944,7 +944,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testRequestWithInvalidConnectionHeader() throws Exception {
+    void testRequestWithInvalidConnectionHeader() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -974,7 +974,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testHeaderTooLarge() throws Exception {
+    void testHeaderTooLarge() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 
@@ -1005,7 +1005,7 @@ public abstract class H2IntegrationTest {
     }
 
     @Test
-    public void testHeaderTooLargePost() throws Exception {
+    void testHeaderTooLargePost() throws Exception {
         final H2TestServer server = resources.server();
         final H2TestClient client = resources.client();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ProtocolNegotiationTest.java
@@ -60,7 +60,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class H2ProtocolNegotiationTest {
+class H2ProtocolNegotiationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -90,7 +90,7 @@ public class H2ProtocolNegotiationTest {
     }
 
     @Test
-    public void testForceHttp1() throws Exception {
+    void testForceHttp1() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTPS);
         final ListenerEndpoint listener = future.get();
@@ -113,7 +113,7 @@ public class H2ProtocolNegotiationTest {
     }
 
     @Test
-    public void testForceHttp2() throws Exception {
+    void testForceHttp2() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTPS);
         final ListenerEndpoint listener = future.get();
@@ -136,7 +136,7 @@ public class H2ProtocolNegotiationTest {
     }
 
     @Test
-    public void testNegotiateProtocol() throws Exception {
+    void testNegotiateProtocol() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTPS);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerBootstrapFiltersTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerBootstrapFiltersTest.java
@@ -65,7 +65,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class H2ServerBootstrapFiltersTest {
+abstract class H2ServerBootstrapFiltersTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -114,7 +114,7 @@ public abstract class H2ServerBootstrapFiltersTest {
                     .build()));
 
     @Test
-    public void testSequentialRequests() throws Exception {
+    void testSequentialRequests() throws Exception {
         final HttpAsyncServer server = serverResource.start();
 
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTP);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerBootstrapFiltersTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ServerBootstrapFiltersTest.java
@@ -70,7 +70,7 @@ abstract class H2ServerBootstrapFiltersTest {
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
     @RegisterExtension
-    private final H2AsyncServerResource serverResource = new H2AsyncServerResource((bootstrap) -> bootstrap
+    private final H2AsyncServerResource serverResource = new H2AsyncServerResource(bootstrap -> bootstrap
             .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
             .setIOReactorConfig(
                     IOReactorConfig.custom()

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2SocksProxyCoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2SocksProxyCoreTransportTest.java
@@ -44,7 +44,7 @@ import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class H2SocksProxyCoreTransportTest extends HttpCoreTransportTest {
+abstract class H2SocksProxyCoreTransportTest extends HttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1AuthenticationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1AuthenticationTest.java
@@ -69,7 +69,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class Http1AuthenticationTest {
+abstract class Http1AuthenticationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -128,7 +128,7 @@ public abstract class Http1AuthenticationTest {
     }
 
     @Test
-    public void testGetRequestAuthentication() throws Exception {
+    void testGetRequestAuthentication() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTP);
         final ListenerEndpoint listener = future.get();
@@ -162,7 +162,7 @@ public abstract class Http1AuthenticationTest {
     }
 
     @Test
-    public void testPostRequestAuthentication() throws Exception {
+    void testPostRequestAuthentication() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTP);
         final ListenerEndpoint listener = future.get();
@@ -200,7 +200,7 @@ public abstract class Http1AuthenticationTest {
     }
 
     @Test
-    public void testPostRequestAuthenticationNoExpectContinue() throws Exception {
+    void testPostRequestAuthenticationNoExpectContinue() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTP);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1CoreTransportTest.java
@@ -66,7 +66,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
+abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -132,7 +132,7 @@ public abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
     }
 
     @Test
-    public void testSequentialRequestsNonPersistentConnection() throws Exception {
+    void testSequentialRequestsNonPersistentConnection() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
@@ -136,7 +136,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class Http1IntegrationTest {
+abstract class Http1IntegrationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
     private static final Timeout LONG_TIMEOUT = Timeout.ofMinutes(2);
@@ -162,7 +162,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSimpleGet() throws Exception {
+    void testSimpleGet() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -189,7 +189,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSimpleGetConnectionClose() throws Exception {
+    void testSimpleGetConnectionClose() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -219,7 +219,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSimpleGetIdentityTransfer() throws Exception {
+    void testSimpleGetIdentityTransfer() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -253,7 +253,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testPostIdentityTransfer() throws Exception {
+    void testPostIdentityTransfer() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -288,7 +288,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testPostIdentityTransferOutOfSequenceResponse() throws Exception {
+    void testPostIdentityTransferOutOfSequenceResponse() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -323,7 +323,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSimpleGetsPipelined() throws Exception {
+    void testSimpleGetsPipelined() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -354,7 +354,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testLargeGet() throws Exception {
+    void testLargeGet() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -400,7 +400,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testLargeGetsPipelined() throws Exception {
+    void testLargeGetsPipelined() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -435,7 +435,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testBasicPost() throws Exception {
+    void testBasicPost() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -463,7 +463,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testBasicPostPipelined() throws Exception {
+    void testBasicPostPipelined() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -495,7 +495,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testHttp10Post() throws Exception {
+    void testHttp10Post() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -524,7 +524,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testHTTP11FeaturesDisabledWithHTTP10Requests() throws Exception {
+    void testHTTP11FeaturesDisabledWithHTTP10Requests() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -546,7 +546,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testNoEntityPost() throws Exception {
+    void testNoEntityPost() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -574,7 +574,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testLargePost() throws Exception {
+    void testLargePost() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -606,7 +606,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testPostsPipelinedLargeResponse() throws Exception {
+    void testPostsPipelinedLargeResponse() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -643,7 +643,7 @@ public abstract class Http1IntegrationTest {
 
 
     @Test
-    public void testLargePostsPipelined() throws Exception {
+    void testLargePostsPipelined() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -679,7 +679,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSimpleHead() throws Exception {
+    void testSimpleHead() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -705,7 +705,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSimpleHeadConnectionClose() throws Exception {
+    void testSimpleHeadConnectionClose() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -734,7 +734,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testHeadPipelined() throws Exception {
+    void testHeadPipelined() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -764,7 +764,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testExpectationFailed() throws Exception {
+    void testExpectationFailed() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -856,7 +856,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testExpectationFailedCloseConnection() throws Exception {
+    void testExpectationFailedCloseConnection() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -912,7 +912,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testDelayedExpectationVerification() throws Exception {
+    void testDelayedExpectationVerification() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1024,7 +1024,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testPrematureResponse() throws Exception {
+    void testPrematureResponse() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1119,7 +1119,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSlowResponseConsumer() throws Exception {
+    void testSlowResponseConsumer() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1176,7 +1176,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSlowRequestProducer() throws Exception {
+    void testSlowRequestProducer() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1225,7 +1225,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testSlowResponseProducer() throws Exception {
+    void testSlowResponseProducer() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1305,7 +1305,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testPipelinedConnectionClose() throws Exception {
+    void testPipelinedConnectionClose() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1366,7 +1366,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testPipelinedInvalidRequest() throws Exception {
+    void testPipelinedInvalidRequest() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1463,7 +1463,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testTruncatedChunk() throws Exception {
+    void testTruncatedChunk() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1548,7 +1548,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testExceptionInHandler() throws Exception {
+    void testExceptionInHandler() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1582,7 +1582,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testNoServiceHandler() throws Exception {
+    void testNoServiceHandler() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1607,7 +1607,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testResponseNoContent() throws Exception {
+    void testResponseNoContent() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1641,7 +1641,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testMessageWithTrailers() throws Exception {
+    void testMessageWithTrailers() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1699,7 +1699,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testProtocolException() throws Exception {
+    void testProtocolException() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1775,7 +1775,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testHeaderTooLarge() throws Exception {
+    void testHeaderTooLarge() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 
@@ -1805,7 +1805,7 @@ public abstract class Http1IntegrationTest {
     }
 
     @Test
-    public void testHeaderTooLargePost() throws Exception {
+    void testHeaderTooLargePost() throws Exception {
         final Http1TestServer server = resources.server();
         final Http1TestClient client = resources.client();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1SocksProxyCoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1SocksProxyCoreTransportTest.java
@@ -52,7 +52,7 @@ import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class Http1SocksProxyCoreTransportTest extends HttpCoreTransportTest {
+abstract class Http1SocksProxyCoreTransportTest extends HttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpCoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpCoreTransportTest.java
@@ -56,7 +56,7 @@ import org.apache.hc.core5.util.Timeout;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
-public abstract class HttpCoreTransportTest {
+abstract class HttpCoreTransportTest {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -71,7 +71,7 @@ public abstract class HttpCoreTransportTest {
     abstract HttpAsyncRequester clientStart() throws IOException;
 
     @Test
-    public void testSequentialRequests() throws Exception {
+    void testSequentialRequests() throws Exception {
         final HttpAsyncServer server = serverStart();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -114,7 +114,7 @@ public abstract class HttpCoreTransportTest {
     }
 
     @Test
-    public void testSequentialRequestsNonPersistentConnection() throws Exception {
+    void testSequentialRequestsNonPersistentConnection() throws Exception {
         final HttpAsyncServer server = serverStart();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -157,7 +157,7 @@ public abstract class HttpCoreTransportTest {
     }
 
     @Test
-    public void testSequentialRequestsSameEndpoint() throws Exception {
+    void testSequentialRequestsSameEndpoint() throws Exception {
         final HttpAsyncServer server = serverStart();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -208,7 +208,7 @@ public abstract class HttpCoreTransportTest {
     }
 
     @Test
-    public void testPipelinedRequests() throws Exception {
+    void testPipelinedRequests() throws Exception {
         final HttpAsyncServer server = serverStart();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();
@@ -251,7 +251,7 @@ public abstract class HttpCoreTransportTest {
     }
 
     @Test
-    public void testNonPersistentHeads() throws Exception {
+    void testNonPersistentHeads() throws Exception {
         final HttpAsyncServer server = serverStart();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), scheme);
         final ListenerEndpoint listener = future.get();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpIntegrationTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpIntegrationTests.java
@@ -31,11 +31,11 @@ import org.apache.hc.core5.http.URIScheme;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
-public class HttpIntegrationTests {
+class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (HTTP/1.1)")
-    public class CoreTransport extends Http1CoreTransportTest {
+    class CoreTransport extends Http1CoreTransportTest {
 
         public CoreTransport() {
             super(URIScheme.HTTP);
@@ -45,7 +45,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (HTTP/1.1, TLS)")
-    public class CoreTransportTls extends Http1CoreTransportTest {
+    class CoreTransportTls extends Http1CoreTransportTest {
 
         public CoreTransportTls() {
             super(URIScheme.HTTPS);
@@ -55,7 +55,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (H2)")
-    public class CoreTransportH2 extends H2CoreTransportTest {
+    class CoreTransportH2 extends H2CoreTransportTest {
 
         public CoreTransportH2() {
             super(URIScheme.HTTP);
@@ -65,7 +65,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (H2, TLS)")
-    public class CoreTransportH2Tls extends H2CoreTransportTest {
+    class CoreTransportH2Tls extends H2CoreTransportTest {
 
         public CoreTransportH2Tls() {
             super(URIScheme.HTTPS);
@@ -75,7 +75,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (H2, multiplexing)")
-    public class CoreTransportH2Multiplexing extends H2CoreTransportMultiplexingTest {
+    class CoreTransportH2Multiplexing extends H2CoreTransportMultiplexingTest {
 
         public CoreTransportH2Multiplexing() {
             super(URIScheme.HTTP);
@@ -85,7 +85,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (H2, multiplexing, TLS)")
-    public class CoreTransportH2MultiplexingTls extends H2CoreTransportMultiplexingTest {
+    class CoreTransportH2MultiplexingTls extends H2CoreTransportMultiplexingTest {
 
         public CoreTransportH2MultiplexingTls() {
             super(URIScheme.HTTPS);
@@ -95,7 +95,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Server filters")
-    public class HttpFilters extends AsyncServerBootstrapFilterTest {
+    class HttpFilters extends AsyncServerBootstrapFilterTest {
 
         public HttpFilters() {
             super();
@@ -105,7 +105,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("H2 Server filters")
-    public class H2Filters extends H2ServerBootstrapFiltersTest {
+    class H2Filters extends H2ServerBootstrapFiltersTest {
 
         public H2Filters() {
             super();
@@ -115,7 +115,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Authentication")
-    public class Authentication extends Http1AuthenticationTest {
+    class Authentication extends Http1AuthenticationTest {
 
         public Authentication() {
             super(false);
@@ -125,7 +125,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Authentication (immediate response)")
-    public class AuthenticationImmediateResponse extends Http1AuthenticationTest {
+    class AuthenticationImmediateResponse extends Http1AuthenticationTest {
 
         public AuthenticationImmediateResponse() {
             super(true);
@@ -135,7 +135,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (HTTP/1.1, SOCKS)")
-    public class CoreTransportSocksProxy extends Http1SocksProxyCoreTransportTest {
+    class CoreTransportSocksProxy extends Http1SocksProxyCoreTransportTest {
 
         public CoreTransportSocksProxy() {
             super(URIScheme.HTTP);
@@ -145,7 +145,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (HTTP/1.1, TLS, SOCKS)")
-    public class CoreTransportSocksProxyTls extends Http1SocksProxyCoreTransportTest {
+    class CoreTransportSocksProxyTls extends Http1SocksProxyCoreTransportTest {
 
         public CoreTransportSocksProxyTls() {
             super(URIScheme.HTTPS);
@@ -155,7 +155,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (H2, SOCKS)")
-    public class CoreTransportH2SocksProxy extends H2SocksProxyCoreTransportTest {
+    class CoreTransportH2SocksProxy extends H2SocksProxyCoreTransportTest {
 
         public CoreTransportH2SocksProxy() {
             super(URIScheme.HTTP);
@@ -165,7 +165,7 @@ public class HttpIntegrationTests {
 
     @Nested
     @DisplayName("Core transport (H2, TLS, SOCKS)")
-    public class CoreTransportH2SocksProxyTls extends H2SocksProxyCoreTransportTest {
+    class CoreTransportH2SocksProxyTls extends H2SocksProxyCoreTransportTest {
 
         public CoreTransportH2SocksProxyTls() {
             super(URIScheme.HTTPS);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpProtocolTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpProtocolTests.java
@@ -31,11 +31,11 @@ import org.apache.hc.core5.http.URIScheme;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
-public class HttpProtocolTests {
+class HttpProtocolTests {
 
     @Nested
     @DisplayName("HTTP/1.1 (plain)")
-    public class Http1 extends Http1IntegrationTest {
+    class Http1 extends Http1IntegrationTest {
 
         public Http1() {
             super(URIScheme.HTTP);
@@ -45,7 +45,7 @@ public class HttpProtocolTests {
 
     @Nested
     @DisplayName("HTTP/1.1 (TLS)")
-    public class Http1Tls extends Http1IntegrationTest {
+    class Http1Tls extends Http1IntegrationTest {
 
         public Http1Tls() {
             super(URIScheme.HTTPS);
@@ -55,7 +55,7 @@ public class HttpProtocolTests {
 
     @Nested
     @DisplayName("HTTP/2 (plain)")
-    public class H2 extends H2IntegrationTest {
+    class H2 extends H2IntegrationTest {
 
         public H2() {
             super(URIScheme.HTTP);
@@ -65,7 +65,7 @@ public class HttpProtocolTests {
 
     @Nested
     @DisplayName("HTTP/2 (TLS)")
-    public class H2Tls extends H2IntegrationTest {
+    class H2Tls extends H2IntegrationTest {
 
         public H2Tls() {
             super(URIScheme.HTTPS);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTest.java
@@ -63,7 +63,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class JSSEProviderIntegrationTest {
+abstract class JSSEProviderIntegrationTest {
 
     private final String securityProviderName;
     private final String protocolVersion;
@@ -204,7 +204,7 @@ public abstract class JSSEProviderIntegrationTest {
     }
 
     @Test
-    public void testSimpleGet() throws Exception {
+    void testSimpleGet() throws Exception {
         server.register("/hello", () -> new SingleLineResponseHandler("Hi there"));
         final InetSocketAddress serverEndpoint = server.start();
 
@@ -228,7 +228,7 @@ public abstract class JSSEProviderIntegrationTest {
     }
 
     @Test
-    public void testSimpleGetConnectionClose() throws Exception {
+    void testSimpleGetConnectionClose() throws Exception {
         server.register("/hello", () -> new SingleLineResponseHandler("Hi there"));
         final InetSocketAddress serverEndpoint = server.start();
 
@@ -255,7 +255,7 @@ public abstract class JSSEProviderIntegrationTest {
     }
 
     @Test
-    public void testSimpleGetIdentityTransfer() throws Exception {
+    void testSimpleGetIdentityTransfer() throws Exception {
         server.register("/hello", () -> new SingleLineResponseHandler("Hi there"));
         server.configure(new DefaultHttpProcessor(new RequestValidateHost()));
         final InetSocketAddress serverEndpoint = server.start();

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/JSSEProviderIntegrationTests.java
@@ -32,11 +32,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-public class JSSEProviderIntegrationTests {
+class JSSEProviderIntegrationTests {
 
     @Nested
     @DisplayName("Oracle (default)")
-    public class Oracle extends JSSEProviderIntegrationTest {
+    class Oracle extends JSSEProviderIntegrationTest {
 
         public Oracle() {
             super("Oracle", null);
@@ -47,7 +47,7 @@ public class JSSEProviderIntegrationTests {
     @Nested
     @DisplayName("Conscrypt (TLSv1.2)")
     @DisabledOnOs(OS.MAC)
-    public class ConscryptTlsV1_2 extends JSSEProviderIntegrationTest {
+    class ConscryptTlsV1_2 extends JSSEProviderIntegrationTest {
 
         public ConscryptTlsV1_2() {
             super("Conscrypt", "TLSv1.2");
@@ -58,7 +58,7 @@ public class JSSEProviderIntegrationTests {
     @Nested
     @DisplayName("Conscrypt (TLSv1.3)")
     @DisabledOnOs(OS.MAC)
-    public class ConscryptTlsV1_3 extends JSSEProviderIntegrationTest {
+    class ConscryptTlsV1_3 extends JSSEProviderIntegrationTest {
 
         public ConscryptTlsV1_3() {
             super("Conscrypt", "TLSv1.3");

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TLSIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TLSIntegrationTest.java
@@ -96,7 +96,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class TLSIntegrationTest {
+class TLSIntegrationTest {
 
     private static final Timeout TIMEOUT = Timeout.ofSeconds(30);
 
@@ -204,7 +204,7 @@ public class TLSIntegrationTest {
 
     @ParameterizedTest(name = "TLS protocol {0}")
     @ArgumentsSource(SupportedTLSProtocolProvider.class)
-    public void testTLSSuccess(final TLS tlsProtocol) throws Exception {
+    void testTLSSuccess(final TLS tlsProtocol) throws Exception {
         final TlsStrategy serverTlsStrategy = new TestTlsStrategy(
                 SSLTestContexts.createServerSSLContext(),
                 (endpoint, sslEngine) -> sslEngine.setEnabledProtocols(new String[]{tlsProtocol.getId()}),
@@ -230,7 +230,7 @@ public class TLSIntegrationTest {
     }
 
     @Test
-    public void testTLSTrustFailure() throws Exception {
+    void testTLSTrustFailure() throws Exception {
         final TlsStrategy serverTlsStrategy = new BasicServerTlsStrategy(SSLTestContexts.createServerSSLContext());
         server = createServer(serverTlsStrategy);
         server.start();
@@ -248,7 +248,7 @@ public class TLSIntegrationTest {
     }
 
     @Test
-    public void testTLSClientAuthFailure() throws Exception {
+    void testTLSClientAuthFailure() throws Exception {
         final TlsStrategy serverTlsStrategy = new BasicServerTlsStrategy(
                 SSLTestContexts.createServerSSLContext(),
                 (endpoint, sslEngine) -> sslEngine.setNeedClientAuth(true),
@@ -278,7 +278,7 @@ public class TLSIntegrationTest {
     }
 
     @Test
-    public void testSSLDisabledByDefault() throws Exception {
+    void testSSLDisabledByDefault() throws Exception {
         final TlsStrategy serverTlsStrategy = new TestTlsStrategy(
                 SSLTestContexts.createServerSSLContext(),
                 (endpoint, sslEngine) -> sslEngine.setEnabledProtocols(new String[]{"SSLv3"}),
@@ -314,7 +314,7 @@ public class TLSIntegrationTest {
             "TLS_KRB5_EXPORT_WITH_RC4_40_SHA",
             "SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5"
     })
-    public void testWeakCipherDisabledByDefault(final String cipher) throws Exception {
+    void testWeakCipherDisabledByDefault(final String cipher) throws Exception {
         final TlsStrategy serverTlsStrategy = new TestTlsStrategy(
                 SSLTestContexts.createServerSSLContext(),
                 (endpoint, sslEngine) -> sslEngine.setEnabledCipherSuites(new String[]{cipher}),
@@ -333,7 +333,7 @@ public class TLSIntegrationTest {
     }
 
     @Test
-    public void testTLSVersionMismatch() throws Exception {
+    void testTLSVersionMismatch() throws Exception {
         final TlsStrategy serverTlsStrategy = new TestTlsStrategy(
                 SSLTestContexts.createServerSSLContext(),
                 (endpoint, sslEngine) -> {
@@ -363,7 +363,7 @@ public class TLSIntegrationTest {
     }
 
     @Test
-    public void testHostNameVerification() throws Exception {
+    void testHostNameVerification() throws Exception {
         server = createServer(new BasicClientTlsStrategy(SSLTestContexts.createServerSSLContext()));
         server.start();
 

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TLSUpgradeTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TLSUpgradeTest.java
@@ -64,7 +64,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TLSUpgradeTest {
+class TLSUpgradeTest {
 
     private static final Timeout TIMEOUT = Timeout.ofSeconds(30);
 
@@ -92,7 +92,7 @@ public class TLSUpgradeTest {
     }
 
     @Test
-    public void testTLSUpgrade() throws Exception {
+    void testTLSUpgrade() throws Exception {
         final HttpAsyncServer server = serverResource.start();
         final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(0), URIScheme.HTTPS);
         final ListenerEndpoint listener = future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TestDefaultListeningIOReactor.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TestDefaultListeningIOReactor.java
@@ -46,12 +46,12 @@ import org.junit.jupiter.api.Test;
 /**
  * Basic tests for {@link DefaultListeningIOReactor}.
  */
-public class TestDefaultListeningIOReactor {
+class TestDefaultListeningIOReactor {
 
     private DefaultListeningIOReactor ioReactor;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() {
         final IOReactorConfig reactorConfig = IOReactorConfig.custom()
                 .setIoThreadCount(1)
                 .build();
@@ -59,14 +59,14 @@ public class TestDefaultListeningIOReactor {
     }
 
     @AfterEach
-    public void cleanup() throws Exception {
+    void cleanup() {
         if (this.ioReactor != null) {
             this.ioReactor.close(CloseMode.IMMEDIATE);
         }
     }
 
     @Test
-    public void testEndpointUpAndDown() throws Exception {
+    void testEndpointUpAndDown() throws Exception {
         ioReactor.start();
 
         Set<ListenerEndpoint> endpoints = ioReactor.getEndpoints();
@@ -100,7 +100,7 @@ public class TestDefaultListeningIOReactor {
     }
 
     @Test
-    public void testEndpointAlreadyBound() throws Exception {
+    void testEndpointAlreadyBound() throws Exception {
         ioReactor.start();
 
         final Future<ListenerEndpoint> future1 = ioReactor.listen(new InetSocketAddress(0));

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/IntegrationTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/IntegrationTests.java
@@ -31,11 +31,11 @@ import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 
-public class IntegrationTests {
+class IntegrationTests {
 
     @Nested
     @DisplayName("Reactive client (HTTP/1.1)")
-    public class CoreFunctions extends ReactiveClientTest {
+    class CoreFunctions extends ReactiveClientTest {
 
         public CoreFunctions() {
             super(HttpVersionPolicy.FORCE_HTTP_1);
@@ -45,7 +45,7 @@ public class IntegrationTests {
 
     @Nested
     @DisplayName("Reactive client (HTTP/2)")
-    public class CoreFunctionsTls extends ReactiveClientTest {
+    class CoreFunctionsTls extends ReactiveClientTest {
 
         public CoreFunctionsTls() {
             super(HttpVersionPolicy.FORCE_HTTP_2);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/ReactiveClientTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/reactive/ReactiveClientTest.java
@@ -75,7 +75,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.reactivestreams.Publisher;
 
-public abstract class ReactiveClientTest {
+abstract class ReactiveClientTest {
 
     private static final Timeout SOCKET_TIMEOUT = Timeout.ofSeconds(30);
     private static final Timeout RESULT_TIMEOUT = Timeout.ofSeconds(60);
@@ -110,7 +110,7 @@ public abstract class ReactiveClientTest {
     }
 
     @Test
-    public void testSimpleRequest() throws Exception {
+    void testSimpleRequest() throws Exception {
         final InetSocketAddress address = startServer();
         final HttpAsyncRequester requester = clientResource.start();
         final byte[] input = new byte[1024];
@@ -141,7 +141,7 @@ public abstract class ReactiveClientTest {
     }
 
     @Test
-    public void testLongRunningRequest() throws Exception {
+    void testLongRunningRequest() throws Exception {
         final InetSocketAddress address = startServer();
         final HttpAsyncRequester requester = clientResource.start();
         final long expectedLength = 6_554_200L;
@@ -161,7 +161,7 @@ public abstract class ReactiveClientTest {
     }
 
     @Test
-    public void testManySmallBuffers() throws Exception {
+    void testManySmallBuffers() throws Exception {
         // This test is not flaky. If it starts randomly failing, then there is a problem with how
         // ReactiveDataConsumer signals capacity with its capacity channel. The situations in which
         // this kind of bug manifests depend on the ordering of several events on different threads
@@ -188,7 +188,7 @@ public abstract class ReactiveClientTest {
     }
 
     @Test
-    public void testRequestError() throws Exception {
+    void testRequestError() throws Exception {
         final InetSocketAddress address = startServer();
         final HttpAsyncRequester requester = clientResource.start();
         final RuntimeException exceptionThrown = new RuntimeException("Test");
@@ -208,7 +208,7 @@ public abstract class ReactiveClientTest {
     }
 
     @Test
-    public void testRequestTimeout() throws Exception {
+    void testRequestTimeout() throws Exception {
         final InetSocketAddress address = startServer();
         final HttpAsyncRequester requester = clientResource.start();
         final AtomicBoolean requestPublisherWasCancelled = new AtomicBoolean(false);
@@ -234,7 +234,7 @@ public abstract class ReactiveClientTest {
     }
 
     @Test
-    public void testResponseCancellation() throws Exception {
+    void testResponseCancellation() throws Exception {
         final InetSocketAddress address = startServer();
         final HttpAsyncRequester requester = clientResource.start();
         final AtomicBoolean requestPublisherWasCancelled = new AtomicBoolean(false);

--- a/httpcore5/src/test/java/org/apache/hc/core5/annotation/ThreadingBehaviorTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/annotation/ThreadingBehaviorTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class ThreadingBehaviorTest {
+class ThreadingBehaviorTest {
 
     @Test
     void testName(){

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/DefaultThreadFactoryTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/DefaultThreadFactoryTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DefaultThreadFactoryTest {
+class DefaultThreadFactoryTest {
 
     @Test
     void newThread() throws Exception {

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestBasicFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestBasicFuture.java
@@ -46,10 +46,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestBasicFuture {
+class TestBasicFuture {
 
     @Test
-    public void testCompleted() throws Exception {
+    void testCompleted() throws Exception {
         final FutureCallback<Object> callback = Mockito.mock(FutureCallback.class);
         final BasicFuture<Object> future = new BasicFuture<>(callback);
 
@@ -70,7 +70,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testCompletedWithTimeout() throws Exception {
+    void testCompletedWithTimeout() throws Exception {
         final FutureCallback<Object> callback = Mockito.mock(FutureCallback.class);
         final BasicFuture<Object> future = new BasicFuture<>(callback);
 
@@ -90,7 +90,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testFailed() throws Exception {
+    void testFailed() throws Exception {
         final FutureCallback<Object> callback = Mockito.mock(FutureCallback.class);
         final BasicFuture<Object> future = new BasicFuture<>(callback);
         final Object result = new Object();
@@ -111,7 +111,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testCancelled() throws Exception {
+    void testCancelled() {
         final FutureCallback<Object> callback = Mockito.mock(FutureCallback.class);
         final BasicFuture<Object> future = new BasicFuture<>(callback);
         final Object result = new Object();
@@ -129,7 +129,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testAsyncCompleted() throws Exception {
+    void testAsyncCompleted() throws Exception {
         final BasicFuture<Object> future = new BasicFuture<>(null);
         final Object result = new Object();
 
@@ -148,7 +148,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testAsyncFailed() throws Exception {
+    void testAsyncFailed() throws Exception {
         final BasicFuture<Object> future = new BasicFuture<>(null);
         final Exception boom = new Exception();
 
@@ -171,7 +171,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testAsyncCancelled() throws Exception {
+    void testAsyncCancelled() {
         final BasicFuture<Object> future = new BasicFuture<>(null);
 
         final Thread t = new Thread(() -> {
@@ -188,7 +188,7 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testAsyncTimeout() throws Exception {
+    void testAsyncTimeout() {
         final BasicFuture<Object> future = new BasicFuture<>(null);
         final Object result = new Object();
 
@@ -206,14 +206,14 @@ public class TestBasicFuture {
     }
 
     @Test
-    public void testAsyncNegativeTimeout() throws Exception {
+    void testAsyncNegativeTimeout() {
         final BasicFuture<Object> future = new BasicFuture<>(null);
         assertThrows(TimeoutValueException.class, () ->
                 future.get(-1, TimeUnit.MILLISECONDS));
     }
 
     @Test
-    public void testConcurrentOperations() throws InterruptedException, ExecutionException {
+    void testConcurrentOperations() throws InterruptedException, ExecutionException {
         final FutureCallback<Object> callback = new FutureCallback<Object>() {
             public void completed(final Object result) {
             }

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestCompletedFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestCompletedFuture.java
@@ -29,10 +29,10 @@ package org.apache.hc.core5.concurrent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestCompletedFuture {
+class TestCompletedFuture {
 
     @Test
-    public void testCompleted() {
+    void testCompleted() {
         final Object result = new Object();
         final CompletedFuture<Object> future = new CompletedFuture<>(result);
         Assertions.assertSame(result, future.get());

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexCancellable.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexCancellable.java
@@ -32,10 +32,10 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestComplexCancellable {
+class TestComplexCancellable {
 
     @Test
-    public void testCancelled() throws Exception {
+    void testCancelled() {
         final ComplexCancellable cancellable = new ComplexCancellable();
 
         final BasicFuture<Object> dependency1 = new BasicFuture<>(null);

--- a/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/concurrent/TestComplexFuture.java
@@ -34,10 +34,10 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestComplexFuture {
+class TestComplexFuture {
 
     @Test
-    public void testCancelled() throws Exception {
+    void testCancelled() {
         final ComplexFuture<Object> future = new ComplexFuture<>(null);
 
         final Future<Object> dependency1 = new BasicFuture<>(null);
@@ -55,7 +55,7 @@ public class TestComplexFuture {
     }
 
     @Test
-    public void testCompleted() throws Exception {
+    void testCompleted() {
         final ComplexFuture<Object> future = new ComplexFuture<>(null);
 
         final Future<Object> dependency1 = new BasicFuture<>(null);
@@ -73,7 +73,7 @@ public class TestComplexFuture {
     }
 
     @Test
-    public void testCancelledWithCallback() throws Exception {
+    void testCancelledWithCallback() {
         final ComplexFuture<Object> future = new ComplexFuture<>(null);
 
         final Future<Object> dependency1 = new BasicFuture<>(new FutureContribution<Object>(future) {
@@ -97,7 +97,7 @@ public class TestComplexFuture {
     }
 
     @Test
-    public void testCanceledAndFailed() {
+    void testCanceledAndFailed() {
         final ComplexFuture<Object> future = new ComplexFuture<>(null);
         assertThat(future.cancel(), CoreMatchers.is(true));
         assertThat(future.failed(new Exception()), CoreMatchers.is(false));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestContentType.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestContentType.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link ContentType}.
  *
  */
-public class TestContentType {
+class TestContentType {
 
     @Test
-    public void testBasis() throws Exception {
+    void testBasis() throws Exception {
         final ContentType contentType = ContentType.create("text/plain", "US-ASCII");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertEquals(StandardCharsets.US_ASCII, contentType.getCharset());
@@ -49,7 +49,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testWithCharset() throws Exception {
+    void testWithCharset() throws Exception {
         ContentType contentType = ContentType.create("text/plain", "US-ASCII");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertEquals(StandardCharsets.US_ASCII, contentType.getCharset());
@@ -61,7 +61,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testWithCharsetString() throws Exception {
+    void testWithCharsetString() throws Exception {
         ContentType contentType = ContentType.create("text/plain", "US-ASCII");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertEquals(StandardCharsets.US_ASCII, contentType.getCharset());
@@ -73,14 +73,14 @@ public class TestContentType {
     }
 
     @Test
-    public void testLowCaseText() throws Exception {
+    void testLowCaseText() throws Exception {
         final ContentType contentType = ContentType.create("Text/Plain", "ascii");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertEquals(StandardCharsets.US_ASCII, contentType.getCharset());
     }
 
     @Test
-    public void testCreateInvalidInput() throws Exception {
+    void testCreateInvalidInput() {
         Assertions.assertThrows(NullPointerException.class, () -> ContentType.create(null, (String) null));
         Assertions.assertThrows(IllegalArgumentException.class, () -> ContentType.create("  ", (String) null));
         Assertions.assertThrows(IllegalArgumentException.class, () -> ContentType.create("stuff;", (String) null));
@@ -88,7 +88,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testParse() throws Exception {
+    void testParse() throws Exception {
         final ContentType contentType = ContentType.parse("text/plain; charset=\"ascii\"");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertEquals(StandardCharsets.US_ASCII, contentType.getCharset());
@@ -96,7 +96,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testParseMultiparam() throws Exception {
+    void testParseMultiparam() throws Exception {
         final ContentType contentType = ContentType.parse("text/plain; charset=\"ascii\"; " +
                 "p0 ; p1 = \"blah-blah\"  ; p2 = \" yada yada \" ");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
@@ -110,14 +110,14 @@ public class TestContentType {
     }
 
     @Test
-    public void testParseEmptyCharset() throws Exception {
+    void testParseEmptyCharset() throws Exception {
         final ContentType contentType = ContentType.parse("text/plain; charset=\" \"");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertNull(contentType.getCharset());
     }
 
     @Test
-    public void testParseDefaultCharset() throws Exception {
+    void testParseDefaultCharset() throws Exception {
         final ContentType contentType = ContentType.parse("text/plain; charset=\" \"");
         Assertions.assertEquals("text/plain", contentType.getMimeType());
         Assertions.assertNull(contentType.getCharset());
@@ -129,7 +129,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testParseEmptyValue() throws Exception {
+    void testParseEmptyValue() throws Exception {
         Assertions.assertNull(ContentType.parse(null));
         Assertions.assertNull(ContentType.parse(""));
         Assertions.assertNull(ContentType.parse("   "));
@@ -138,7 +138,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testWithParamArrayChange() throws Exception {
+    void testWithParamArrayChange() throws Exception {
         final BasicNameValuePair[] params = {new BasicNameValuePair("charset", "UTF-8"),
                 new BasicNameValuePair("p", "this"),
                 new BasicNameValuePair("p", "that")};
@@ -154,7 +154,7 @@ public class TestContentType {
     }
 
     @Test
-    public void testWithParams() throws Exception {
+    void testWithParams() throws Exception {
         ContentType contentType = ContentType.create("text/plain",
                 new BasicNameValuePair("charset", "UTF-8"),
                 new BasicNameValuePair("p", "this"),

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpExceptions.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpExceptions.java
@@ -42,18 +42,18 @@ class TestHttpExceptions {
     @Test
     void testConstructor() {
         final Throwable cause = new Exception();
-        new HttpException();
-        new HttpException("Oppsie");
-        new HttpException("Oppsie", cause);
-        new ProtocolException();
-        new ProtocolException("Oppsie");
-        new ProtocolException("Oppsie", cause);
-        new NoHttpResponseException("Oppsie");
-        new ConnectionClosedException("Oppsie");
-        new MethodNotSupportedException("Oppsie");
-        new MethodNotSupportedException("Oppsie", cause);
-        new UnsupportedHttpVersionException();
-        new UnsupportedHttpVersionException("Oppsie");
+        Assertions.assertDoesNotThrow(() -> new HttpException());
+        Assertions.assertDoesNotThrow(() -> new HttpException("Oppsie"));
+        Assertions.assertDoesNotThrow(() -> new HttpException("Oppsie", cause));
+        Assertions.assertDoesNotThrow(() -> new ProtocolException());
+        Assertions.assertDoesNotThrow(() -> new ProtocolException("Oppsie"));
+        Assertions.assertDoesNotThrow(() -> new ProtocolException("Oppsie", cause));
+        Assertions.assertDoesNotThrow(() -> new NoHttpResponseException("Oppsie"));
+        Assertions.assertDoesNotThrow(() -> new ConnectionClosedException("Oppsie"));
+        Assertions.assertDoesNotThrow(() -> new MethodNotSupportedException("Oppsie"));
+        Assertions.assertDoesNotThrow(() -> new MethodNotSupportedException("Oppsie", cause));
+        Assertions.assertDoesNotThrow(() -> new UnsupportedHttpVersionException());
+        Assertions.assertDoesNotThrow(() -> new UnsupportedHttpVersionException("Oppsie"));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpExceptions.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpExceptions.java
@@ -33,14 +33,14 @@ import org.junit.jupiter.api.Test;
 /**
  * Simple tests for various HTTP exception classes.
  */
-public class TestHttpExceptions {
+class TestHttpExceptions {
 
     private static final String CLEAN_MESSAGE = "[0x00]Hello[0x06][0x07][0x08][0x09][0x0a][0x0b][0x0c][0x0d][0x0e][0x0f]World";
     private static final String nonPrintableMessage = String.valueOf(
             new char[] { 1, 'H', 'e', 'l', 'l', 'o', 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 'W', 'o', 'r', 'l', 'd' });
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final Throwable cause = new Exception();
         new HttpException();
         new HttpException("Oppsie");
@@ -57,32 +57,32 @@ public class TestHttpExceptions {
     }
 
     @Test
-    public void testNonPrintableCharactersInConnectionClosedException() {
+    void testNonPrintableCharactersInConnectionClosedException() {
         Assertions.assertEquals(CLEAN_MESSAGE, new ConnectionClosedException(nonPrintableMessage).getMessage());
     }
 
     @Test
-    public void testNonPrintableCharactersInHttpException() {
+    void testNonPrintableCharactersInHttpException() {
         Assertions.assertEquals(CLEAN_MESSAGE, new HttpException(nonPrintableMessage).getMessage());
     }
 
     @Test
-    public void testNonPrintableCharactersInMethodNotSupportedException() {
+    void testNonPrintableCharactersInMethodNotSupportedException() {
         Assertions.assertEquals(CLEAN_MESSAGE, new MethodNotSupportedException(nonPrintableMessage).getMessage());
     }
 
     @Test
-    public void testNonPrintableCharactersInNoHttpResponseException() {
+    void testNonPrintableCharactersInNoHttpResponseException() {
         Assertions.assertEquals(CLEAN_MESSAGE, new NoHttpResponseException(nonPrintableMessage).getMessage());
     }
 
     @Test
-    public void testNonPrintableCharactersInProtocolException() {
+    void testNonPrintableCharactersInProtocolException() {
         Assertions.assertEquals(CLEAN_MESSAGE, new ProtocolException(nonPrintableMessage).getMessage());
     }
 
     @Test
-    public void testNonPrintableCharactersInUnsupportedHttpVersionException() {
+    void testNonPrintableCharactersInUnsupportedHttpVersionException() {
         Assertions.assertEquals(CLEAN_MESSAGE, new UnsupportedHttpVersionException(nonPrintableMessage).getMessage());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
@@ -90,16 +90,16 @@ class TestHttpHost {
                         "http", InetAddress.getByAddress("someotherhost",new byte[] {127,0,0,1}), 80);
 
         Assertions.assertEquals(host1.hashCode(), host1.hashCode());
-        Assertions.assertTrue(host1.hashCode() != host2.hashCode());
-        Assertions.assertTrue(host1.hashCode() != host3.hashCode());
+        Assertions.assertNotEquals(host1.hashCode(), host2.hashCode());
+        Assertions.assertNotEquals(host1.hashCode(), host3.hashCode());
         Assertions.assertEquals(host2.hashCode(), host4.hashCode());
         Assertions.assertEquals(host2.hashCode(), host5.hashCode());
-        Assertions.assertTrue(host5.hashCode() != host6.hashCode());
-        Assertions.assertTrue(host7.hashCode() != host8.hashCode());
-        Assertions.assertTrue(host8.hashCode() != host9.hashCode());
+        Assertions.assertNotEquals(host5.hashCode(), host6.hashCode());
+        Assertions.assertNotEquals(host7.hashCode(), host8.hashCode());
+        Assertions.assertNotEquals(host8.hashCode(), host9.hashCode());
         Assertions.assertEquals(host9.hashCode(), host10.hashCode());
-        Assertions.assertTrue(host10.hashCode() != host11.hashCode());
-        Assertions.assertTrue(host9.hashCode() != host11.hashCode());
+        Assertions.assertNotEquals(host10.hashCode(), host11.hashCode());
+        Assertions.assertNotEquals(host9.hashCode(), host11.hashCode());
     }
 
     @Test
@@ -127,7 +127,7 @@ class TestHttpHost {
         Assertions.assertEquals(host2, host5);
         Assertions.assertNotEquals(host5, host6);
         Assertions.assertNotEquals(host7, host8);
-        Assertions.assertFalse(host7.equals(host9));
+        Assertions.assertNotEquals(host7, host9);
         Assertions.assertNotEquals(null, host1);
         Assertions.assertNotEquals("http://somehost", host1);
         Assertions.assertNotEquals("http://somehost", host9);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
@@ -42,10 +42,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link HttpHost}.
  *
  */
-public class TestHttpHost {
+class TestHttpHost {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final HttpHost host1 = new HttpHost("somehost");
         Assertions.assertEquals("somehost", host1.getHostName());
         Assertions.assertEquals(-1, host1.getPort());
@@ -72,7 +72,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    void testHashCode() throws Exception {
         final HttpHost host1 = new HttpHost("http", "somehost", 8080);
         final HttpHost host2 = new HttpHost("http", "somehost", 80);
         final HttpHost host3 = new HttpHost("http", "someotherhost", 8080);
@@ -103,7 +103,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    void testEquals() throws Exception {
         final HttpHost host1 = new HttpHost("http", "somehost", 8080);
         final HttpHost host2 = new HttpHost("http", "somehost", 80);
         final HttpHost host3 = new HttpHost("http", "someotherhost", 8080);
@@ -137,7 +137,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testToString() throws Exception {
+    void testToString() throws Exception {
         final HttpHost host1 = new HttpHost("somehost");
         Assertions.assertEquals("http://somehost", host1.toString());
         final HttpHost host2 = new HttpHost("somehost", -1);
@@ -159,7 +159,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testToHostString() {
+    void testToHostString() {
         final HttpHost host1 = new HttpHost("somehost");
         Assertions.assertEquals("somehost", host1.toHostString());
         final HttpHost host2 = new HttpHost("somehost");
@@ -171,7 +171,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final HttpHost orig = new HttpHost("https", "somehost", 8080);
         final ByteArrayOutputStream outbuffer = new ByteArrayOutputStream();
         final ObjectOutputStream outStream = new ObjectOutputStream(outbuffer);
@@ -185,7 +185,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testCreateFromString() throws Exception {
+    void testCreateFromString() throws Exception {
         Assertions.assertEquals(new HttpHost("https", "somehost", 8080), HttpHost.create("https://somehost:8080"));
         Assertions.assertEquals(new HttpHost("https", "somehost", 8080), HttpHost.create("HttpS://SomeHost:8080"));
         Assertions.assertEquals(new HttpHost(null, "somehost", 1234), HttpHost.create("somehost:1234"));
@@ -193,21 +193,21 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testCreateFromURI() throws Exception {
+    void testCreateFromURI() {
         Assertions.assertEquals(new HttpHost("https", "somehost", 8080), HttpHost.create(URI.create("https://somehost:8080")));
         Assertions.assertEquals(new HttpHost("https", "somehost", 8080), HttpHost.create(URI.create("HttpS://SomeHost:8080")));
         Assertions.assertEquals(new HttpHost("https", "somehost", 8080), HttpHost.create(URI.create("HttpS://SomeHost:8080/foo")));
     }
 
     @Test
-    public void testCreateFromStringInvalid() throws Exception {
+    void testCreateFromStringInvalid() {
         Assertions.assertThrows(URISyntaxException.class, () -> HttpHost.create(" host "));
         Assertions.assertThrows(URISyntaxException.class, () -> HttpHost.create("host :8080"));
         Assertions.assertThrows(IllegalArgumentException.class, () -> HttpHost.create(""));
     }
 
     @Test
-    public void testIpv6HostAndPort() throws Exception {
+    void testIpv6HostAndPort() throws Exception {
         final HttpHost host = HttpHost.create("[::1]:80");
         Assertions.assertEquals("http", host.getSchemeName());
         Assertions.assertEquals("::1", host.getHostName());
@@ -215,7 +215,7 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testIpv6HostAndPortWithScheme() throws Exception {
+    void testIpv6HostAndPortWithScheme() throws Exception {
         final HttpHost host = HttpHost.create("https://[::1]:80");
         Assertions.assertEquals("https", host.getSchemeName());
         Assertions.assertEquals("::1", host.getHostName());
@@ -223,17 +223,17 @@ public class TestHttpHost {
     }
 
     @Test
-    public void testIpv6HostAndPortWithoutBrackets() throws Exception {
+    void testIpv6HostAndPortWithoutBrackets() {
         Assertions.assertThrows(URISyntaxException.class, () -> HttpHost.create("::1:80"));
     }
 
     @Test
-    public void testIpv6HostWithoutPort() throws Exception {
+    void testIpv6HostWithoutPort() {
         Assertions.assertThrows(URISyntaxException.class, () -> HttpHost.create("::1"));
     }
 
     @Test
-    public void testIpv6HostToString() {
+    void testIpv6HostToString() {
         Assertions.assertEquals("http://[::1]:80", new HttpHost("::1", 80).toString());
         Assertions.assertEquals("http://[::1]", new HttpHost("::1", -1).toString());
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpVersion.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpVersion.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Test cases for HTTP version class
  */
-public class TestHttpVersion {
+class TestHttpVersion {
 
     @Test
-    public void testEqualsMajorMinor() {
+    void testEqualsMajorMinor() {
         Assertions.assertTrue(HttpVersion.HTTP_0_9.equals(0, 9));
         Assertions.assertTrue(HttpVersion.HTTP_1_0.equals(1, 0));
         Assertions.assertTrue(HttpVersion.HTTP_1_1.equals(1, 1));
@@ -52,7 +52,7 @@ public class TestHttpVersion {
     }
 
     @Test
-    public void testGet() {
+    void testGet() {
         Assertions.assertEquals(HttpVersion.HTTP_0_9, HttpVersion.get(0, 9));
         Assertions.assertEquals(HttpVersion.HTTP_1_0, HttpVersion.get(1, 0));
         Assertions.assertEquals(HttpVersion.HTTP_1_1, HttpVersion.get(1, 1));
@@ -70,13 +70,13 @@ public class TestHttpVersion {
 
     @SuppressWarnings("unused")
     @Test
-    public void testHttpVersionInvalidConstructorInput() throws Exception {
+    void testHttpVersionInvalidConstructorInput() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> new HttpVersion(-1, -1));
         Assertions.assertThrows(IllegalArgumentException.class, () -> new HttpVersion(0, -1));
     }
 
     @Test
-    public void testHttpVersionEquality() throws Exception {
+    void testHttpVersionEquality() {
         final HttpVersion ver1 = new HttpVersion(1, 1);
         final HttpVersion ver2 = new HttpVersion(1, 1);
 
@@ -105,7 +105,7 @@ public class TestHttpVersion {
     }
 
     @Test
-    public void testHttpVersionComparison() {
+    void testHttpVersionComparison() {
         Assertions.assertTrue(HttpVersion.HTTP_0_9.lessEquals(HttpVersion.HTTP_1_1));
         Assertions.assertTrue(HttpVersion.HTTP_0_9.greaterEquals(HttpVersion.HTTP_0_9));
         Assertions.assertFalse(HttpVersion.HTTP_0_9.greaterEquals(HttpVersion.HTTP_1_0));
@@ -116,7 +116,7 @@ public class TestHttpVersion {
    }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final HttpVersion orig = HttpVersion.HTTP_1_1;
         final ByteArrayOutputStream outbuffer = new ByteArrayOutputStream();
         try (final ObjectOutputStream outStream = new ObjectOutputStream(outbuffer)) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpVersion.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpVersion.java
@@ -86,17 +86,17 @@ class TestHttpVersion {
         Assertions.assertEquals(ver1, ver1);
         Assertions.assertEquals(ver1, ver2);
 
-        Assertions.assertFalse(ver1.equals(Float.valueOf(1.1f)));
+        Assertions.assertNotEquals(ver1, Float.valueOf(1.1f));
 
-        Assertions.assertEquals((new HttpVersion(0, 9)), HttpVersion.HTTP_0_9);
-        Assertions.assertEquals((new HttpVersion(1, 0)), HttpVersion.HTTP_1_0);
-        Assertions.assertEquals((new HttpVersion(1, 1)), HttpVersion.HTTP_1_1);
-        Assertions.assertNotEquals((new HttpVersion(1, 1)), HttpVersion.HTTP_1_0);
+        Assertions.assertEquals(HttpVersion.HTTP_0_9, (new HttpVersion(0, 9)));
+        Assertions.assertEquals(HttpVersion.HTTP_1_0, (new HttpVersion(1, 0)));
+        Assertions.assertEquals(HttpVersion.HTTP_1_1, (new HttpVersion(1, 1)));
+        Assertions.assertNotEquals(HttpVersion.HTTP_1_0, (new HttpVersion(1, 1)));
 
-        Assertions.assertEquals((new ProtocolVersion("HTTP", 0, 9)), HttpVersion.HTTP_0_9);
-        Assertions.assertEquals((new ProtocolVersion("HTTP", 1, 0)), HttpVersion.HTTP_1_0);
-        Assertions.assertEquals((new ProtocolVersion("HTTP", 1, 1)), HttpVersion.HTTP_1_1);
-        Assertions.assertNotEquals((new ProtocolVersion("http", 1, 1)), HttpVersion.HTTP_1_1);
+        Assertions.assertEquals(HttpVersion.HTTP_0_9, (new ProtocolVersion("HTTP", 0, 9)));
+        Assertions.assertEquals(HttpVersion.HTTP_1_0, (new ProtocolVersion("HTTP", 1, 0)));
+        Assertions.assertEquals(HttpVersion.HTTP_1_1, (new ProtocolVersion("HTTP", 1, 1)));
+        Assertions.assertNotEquals(HttpVersion.HTTP_1_1, (new ProtocolVersion("http", 1, 1)));
 
         Assertions.assertEquals(HttpVersion.HTTP_0_9, new ProtocolVersion("HTTP", 0, 9));
         Assertions.assertEquals(HttpVersion.HTTP_1_0, new ProtocolVersion("HTTP", 1, 0));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestProtocolVersion.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestProtocolVersion.java
@@ -34,14 +34,14 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestProtocolVersion {
+class TestProtocolVersion {
 
     private static final ProtocolVersion PROTOCOL_VERSION_0_0 = new ProtocolVersion("a", 0, 0);
     private static final ProtocolVersion PROTOCOL_VERSION_1_0 = new ProtocolVersion("b", 1, 0);
     private static final ProtocolVersion PROTOCOL_VERSION_1_2 = new ProtocolVersion("c", 1, 2);
 
     @Test
-    public void testEqualsMajorMinor() {
+    void testEqualsMajorMinor() {
         Assertions.assertTrue(PROTOCOL_VERSION_0_0.equals(0, 0));
         Assertions.assertTrue(PROTOCOL_VERSION_1_0.equals(1, 0));
         Assertions.assertTrue(PROTOCOL_VERSION_1_2.equals(1, 2));
@@ -50,7 +50,7 @@ public class TestProtocolVersion {
     }
 
     @Test
-    public void testParseBasic() throws Exception {
+    void testParseBasic() throws Exception {
         assertThat(ProtocolVersion.parse("PROTO/1"), CoreMatchers.equalTo(new ProtocolVersion("PROTO", 1, 0)));
         assertThat(ProtocolVersion.parse("PROTO/1.1"), CoreMatchers.equalTo(new ProtocolVersion("PROTO", 1, 1)));
         assertThat(ProtocolVersion.parse("PROTO/1.2"), CoreMatchers.equalTo(new ProtocolVersion("PROTO", 1, 2)));
@@ -60,14 +60,14 @@ public class TestProtocolVersion {
     }
 
     @Test
-    public void testParseBuffer() throws Exception {
+    void testParseBuffer() throws Exception {
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(1, 13);
         assertThat(ProtocolVersion.parse(" PROTO/1.2,0000", cursor, Tokenizer.delimiters(',')), CoreMatchers.equalTo(new ProtocolVersion("PROTO", 1, 2)));
         assertThat(cursor.getPos(), CoreMatchers.equalTo(10));
     }
 
     @Test
-    public void testParseFailure() throws Exception {
+    void testParseFailure() {
         Assertions.assertThrows(ParseException.class, () -> ProtocolVersion.parse("/1"));
         Assertions.assertThrows(ParseException.class, () -> ProtocolVersion.parse(" /1"));
         Assertions.assertThrows(ParseException.class, () -> ProtocolVersion.parse("PROTO/"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestProtocolVersionParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestProtocolVersionParser.java
@@ -39,12 +39,12 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link ProtocolVersionParser}.
  */
-public class TestProtocolVersionParser {
+class TestProtocolVersionParser {
 
     private ProtocolVersionParser impl;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         impl = new ProtocolVersionParser();
     }
 
@@ -69,7 +69,7 @@ public class TestProtocolVersionParser {
     }
 
     @Test
-    public void testParseVersion() throws Exception {
+    void testParseVersion() throws Exception {
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 0), parseStr("PROTO", "1  "));
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 1), parseStr("PROTO", "1.1   "));
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 20), parseStr("PROTO", "1.020  "));
@@ -81,14 +81,14 @@ public class TestProtocolVersionParser {
     }
 
     @Test
-    public void testParseVersionWithCursor() throws Exception {
+    void testParseVersionWithCursor() throws Exception {
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(2, 13);
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 20), parseStr("PROTO", "  1.20,0000,00000", cursor, Tokenizer.delimiters(',')));
         assertThat(cursor.getPos(), CoreMatchers.equalTo(6));
     }
 
     @Test
-    public void testParseProtocolVersion() throws Exception {
+    void testParseProtocolVersion() throws Exception {
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 0), parseStr("PROTO/1  "));
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 1), parseStr("PROTO/1.1   "));
         Assertions.assertEquals(new ProtocolVersion("PROTO", 1, 20), parseStr("PROTO/1.020  "));
@@ -100,7 +100,7 @@ public class TestProtocolVersionParser {
     }
 
     @Test
-    public void testParseFailures() throws Exception {
+    void testParseFailures() {
         Assertions.assertThrows(ParseException.class, () -> parseStr("PROTO", "blah"));
         Assertions.assertThrows(ParseException.class, () -> parseStr("PROTO", "1.blah"));
         Assertions.assertThrows(ParseException.class, () -> parseStr("PROTO", "1A.0"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/config/TestNamedElementChain.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/config/TestNamedElementChain.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link NamedElementChain}.
  */
-public class TestNamedElementChain {
+class TestNamedElementChain {
 
     @Test
-    public void testBasics() {
+    void testBasics() {
         final NamedElementChain<Character> list = new NamedElementChain<>();
         assertThat(list.getFirst(), CoreMatchers.nullValue());
         assertThat(list.getLast(), CoreMatchers.nullValue());
@@ -100,7 +100,7 @@ public class TestNamedElementChain {
     }
 
     @Test
-    public void testFind() {
+    void testFind() {
         final NamedElementChain<Character> list = new NamedElementChain<>();
         list.addLast('c', "c");
         assertThat(list.find("c"), notNullValue());
@@ -108,7 +108,7 @@ public class TestNamedElementChain {
     }
 
     @Test
-    public void testReplace() {
+    void testReplace() {
         final NamedElementChain<Character> list = new NamedElementChain<>();
         list.addLast('c', "c");
         final boolean found = list.replace("c",'z' );

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/config/TestRegistry.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/config/TestRegistry.java
@@ -29,10 +29,10 @@ package org.apache.hc.core5.http.config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestRegistry {
+class TestRegistry {
 
     @Test
-    public void testCompleted() throws Exception {
+    void testCompleted() {
         final Registry<String> reg = RegistryBuilder.<String>create().register("Stuff", "Stuff").build();
         Assertions.assertEquals("Stuff", reg.lookup("Stuff"));
         Assertions.assertEquals("Stuff", reg.lookup("stuff"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/IncomingEntityDetailsTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/IncomingEntityDetailsTest.java
@@ -46,10 +46,10 @@ import org.apache.hc.core5.http.message.HeaderGroup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class IncomingEntityDetailsTest {
+class IncomingEntityDetailsTest {
 
     @Test
-    public void getContentLengthEmpty() {
+    void getContentLengthEmpty() {
         final MessageHeaders messageHeaders = new HeaderGroup();
         final IncomingEntityDetails incomingEntityDetails = new IncomingEntityDetails(messageHeaders);
         assertAll(
@@ -61,13 +61,13 @@ public class IncomingEntityDetailsTest {
     }
 
     @Test
-    public void messageHeadersNull() {
+    void messageHeadersNull() {
         Assertions.assertThrows(NullPointerException.class, () -> new IncomingEntityDetails(null),
                 "Message Header Null");
     }
 
     @Test
-    public void getContentLength() {
+    void getContentLength() {
         final MessageHeaders messageHeaders = new HeaderGroup();
         final HeaderGroup headerGroup = new HeaderGroup();
         final Header header = new BasicHeader("name", "value");
@@ -80,7 +80,7 @@ public class IncomingEntityDetailsTest {
     }
 
     @Test
-    public void getTrailerNames() {
+    void getTrailerNames() {
         final HeaderGroup messageHeaders = new HeaderGroup();
         final Header header = new BasicHeader(HttpHeaders.TRAILER, "a, b, c, c");
         messageHeaders.setHeaders(header);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/IncomingEntityDetailsTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/IncomingEntityDetailsTest.java
@@ -56,7 +56,7 @@ class IncomingEntityDetailsTest {
                 () -> assertEquals(-1, incomingEntityDetails.getContentLength()),
                 () -> assertNull(incomingEntityDetails.getContentType()),
                 () -> assertNull(incomingEntityDetails.getContentEncoding()),
-                () -> assertEquals(incomingEntityDetails.getTrailerNames().size(), 0)
+                () -> assertEquals(0, incomingEntityDetails.getTrailerNames().size())
         );
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultConnectionReuseStrategy.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultConnectionReuseStrategy.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestDefaultConnectionReuseStrategy {
+class TestDefaultConnectionReuseStrategy {
 
     /** HTTP context. */
     private HttpCoreContext context;
@@ -49,39 +49,39 @@ public class TestDefaultConnectionReuseStrategy {
     private ConnectionReuseStrategy reuseStrategy;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         reuseStrategy = DefaultConnectionReuseStrategy.INSTANCE;
         context = HttpCoreContext.create();
     }
 
     @Test
-    public void testInvalidResponseArg() throws Exception {
+    void testInvalidResponseArg() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 reuseStrategy.keepAlive(null, null, this.context));
     }
 
     @Test
-    public void testNoContentLengthResponseHttp1_0() throws Exception {
+    void testNoContentLengthResponseHttp1_0() {
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         Assertions.assertFalse(reuseStrategy.keepAlive(null, response, context));
     }
 
     @Test
-    public void testNoContentLengthResponseHttp1_1() throws Exception {
+    void testNoContentLengthResponseHttp1_1() {
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         Assertions.assertFalse(reuseStrategy.keepAlive(null, response, context));
     }
 
     @Test
-    public void testChunkedContent() throws Exception {
+    void testChunkedContent() {
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
         Assertions.assertTrue(reuseStrategy.keepAlive(null, response, context));
     }
 
     @Test
-    public void testIgnoreInvalidKeepAlive() throws Exception {
+    void testIgnoreInvalidKeepAlive() {
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Connection", "keep-alive");
@@ -89,7 +89,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testExplicitClose() throws Exception {
+    void testExplicitClose() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -98,7 +98,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testExplicitKeepAlive() throws Exception {
+    void testExplicitKeepAlive() {
         // Use HTTP 1.0
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -109,7 +109,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHTTP10Default() throws Exception {
+    void testHTTP10Default() {
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
         response.addHeader("Content-Length", "10");
@@ -117,14 +117,14 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHTTP11Default() throws Exception {
+    void testHTTP11Default() {
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Content-Length", "10");
         Assertions.assertTrue(reuseStrategy.keepAlive(null, response, context));
     }
 
     @Test
-    public void testBrokenConnectionDirective1() throws Exception {
+    void testBrokenConnectionDirective1() {
         // Use HTTP 1.0
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -134,7 +134,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testBrokenConnectionDirective2() throws Exception {
+    void testBrokenConnectionDirective2() {
         // Use HTTP 1.0
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -144,7 +144,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testConnectionTokens1() throws Exception {
+    void testConnectionTokens1() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -153,7 +153,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testConnectionTokens2() throws Exception {
+    void testConnectionTokens2() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -162,7 +162,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testConnectionTokens3() throws Exception {
+    void testConnectionTokens3() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -171,7 +171,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testConnectionTokens4() throws Exception {
+    void testConnectionTokens4() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -182,7 +182,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testConnectionTokens5() throws Exception {
+    void testConnectionTokens5() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -195,7 +195,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testConnectionTokens6() throws Exception {
+    void testConnectionTokens6() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
@@ -207,7 +207,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testMultipleContentLength() throws Exception {
+    void testMultipleContentLength() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.addHeader("Content-Length", "10");
@@ -216,14 +216,14 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testNoContentResponse() throws Exception {
+    void testNoContentResponse() {
         // Use HTTP 1.1
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         Assertions.assertTrue(reuseStrategy.keepAlive(null, response, context));
     }
 
     @Test
-    public void testNoContentResponseHttp10() throws Exception {
+    void testNoContentResponseHttp10() {
         // Use HTTP 1.0
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -231,7 +231,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testRequestExplicitClose() throws Exception {
+    void testRequestExplicitClose() {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "/");
         request.addHeader("Connection", "close");
 
@@ -242,7 +242,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testRequestNoExplicitClose() throws Exception {
+    void testRequestNoExplicitClose() {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "/");
         request.addHeader("Connection", "blah, blah, blah");
 
@@ -253,7 +253,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testRequestExplicitCloseMultipleTokens() throws Exception {
+    void testRequestExplicitCloseMultipleTokens() {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "/");
         request.addHeader("Connection", "blah, blah, blah");
         request.addHeader("Connection", "keep-alive");
@@ -266,7 +266,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testRequestClose() throws Exception {
+    void testRequestClose() {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "/");
         request.addHeader("Connection", "close");
 
@@ -278,7 +278,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHeadRequestWithout() throws Exception {
+    void testHeadRequestWithout() {
         final HttpRequest request = new BasicHttpRequest(Method.HEAD, "/");
         final HttpResponse response = new BasicHttpResponse(200, "OK");
 
@@ -286,7 +286,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHttp204ContentLengthGreaterThanZero() throws Exception {
+    void testHttp204ContentLengthGreaterThanZero() {
         final HttpResponse response = new BasicHttpResponse(204, "OK");
         response.addHeader("Content-Length", "10");
         response.addHeader("Connection", "keep-alive");
@@ -294,7 +294,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHttp204ContentLengthEqualToZero() throws Exception {
+    void testHttp204ContentLengthEqualToZero() {
         final HttpResponse response = new BasicHttpResponse(204, "OK");
         response.addHeader("Content-Length", "0");
         response.addHeader("Connection", "keep-alive");
@@ -302,7 +302,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testHttp204ChunkedContent() throws Exception {
+    void testHttp204ChunkedContent() {
         final HttpResponse response = new BasicHttpResponse(204, "OK");
         response.addHeader("Transfer-Encoding", "chunked");
         response.addHeader("Connection", "keep-alive");
@@ -310,7 +310,7 @@ public class TestDefaultConnectionReuseStrategy {
     }
 
     @Test
-    public void testResponseHTTP10TransferEncodingPresent() throws Exception {
+    void testResponseHTTP10TransferEncodingPresent() {
         final HttpResponse response = new BasicHttpResponse(200, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
         response.addHeader("Transfer-Encoding", "chunked");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultContentLengthStrategy.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultContentLengthStrategy.java
@@ -37,7 +37,7 @@ import org.apache.hc.core5.http.message.HeaderGroup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDefaultContentLengthStrategy {
+class TestDefaultContentLengthStrategy {
 
     static class TestHttpMessage extends HeaderGroup implements HttpMessage {
 
@@ -65,7 +65,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithChunkTransferEncoding() throws Exception {
+    void testEntityWithChunkTransferEncoding() throws Exception {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", "Chunked");
@@ -74,7 +74,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithChunkTransferEncodingAndEmptyTokens() throws Exception {
+    void testEntityWithChunkTransferEncodingAndEmptyTokens() throws Exception {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", ",,Chunked,,");
@@ -83,7 +83,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithChunkTransferEncodingDoubleChunk() throws Exception {
+    void testEntityWithChunkTransferEncodingDoubleChunk() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", "Chunked,Chunked");
@@ -92,7 +92,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithChunkTransferEncodingUnknown1() throws Exception {
+    void testEntityWithChunkTransferEncodingUnknown1() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", "blah");
@@ -101,7 +101,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithChunkTransferEncodingUnknown2() throws Exception {
+    void testEntityWithChunkTransferEncodingUnknown2() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", "blah, chunked");
@@ -110,7 +110,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithChunkTransferEncodingUnknown3() throws Exception {
+    void testEntityWithChunkTransferEncodingUnknown3() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", "chunked,blah");
@@ -119,7 +119,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithIdentityTransferEncoding() throws Exception {
+    void testEntityWithIdentityTransferEncoding() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Transfer-Encoding", "Identity");
@@ -128,7 +128,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithContentLength() throws Exception {
+    void testEntityWithContentLength() throws Exception  {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Content-Length", "100");
@@ -136,7 +136,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithInvalidContentLength() throws Exception {
+    void testEntityWithInvalidContentLength() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Content-Length", "whatever");
@@ -145,7 +145,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityWithNegativeContentLength() throws Exception {
+    void testEntityWithNegativeContentLength() {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         message.addHeader("Content-Length", "-10");
@@ -154,7 +154,7 @@ public class TestDefaultContentLengthStrategy {
     }
 
     @Test
-    public void testEntityNoContentDelimiter() throws Exception {
+    void testEntityNoContentDelimiter() throws Exception {
         final ContentLengthStrategy lenStrategy = new DefaultContentLengthStrategy();
         final HttpMessage message = new TestHttpMessage();
         Assertions.assertEquals(ContentLengthStrategy.UNDEFINED, lenStrategy.determineLength(message));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestEnglishReasonPhraseCatalog.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestEnglishReasonPhraseCatalog.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link EnglishReasonPhraseCatalog}
  *
  */
-public class TestEnglishReasonPhraseCatalog {
+class TestEnglishReasonPhraseCatalog {
 
     @Test
-    public void testReasonPhrases() throws IllegalAccessException {
+    void testReasonPhrases() throws IllegalAccessException {
     final Field[] publicFields = HttpStatus.class.getFields();
 
     Assertions.assertNotNull( publicFields );
@@ -68,7 +68,7 @@ public class TestEnglishReasonPhraseCatalog {
 
 
     @Test
-    public void testStatusInvalid() throws Exception {
+    void testStatusInvalid() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 EnglishReasonPhraseCatalog.INSTANCE.getReason(-1, null));
         Assertions.assertThrows(IllegalArgumentException.class, () ->
@@ -78,7 +78,7 @@ public class TestEnglishReasonPhraseCatalog {
     }
 
     @Test
-    public void testStatusAll() throws Exception {
+    void testStatusAll() {
         for (int i = 100; i < 600; i++) {
             EnglishReasonPhraseCatalog.INSTANCE.getReason(i, null);
         }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestBHttpConnectionBase.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestBHttpConnectionBase.java
@@ -50,7 +50,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class TestBHttpConnectionBase {
+class TestBHttpConnectionBase {
 
     @Mock
     private Socket socket;
@@ -58,13 +58,13 @@ public class TestBHttpConnectionBase {
     private BHttpConnectionBase conn;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
         conn = new BHttpConnectionBase(Http1Config.DEFAULT, null, null);
     }
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
         Assertions.assertFalse(conn.isOpen());
         Assertions.assertNull(conn.getLocalAddress());
         Assertions.assertNull(conn.getRemoteAddress());
@@ -72,7 +72,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testSocketBind() throws Exception {
+    void testSocketBind() throws Exception {
         final InetAddress localAddress = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
         final int localPort = 8888;
         final InetAddress remoteAddress = InetAddress.getByAddress(new byte[] {10, 0, 0, 2});
@@ -93,7 +93,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testConnectionClose() throws Exception {
+    void testConnectionClose() throws Exception {
         final OutputStream outStream = Mockito.mock(OutputStream.class);
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -118,7 +118,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testConnectionShutdown() throws Exception {
+    void testConnectionShutdown() throws Exception {
         final OutputStream outStream = Mockito.mock(OutputStream.class);
 
         conn.bind(socket);
@@ -145,7 +145,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testCreateEntityLengthDelimited() throws Exception {
+    void testCreateEntityLengthDelimited() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         final ClassicHttpResponse message = new BasicClassicHttpResponse(200, "OK");
         message.addHeader("Content-Length", "10");
@@ -163,7 +163,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testCreateEntityInputChunked() throws Exception {
+    void testCreateEntityInputChunked() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         final ClassicHttpResponse message = new BasicClassicHttpResponse(200, "OK");
         final HttpEntity entity = conn.createIncomingEntity(message, conn.inBuffer, inStream, ContentLengthStrategy.CHUNKED);
@@ -176,7 +176,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testCreateEntityInputUndefined() throws Exception {
+    void testCreateEntityInputUndefined() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         final ClassicHttpResponse message = new BasicClassicHttpResponse(200, "OK");
         final HttpEntity entity = conn.createIncomingEntity(message, conn.inBuffer, inStream, ContentLengthStrategy.UNDEFINED);
@@ -189,7 +189,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testSetSocketTimeout() throws Exception {
+    void testSetSocketTimeout() throws Exception {
         conn.bind(socket);
 
         conn.setSocketTimeout(Timeout.ofMilliseconds(123));
@@ -198,7 +198,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testSetSocketTimeoutException() throws Exception {
+    void testSetSocketTimeoutException() throws Exception {
         conn.bind(socket);
 
         Mockito.doThrow(new SocketException()).when(socket).setSoTimeout(ArgumentMatchers.anyInt());
@@ -209,7 +209,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testGetSocketTimeout() throws Exception {
+    void testGetSocketTimeout() throws Exception {
         Assertions.assertEquals(Timeout.INFINITE, conn.getSocketTimeout());
 
         Mockito.when(socket.getSoTimeout()).thenReturn(345);
@@ -219,7 +219,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testGetSocketTimeoutException() throws Exception {
+    void testGetSocketTimeoutException() throws Exception {
         Assertions.assertEquals(Timeout.INFINITE, conn.getSocketTimeout());
 
         Mockito.when(socket.getSoTimeout()).thenThrow(new SocketException());
@@ -229,7 +229,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testAwaitInputInBuffer() throws Exception {
+    void testAwaitInputInBuffer() throws Exception {
         final ByteArrayInputStream inStream = new ByteArrayInputStream(
                 new byte[] {1, 2, 3, 4, 5});
         conn.bind(socket);
@@ -242,7 +242,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testAwaitInputInSocket() throws Exception {
+    void testAwaitInputInSocket() throws Exception {
         final ByteArrayInputStream inStream = new ByteArrayInputStream(
                 new byte[] {1, 2, 3, 4, 5});
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -258,7 +258,7 @@ public class TestBHttpConnectionBase {
         }
 
     @Test
-    public void testAwaitInputNoData() throws Exception {
+    void testAwaitInputNoData() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
         Mockito.when(inStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
@@ -271,7 +271,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testStaleWhenClosed() throws Exception {
+    void testStaleWhenClosed() throws Exception {
         final OutputStream outStream = Mockito.mock(OutputStream.class);
 
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
@@ -283,7 +283,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testNotStaleWhenHasData() throws Exception {
+    void testNotStaleWhenHasData() throws Exception {
         final ByteArrayInputStream inStream = new ByteArrayInputStream(
                 new byte[] {1, 2, 3, 4, 5});
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -295,7 +295,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testStaleWhenEndOfStream() throws Exception {
+    void testStaleWhenEndOfStream() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
         Mockito.when(inStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
@@ -308,7 +308,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testNotStaleWhenTimeout() throws Exception {
+    void testNotStaleWhenTimeout() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
         Mockito.when(inStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
@@ -321,7 +321,7 @@ public class TestBHttpConnectionBase {
     }
 
     @Test
-    public void testStaleWhenIOError() throws Exception {
+    void testStaleWhenIOError() throws Exception {
         final InputStream inStream = Mockito.mock(InputStream.class);
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
         Mockito.when(inStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
@@ -45,7 +45,7 @@ import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestChunkCoding {
+class TestChunkCoding {
 
     private final static String CHUNKED_INPUT
         = "10;key=\"value\"\r\n1234567890123456\r\n5\r\n12345\r\n0\r\nFooter1: abcde\r\nFooter2: fghij\r\n";
@@ -54,7 +54,7 @@ public class TestChunkCoding {
         = "123456789012345612345";
 
     @Test
-    public void testChunkedInputStreamLargeBuffer() throws IOException {
+    void testChunkedInputStreamLargeBuffer() throws IOException {
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
@@ -83,7 +83,7 @@ public class TestChunkCoding {
 
     //Test for when buffer is smaller than chunk size.
     @Test
-    public void testChunkedInputStreamSmallBuffer() throws IOException {
+    void testChunkedInputStreamSmallBuffer() throws IOException {
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(CHUNKED_INPUT.getBytes(StandardCharsets.US_ASCII));
         final ChunkedInputStream in = new ChunkedInputStream(inBuffer, inputStream);
@@ -110,7 +110,7 @@ public class TestChunkCoding {
 
     // One byte read
     @Test
-    public void testChunkedInputStreamOneByteRead() throws IOException {
+    void testChunkedInputStreamOneByteRead() throws IOException {
         final String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -128,7 +128,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testAvailable() throws IOException {
+    void testAvailable() throws IOException {
         final String s = "5\r\n12345\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -140,7 +140,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedInputStreamClose() throws IOException {
+    void testChunkedInputStreamClose() throws IOException {
         final String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -155,7 +155,7 @@ public class TestChunkCoding {
 
     // Missing closing chunk
     @Test
-    public void testChunkedInputStreamNoClosingChunk() throws IOException {
+    void testChunkedInputStreamNoClosingChunk() throws IOException {
         final String s = "5\r\n01234\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -168,7 +168,7 @@ public class TestChunkCoding {
 
     // Truncated stream (missing closing CRLF)
     @Test
-    public void testCorruptChunkedInputStreamTruncatedCRLF() throws IOException {
+    void testCorruptChunkedInputStreamTruncatedCRLF() throws IOException {
         final String s = "5\r\n01234";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -181,7 +181,7 @@ public class TestChunkCoding {
 
     // Missing \r\n at the end of the first chunk
     @Test
-    public void testCorruptChunkedInputStreamMissingCRLF() throws IOException {
+    void testCorruptChunkedInputStreamMissingCRLF() throws IOException {
         final String s = "5\r\n012345\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -199,7 +199,7 @@ public class TestChunkCoding {
 
     // Missing LF
     @Test
-    public void testCorruptChunkedInputStreamMissingLF() throws IOException {
+    void testCorruptChunkedInputStreamMissingLF() throws IOException {
         final String s = "5\r01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -210,7 +210,7 @@ public class TestChunkCoding {
 
     // Invalid chunk size
     @Test
-    public void testCorruptChunkedInputStreamInvalidSize() throws IOException {
+    void testCorruptChunkedInputStreamInvalidSize() throws IOException {
         final String s = "whatever\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -221,7 +221,7 @@ public class TestChunkCoding {
 
     // Negative chunk size
     @Test
-    public void testCorruptChunkedInputStreamNegativeSize() throws IOException {
+    void testCorruptChunkedInputStreamNegativeSize() throws IOException {
         final String s = "-5\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -232,7 +232,7 @@ public class TestChunkCoding {
 
     // Truncated chunk
     @Test
-    public void testCorruptChunkedInputStreamTruncatedChunk() throws IOException {
+    void testCorruptChunkedInputStreamTruncatedChunk() throws IOException {
         final String s = "3\r\n12";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -245,7 +245,7 @@ public class TestChunkCoding {
 
     // Invalid footer
     @Test
-    public void testCorruptChunkedInputStreamInvalidFooter() throws IOException {
+    void testCorruptChunkedInputStreamInvalidFooter() throws IOException {
         final String s = "1\r\n0\r\n0\r\nstuff\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -256,7 +256,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testCorruptChunkedInputStreamClose() throws IOException {
+    void testCorruptChunkedInputStreamClose() throws IOException {
         final String s = "whatever\r\n01234\r\n5\r\n56789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -266,7 +266,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testEmptyChunkedInputStream() throws IOException {
+    void testEmptyChunkedInputStream() throws IOException {
         final String s = "0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -282,7 +282,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testTooLongChunkHeader() throws IOException {
+    void testTooLongChunkHeader() throws IOException {
         final String s = "5; and some very looooong commend\r\n12345\r\n0\r\n";
         final SessionInputBuffer inBuffer1 = new SessionInputBufferImpl(16);
         final byte[] buffer = new byte[300];
@@ -298,7 +298,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedOutputStreamClose() throws IOException {
+    void testChunkedOutputStreamClose() throws IOException {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final ChunkedOutputStream out = new ChunkedOutputStream(outbuffer, outputStream, 2048);
@@ -309,7 +309,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedConsistence() throws IOException {
+    void testChunkedConsistence() throws IOException {
         final String input = "76126;27823abcd;:q38a-\nkjc\rk%1ad\tkh/asdui\r\njkh+?\\suweb";
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -335,7 +335,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedOutputStreamWithTrailers() throws IOException {
+    void testChunkedOutputStreamWithTrailers() throws IOException {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final ChunkedOutputStream out = new ChunkedOutputStream(outbuffer, outputStream, 2, () -> Arrays.asList(
@@ -351,7 +351,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedOutputStream() throws IOException {
+    void testChunkedOutputStream() throws IOException {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final ChunkedOutputStream out = new ChunkedOutputStream(outbuffer, outputStream, 2);
@@ -367,7 +367,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedOutputStreamLargeChunk() throws IOException {
+    void testChunkedOutputStreamLargeChunk() throws IOException {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final ChunkedOutputStream out = new ChunkedOutputStream(outbuffer, outputStream, 2);
@@ -380,7 +380,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testChunkedOutputStreamSmallChunk() throws IOException {
+    void testChunkedOutputStreamSmallChunk() throws IOException {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final ChunkedOutputStream out = new ChunkedOutputStream(outbuffer, outputStream, 2);
@@ -393,7 +393,7 @@ public class TestChunkCoding {
     }
 
     @Test
-    public void testResumeOnSocketTimeoutInData() throws IOException {
+    void testResumeOnSocketTimeoutInData() throws IOException {
         final String s = "5\r\n01234\r\n5\r\n5\0006789\r\na\r\n0123\000456789\r\n0\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final TimeoutByteArrayInputStream inputStream = new TimeoutByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -421,7 +421,7 @@ public class TestChunkCoding {
 }
 
     @Test
-    public void testResumeOnSocketTimeoutInChunk() throws IOException {
+    void testResumeOnSocketTimeoutInChunk() throws IOException {
         final String s = "5\000\r\000\n\00001234\r\n\0005\r\n56789\r\na\r\n0123456789\r\n\0000\r\n";
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final TimeoutByteArrayInputStream inputStream = new TimeoutByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -450,7 +450,7 @@ public class TestChunkCoding {
 
     // Test for when buffer is larger than chunk size
     @Test
-    public void testHugeChunk() throws IOException {
+    void testHugeChunk() throws IOException {
 
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("1234567890abcdef\r\n01234567".getBytes(

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestChunkCoding.java
@@ -70,7 +70,7 @@ class TestChunkCoding {
         in.close();
 
         final String result = new String(out.toByteArray(), StandardCharsets.US_ASCII);
-        Assertions.assertEquals(result, CHUNKED_RESULT);
+        Assertions.assertEquals(CHUNKED_RESULT, result);
 
         final Header[] footers = in.getFooters();
         Assertions.assertNotNull(footers);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
@@ -56,7 +56,7 @@ class TestContentLengthInputStream {
         outputStream.write(buffer, 0, len);
 
         final String result = new String(outputStream.toByteArray(), StandardCharsets.US_ASCII);
-        Assertions.assertEquals(result, "1234567890");
+        Assertions.assertEquals("1234567890", result);
         in.close();
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthInputStream.java
@@ -39,10 +39,10 @@ import org.apache.hc.core5.http.io.SessionInputBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestContentLengthInputStream {
+class TestContentLengthInputStream {
 
     @Test
-    public void testBasics() throws IOException {
+    void testBasics() throws IOException {
         final String s = "1234567890123456";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
@@ -61,7 +61,7 @@ public class TestContentLengthInputStream {
     }
 
     @Test
-    public void testSkip() throws IOException {
+    void testSkip() throws IOException {
         final ByteArrayInputStream inputStream1 = new ByteArrayInputStream(new byte[20]);
         final SessionInputBuffer inBuffer1 = new SessionInputBufferImpl(16);
         final InputStream in1 = new ContentLengthInputStream(inBuffer1, inputStream1, 10L);
@@ -96,7 +96,7 @@ public class TestContentLengthInputStream {
     }
 
     @Test
-    public void testAvailable() throws IOException {
+    void testAvailable() throws IOException {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {1, 2, 3});
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final InputStream in = new ContentLengthInputStream(inBuffer, inputStream, 3L);
@@ -107,7 +107,7 @@ public class TestContentLengthInputStream {
     }
 
     @Test
-    public void testClose() throws IOException {
+    void testClose() throws IOException {
         final String s = "1234567890123456-";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
@@ -122,7 +122,7 @@ public class TestContentLengthInputStream {
     }
 
     @Test
-    public void testTruncatedContent() throws IOException {
+    void testTruncatedContent() throws IOException {
         final String s = "1234567890123456";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthOutputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestContentLengthOutputStream.java
@@ -35,10 +35,10 @@ import org.apache.hc.core5.http.io.SessionOutputBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestContentLengthOutputStream {
+class TestContentLengthOutputStream {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final OutputStream out = new ContentLengthOutputStream(outbuffer, outputStream, 15L);
@@ -58,7 +58,7 @@ public class TestContentLengthOutputStream {
     }
 
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final OutputStream out = new ContentLengthOutputStream(outbuffer, outputStream, 15L);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestDefaultBHttpClientConnection.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestDefaultBHttpClientConnection.java
@@ -51,7 +51,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class TestDefaultBHttpClientConnection {
+class TestDefaultBHttpClientConnection {
 
     @Mock
     private Socket socket;
@@ -59,7 +59,7 @@ public class TestDefaultBHttpClientConnection {
     private DefaultBHttpClientConnection conn;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
         conn = new DefaultBHttpClientConnection(Http1Config.DEFAULT,
                 null, null,
@@ -70,13 +70,13 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
         Assertions.assertFalse(conn.isOpen());
         Assertions.assertEquals("[Not bound]", conn.toString());
     }
 
     @Test
-    public void testReadResponseHead() throws Exception {
+    void testReadResponseHead() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nUser-Agent: test\r\n\r\n";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -93,7 +93,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testReadResponseEntityWithoutContentLength() throws Exception {
+    void testReadResponseEntityWithoutContentLength() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nServer: test\r\n\r\n123";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -125,7 +125,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testReadResponseEntityWithContentLength() throws Exception {
+    void testReadResponseEntityWithContentLength() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nServer: test\r\nContent-Length: 3\r\n\r\n123";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -153,7 +153,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testReadResponseEntityChunkCoded() throws Exception {
+    void testReadResponseEntityChunkCoded() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nServer: test\r\nTransfer-Encoding: " +
                 "chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -183,7 +183,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testReadResponseEntityIdentity() throws Exception {
+    void testReadResponseEntityIdentity() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nServer: test\r\nTransfer-Encoding: identity\r\n\r\n123";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -204,7 +204,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testReadResponseNoEntity() throws Exception {
+    void testReadResponseNoEntity() throws Exception {
         final String s = "HTTP/1.1 200 OK\r\nServer: test\r\n\r\n";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -230,7 +230,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testWriteRequestHead() throws Exception {
+    void testWriteRequestHead() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -250,7 +250,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testWriteRequestEntityWithContentLength() throws Exception {
+    void testWriteRequestEntityWithContentLength() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -273,7 +273,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testWriteRequestEntityChunkCoded() throws Exception {
+    void testWriteRequestEntityChunkCoded() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -297,7 +297,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testWriteRequestEntityNoContentLength() throws Exception {
+    void testWriteRequestEntityNoContentLength() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -315,7 +315,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testWriteRequestNoEntity() throws Exception {
+    void testWriteRequestNoEntity() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -336,7 +336,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testTerminateRequestChunkedEntity() throws Exception {
+    void testTerminateRequestChunkedEntity() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -363,7 +363,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testTerminateRequestContentLengthShort() throws Exception {
+    void testTerminateRequestContentLengthShort() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -389,7 +389,7 @@ public class TestDefaultBHttpClientConnection {
     }
 
     @Test
-    public void testTerminateRequestContentLengthLong() throws Exception {
+    void testTerminateRequestContentLengthLong() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestDefaultBHttpServerConnection.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestDefaultBHttpServerConnection.java
@@ -51,7 +51,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class TestDefaultBHttpServerConnection {
+class TestDefaultBHttpServerConnection {
 
     @Mock
     private Socket socket;
@@ -59,7 +59,7 @@ public class TestDefaultBHttpServerConnection {
     private DefaultBHttpServerConnection conn;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
         conn = new DefaultBHttpServerConnection("http", Http1Config.DEFAULT,
                 null, null,
@@ -70,13 +70,13 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
         Assertions.assertFalse(conn.isOpen());
         Assertions.assertEquals("[Not bound]", conn.toString());
     }
 
     @Test
-    public void testReadRequestHead() throws Exception {
+    void testReadRequestHead() throws Exception {
         final String s = "GET / HTTP/1.1\r\nUser-Agent: test\r\n\r\n";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -99,7 +99,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testReadRequestEntityWithContentLength() throws Exception {
+    void testReadRequestEntityWithContentLength() throws Exception {
         final String s = "POST / HTTP/1.1\r\nUser-Agent: test\r\nContent-Length: 3\r\n\r\n123";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -129,7 +129,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testReadRequestEntityChunckCoded() throws Exception {
+    void testReadRequestEntityChunckCoded() throws Exception {
         final String s = "POST /stuff HTTP/1.1\r\nUser-Agent: test\r\nTransfer-Encoding: " +
                 "chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -161,7 +161,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testReadRequestEntityIdentity() throws Exception {
+    void testReadRequestEntityIdentity() throws Exception {
         final String s = "POST /stuff HTTP/1.1\r\nUser-Agent: test\r\nTransfer-Encoding: " +
                 "identity\r\n\r\n123";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -185,7 +185,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testReadRequestNoEntity() throws Exception {
+    void testReadRequestNoEntity() throws Exception {
         final String s = "POST /stuff HTTP/1.1\r\nUser-Agent: test\r\n\r\n";
         final ByteArrayInputStream inStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         Mockito.when(socket.getInputStream()).thenReturn(inStream);
@@ -210,7 +210,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testWriteResponseHead() throws Exception {
+    void testWriteResponseHead() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -230,7 +230,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testWriteResponse100Head() throws Exception {
+    void testWriteResponse100Head() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -249,7 +249,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testWriteResponseEntityWithContentLength() throws Exception {
+    void testWriteResponseEntityWithContentLength() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -272,7 +272,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testWriteResponseEntityChunkCoded() throws Exception {
+    void testWriteResponseEntityChunkCoded() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -296,7 +296,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testWriteResponseEntityIdentity() throws Exception {
+    void testWriteResponseEntityIdentity() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 
@@ -316,7 +316,7 @@ public class TestDefaultBHttpServerConnection {
     }
 
     @Test
-    public void testWriteResponseNoEntity() throws Exception {
+    void testWriteResponseNoEntity() throws Exception {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(outStream);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
@@ -50,10 +50,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestHttpRequestExecutor {
+class TestHttpRequestExecutor {
 
     @Test
-    public void testInvalidInput() throws Exception {
+    void testInvalidInput() {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
@@ -99,7 +99,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testBasicExecution() throws Exception {
+    void testBasicExecution() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -127,7 +127,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionSkipIntermediateResponses() throws Exception {
+    void testExecutionSkipIntermediateResponses() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -172,7 +172,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionNoResponseBody() throws Exception {
+    void testExecutionNoResponseBody() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -197,7 +197,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionHead() throws Exception {
+    void testExecutionHead() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -222,7 +222,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequest() throws Exception {
+    void testExecutionEntityEnclosingRequest() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -250,7 +250,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequestWithExpectContinueSuccess() throws Exception {
+    void testExecutionEntityEnclosingRequestWithExpectContinueSuccess() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -282,7 +282,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequestWithExpectContinueFailure() throws Exception {
+    void testExecutionEntityEnclosingRequestWithExpectContinueFailure() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -314,7 +314,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequestWithExpectContinueMultiple1xxResponses() throws Exception {
+    void testExecutionEntityEnclosingRequestWithExpectContinueMultiple1xxResponses() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -362,7 +362,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequestWithExpectContinueNoResponse() throws Exception {
+    void testExecutionEntityEnclosingRequestWithExpectContinueNoResponse() throws Exception {
         final HttpProcessor httprocessor = Mockito.mock(HttpProcessor.class);
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
@@ -393,7 +393,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionIOException() throws Exception {
+    void testExecutionIOException() throws Exception {
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
 
@@ -406,7 +406,7 @@ public class TestHttpRequestExecutor {
     }
 
     @Test
-    public void testExecutionRuntimeException() throws Exception {
+    void testExecutionRuntimeException() throws Exception {
         final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
         final HttpRequestExecutor executor = new HttpRequestExecutor();
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpService.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpService.java
@@ -59,7 +59,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
-public class TestHttpService {
+class TestHttpService {
 
     @Mock
     private HttpProcessor httprocessor;
@@ -79,7 +79,7 @@ public class TestHttpService {
     private HttpService httpservice;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
         httpservice = new HttpService(
                 httprocessor,
@@ -89,7 +89,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testInvalidInitialization() throws Exception {
+    void testInvalidInitialization() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 new HttpService(
                         null,
@@ -99,7 +99,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testBasicExecution() throws Exception {
+    void testBasicExecution() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         Mockito.when(conn.receiveRequestHeader()).thenReturn(request);
@@ -123,7 +123,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequest() throws Exception {
+    void testExecutionEntityEnclosingRequest() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         final InputStream inStream = Mockito.mock(InputStream.class);
@@ -155,7 +155,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testExecutionEntityEnclosingRequestWithExpectContinue() throws Exception {
+    void testExecutionEntityEnclosingRequestWithExpectContinue() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.addHeader(HttpHeaders.EXPECT, HeaderElements.CONTINUE);
@@ -192,7 +192,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testMethodNotSupported() throws Exception {
+    void testMethodNotSupported() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest("whatever", "/");
 
@@ -219,7 +219,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testUnsupportedHttpVersionException() throws Exception {
+    void testUnsupportedHttpVersionException() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest("whatever", "/");
 
@@ -246,7 +246,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testProtocolException() throws Exception {
+    void testProtocolException() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest("whatever", "/");
 
@@ -273,7 +273,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testConnectionKeepAlive() throws Exception {
+    void testConnectionKeepAlive() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         Mockito.when(conn.receiveRequestHeader()).thenReturn(request);
@@ -298,7 +298,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testNoContentResponse() throws Exception {
+    void testNoContentResponse() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
 
@@ -321,7 +321,7 @@ public class TestHttpService {
     }
 
     @Test
-    public void testResponseToHead() throws Exception {
+    void testResponseToHead() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.HEAD, "/");
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestIdentityInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestIdentityInputStream.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link IdentityInputStream}.
  */
-public class TestIdentityInputStream {
+class TestIdentityInputStream {
 
     @Test
-    public void testBasicRead() throws Exception {
+    void testBasicRead() throws Exception {
         final byte[] input = new byte[] {'a', 'b', 'c'};
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(input);
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
@@ -59,7 +59,7 @@ public class TestIdentityInputStream {
     }
 
     @Test
-    public void testClosedCondition() throws Exception {
+    void testClosedCondition() throws Exception {
         final byte[] input = new byte[] {'a', 'b', 'c'};
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(input);
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
@@ -75,7 +75,7 @@ public class TestIdentityInputStream {
     }
 
     @Test
-    public void testAvailable() throws Exception {
+    void testAvailable() throws Exception {
         final byte[] input = new byte[] {'a', 'b', 'c'};
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(input);
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(new BasicHttpTransportMetrics(), 16, 16, 1024, null);
@@ -86,7 +86,7 @@ public class TestIdentityInputStream {
     }
 
     @Test
-    public void testAvailableInStream() throws Exception {
+    void testAvailableInStream() throws Exception {
         final byte[] input = new byte[] {'a', 'b', 'c', 'd', 'e', 'f'};
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(input);
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(new BasicHttpTransportMetrics(), 16, 0, 1024, null);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestIdentityOutputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestIdentityOutputStream.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link IdentityOutputStream}.
  */
-public class TestIdentityOutputStream {
+class TestIdentityOutputStream {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final OutputStream out = new IdentityOutputStream(outbuffer, outputStream);
@@ -58,7 +58,7 @@ public class TestIdentityOutputStream {
     }
 
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final OutputStream out = new IdentityOutputStream(outbuffer, outputStream);
@@ -70,7 +70,7 @@ public class TestIdentityOutputStream {
     }
 
     @Test
-    public void testBasicWrite() throws Exception {
+    void testBasicWrite() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final OutputStream out = new IdentityOutputStream(outbuffer, outputStream);
@@ -90,7 +90,7 @@ public class TestIdentityOutputStream {
     }
 
     @Test
-    public void testClosedCondition() throws Exception {
+    void testClosedCondition() throws Exception {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final OutputStream out = new IdentityOutputStream(outbuffer, outputStream);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestMessageParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestMessageParser.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link AbstractMessageParser}.
  */
-public class TestMessageParser {
+class TestMessageParser {
 
     @Test
-    public void testBasicHeaderParsing() throws Exception {
+    void testBasicHeaderParsing() throws Exception {
         final String s =
             "header1: stuff\r\n" +
             "header2:  stuff \r\n" +
@@ -66,7 +66,7 @@ public class TestMessageParser {
     }
 
     @Test
-    public void testParsingHeader() throws Exception {
+    void testParsingHeader() throws Exception {
         final String s = "header1: stuff; param1 = value1; param2 = \"value 2\" \r\n" +
                 "\r\n";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
@@ -78,7 +78,7 @@ public class TestMessageParser {
     }
 
     @Test
-    public void testParsingInvalidHeaders() throws Exception {
+    void testParsingInvalidHeaders() {
         final String s1 = "    stuff\r\n" +
             "header1: stuff\r\n" +
             "\r\n";
@@ -96,7 +96,7 @@ public class TestMessageParser {
     }
 
     @Test
-    public void testParsingMalformedFirstHeader() throws Exception {
+    void testParsingMalformedFirstHeader() throws Exception {
         final String s =
             "    header1: stuff\r\n" +
             "header2: stuff \r\n";
@@ -112,7 +112,7 @@ public class TestMessageParser {
     }
 
     @Test
-    public void testEmptyDataStream() throws Exception {
+    void testEmptyDataStream() throws Exception {
         final String s = "";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(s.getBytes(StandardCharsets.US_ASCII));
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16, StandardCharsets.US_ASCII.newDecoder());
@@ -122,7 +122,7 @@ public class TestMessageParser {
     }
 
     @Test
-    public void testMaxHeaderCount() throws Exception {
+    void testMaxHeaderCount() {
         final String s =
             "header1: stuff\r\n" +
             "header2: stuff \r\n" +
@@ -135,7 +135,7 @@ public class TestMessageParser {
     }
 
     @Test
-    public void testMaxHeaderCountForFoldedHeader() throws Exception {
+    void testMaxHeaderCountForFoldedHeader() {
         final String s =
             "header1: stuff\r\n" +
             " stuff \r\n" +

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestMonitoringResponseOutOfOrderStrategy.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestMonitoringResponseOutOfOrderStrategy.java
@@ -42,12 +42,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestMonitoringResponseOutOfOrderStrategy {
+class TestMonitoringResponseOutOfOrderStrategy {
 
     private static final ClassicHttpRequest REQUEST = new BasicClassicHttpRequest("POST", "/path");
 
     @Test
-    public void testFirstByteIsNotCheckedSsl() throws IOException {
+    void testFirstByteIsNotCheckedSsl() throws IOException {
         final boolean earlyResponse = MonitoringResponseOutOfOrderStrategy.INSTANCE.isEarlyResponseDetected(
                 REQUEST,
                 connection(true, true),
@@ -59,7 +59,7 @@ public class TestMonitoringResponseOutOfOrderStrategy {
     }
 
     @Test
-    public void testFirstByteIsNotCheckedPlain() throws IOException {
+    void testFirstByteIsNotCheckedPlain() throws IOException {
         final boolean earlyResponse = MonitoringResponseOutOfOrderStrategy.INSTANCE.isEarlyResponseDetected(
                 REQUEST,
                 connection(true, false),
@@ -70,7 +70,7 @@ public class TestMonitoringResponseOutOfOrderStrategy {
     }
 
     @Test
-    public void testWritesWithinChunkAreNotChecked() throws IOException {
+    void testWritesWithinChunkAreNotChecked() throws IOException {
         final boolean earlyResponse = MonitoringResponseOutOfOrderStrategy.INSTANCE.isEarlyResponseDetected(
                 REQUEST,
                 connection(true, true),
@@ -81,7 +81,7 @@ public class TestMonitoringResponseOutOfOrderStrategy {
     }
 
     @Test
-    public void testWritesAcrossChunksAreChecked() throws IOException {
+    void testWritesAcrossChunksAreChecked() throws IOException {
         final boolean earlyResponse = MonitoringResponseOutOfOrderStrategy.INSTANCE.isEarlyResponseDetected(
                 REQUEST,
                 connection(true, true),
@@ -92,7 +92,7 @@ public class TestMonitoringResponseOutOfOrderStrategy {
     }
 
     @Test
-    public void testMaximumChunks() throws IOException {
+    void testMaximumChunks() throws IOException {
         final ResponseOutOfOrderStrategy strategy = new MonitoringResponseOutOfOrderStrategy(1, 2);
         Assertions.assertTrue(strategy.isEarlyResponseDetected(
                 REQUEST,

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestRequestParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestRequestParser.java
@@ -42,10 +42,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link DefaultHttpRequestParser}.
  */
-public class TestRequestParser {
+class TestRequestParser {
 
     @Test
-    public void testBasicMessageParsing() throws Exception {
+    void testBasicMessageParsing() throws Exception {
         final String s =
             "GET / HTTP/1.1\r\n" +
             "Host: localhost\r\n" +
@@ -65,7 +65,7 @@ public class TestRequestParser {
     }
 
     @Test
-    public void testConnectionClosedException() throws Exception {
+    void testConnectionClosedException() throws Exception {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {});
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
 
@@ -75,7 +75,7 @@ public class TestRequestParser {
     }
 
     @Test
-    public void testBasicMessageParsingLeadingEmptyLines() throws Exception {
+    void testBasicMessageParsingLeadingEmptyLines() throws Exception {
         final String s =
                 "\r\n" +
                 "\r\n" +
@@ -96,7 +96,7 @@ public class TestRequestParser {
     }
 
     @Test
-    public void testBasicMessageParsingTooManyLeadingEmptyLines() throws Exception {
+    void testBasicMessageParsingTooManyLeadingEmptyLines() {
         final String s =
                 "\r\n" +
                 "\r\n" +
@@ -114,7 +114,7 @@ public class TestRequestParser {
     }
 
     @Test
-    public void testMessageParsingTimeout() throws Exception {
+    void testMessageParsingTimeout() throws Exception {
         final String s =
             "GET \000/ HTTP/1.1\r\000\n" +
             "Host: loca\000lhost\r\n" +

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestResponseParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestResponseParser.java
@@ -42,10 +42,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link DefaultHttpResponseParser}.
  */
-public class TestResponseParser {
+class TestResponseParser {
 
     @Test
-    public void testBasicMessageParsing() throws Exception {
+    void testBasicMessageParsing() throws Exception {
         final String s =
             "HTTP/1.1 200 OK\r\n" +
             "Server: whatever\r\n" +
@@ -65,7 +65,7 @@ public class TestResponseParser {
     }
 
     @Test
-    public void testConnectionClosedException() throws Exception {
+    void testConnectionClosedException() throws Exception {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {});
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
 
@@ -75,7 +75,7 @@ public class TestResponseParser {
     }
 
     @Test
-    public void testBasicMessageParsingLeadingEmptyLines() throws Exception {
+    void testBasicMessageParsingLeadingEmptyLines() throws Exception {
         final String s =
                 "\r\n" +
                 "\r\n" +
@@ -96,7 +96,7 @@ public class TestResponseParser {
     }
 
     @Test
-    public void testBasicMessageParsingTooManyLeadingEmptyLines() throws Exception {
+    void testBasicMessageParsingTooManyLeadingEmptyLines() {
         final String s =
                 "\r\n" +
                 "\r\n" +
@@ -114,7 +114,7 @@ public class TestResponseParser {
     }
 
     @Test
-    public void testMessageParsingTimeout() throws Exception {
+    void testMessageParsingTimeout() throws Exception {
         final String s =
             "HTTP\000/1.1 200\000 OK\r\n" +
             "Server: wha\000tever\r\n" +

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestSessionInOutBuffers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestSessionInOutBuffers.java
@@ -48,10 +48,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestSessionInOutBuffers {
+class TestSessionInOutBuffers {
 
     @Test
-    public void testBasicBufferProperties() throws Exception {
+    void testBasicBufferProperties() throws Exception {
         final SessionInputBuffer inBuffer = new SessionInputBufferImpl(16);
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2 , 3});
         Assertions.assertEquals(16, inBuffer.capacity());
@@ -72,7 +72,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testBasicReadWriteLine() throws Exception {
+    void testBasicReadWriteLine() throws Exception {
 
         final String[] teststrs = new String[5];
         teststrs[0] = "Hello";
@@ -126,7 +126,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testComplexReadWriteLine() throws Exception {
+    void testComplexReadWriteLine() throws Exception {
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16);
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         outbuffer.write(new byte[] {'a', '\n'}, outputStream);
@@ -219,7 +219,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testBasicReadWriteLineLargeBuffer() throws Exception {
+    void testBasicReadWriteLineLargeBuffer() throws Exception {
 
         final String[] teststrs = new String[5];
         teststrs[0] = "Hello";
@@ -270,7 +270,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadWriteBytes() throws Exception {
+    void testReadWriteBytes() throws Exception {
         // make the buffer larger than that of outbuffer
         final byte[] out = new byte[40];
         for (int i = 0; i < out.length; i++) {
@@ -333,7 +333,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadWriteByte() throws Exception {
+    void testReadWriteByte() throws Exception {
         // make the buffer larger than that of outbuffer
         final byte[] out = new byte[40];
         for (int i = 0; i < out.length; i++) {
@@ -370,7 +370,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testWriteSmallFragmentBuffering() throws Exception {
+    void testWriteSmallFragmentBuffering() throws Exception {
         final OutputStream outputStream = Mockito.mock(OutputStream.class);
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(new BasicHttpTransportMetrics(), 16, 16, null);
         outbuffer.write(1, outputStream);
@@ -383,7 +383,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testWriteSmallFragmentNoBuffering() throws Exception {
+    void testWriteSmallFragmentNoBuffering() throws Exception {
         final OutputStream outputStream = Mockito.mock(OutputStream.class);
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(new BasicHttpTransportMetrics(), 16, 0, null);
         outbuffer.write(1, outputStream);
@@ -395,7 +395,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testLineLimit() throws Exception {
+    void testLineLimit() throws Exception {
         final String s = "a very looooooooooooooooooooooooooooooooooooooooooong line\r\n";
         final byte[] tmp = s.getBytes(StandardCharsets.US_ASCII);
         // no limit
@@ -415,7 +415,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testLineLimit2() throws Exception {
+    void testLineLimit2() throws Exception {
         final String s = "just a line\r\n";
         final byte[] tmp = s.getBytes(StandardCharsets.US_ASCII);
         // no limit
@@ -435,7 +435,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test //HTTPCORE-472
-    public void testLineLimit3() throws Exception {
+    void testLineLimit3() throws Exception {
         final String s = "012345678\r\nblaaaaaaaaaaaaaaaaaah";
         final byte[] tmp = s.getBytes(StandardCharsets.US_ASCII);
         final SessionInputBuffer inBuffer1 = new SessionInputBufferImpl(128);
@@ -446,7 +446,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadLineFringeCase1() throws Exception {
+    void testReadLineFringeCase1() throws Exception {
         final String s = "abc\r\n";
         final byte[] tmp = s.getBytes(StandardCharsets.US_ASCII);
         final SessionInputBuffer inBuffer1 = new SessionInputBufferImpl(128);
@@ -479,7 +479,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMultibyteCodedReadWriteLine() throws Exception {
+    void testMultibyteCodedReadWriteLine() throws Exception {
         final String s1 = constructString(SWISS_GERMAN_HELLO);
         final String s2 = constructString(RUSSIAN_HELLO);
         final String s3 = "Like hello and stuff";
@@ -529,7 +529,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMultibyteCodedReadWriteLongLine() throws Exception {
+    void testMultibyteCodedReadWriteLongLine() throws Exception {
         final String s1 = constructString(SWISS_GERMAN_HELLO);
         final String s2 = constructString(RUSSIAN_HELLO);
         final String s3 = "Like hello and stuff";
@@ -556,7 +556,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testNonAsciiReadWriteLine() throws Exception {
+    void testNonAsciiReadWriteLine() throws Exception {
         final String s1 = constructString(SWISS_GERMAN_HELLO);
 
         final SessionOutputBuffer outbuffer = new SessionOutputBufferImpl(16, StandardCharsets.UTF_8.newEncoder());
@@ -595,7 +595,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testUnmappableInputActionReport() throws Exception {
+    void testUnmappableInputActionReport() {
         final String s = "This text contains a circumflex \u0302 !!!";
         final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         encoder.onMalformedInput(CodingErrorAction.IGNORE);
@@ -609,7 +609,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testUnmappableInputActionReplace() throws Exception {
+    void testUnmappableInputActionReplace() throws Exception {
         final String s = "This text contains a circumflex \u0302 !!!";
         final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         encoder.onMalformedInput(CodingErrorAction.IGNORE);
@@ -625,7 +625,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testUnmappableInputActionIgnore() throws Exception {
+    void testUnmappableInputActionIgnore() throws Exception {
         final String s = "This text contains a circumflex \u0302 !!!";
         final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         encoder.onMalformedInput(CodingErrorAction.IGNORE);
@@ -641,7 +641,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMalformedInputActionReport() throws Exception {
+    void testMalformedInputActionReport() {
         final byte[] tmp = constructString(SWISS_GERMAN_HELLO).getBytes(StandardCharsets.ISO_8859_1);
         final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         decoder.onMalformedInput(CodingErrorAction.REPORT);
@@ -654,7 +654,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMalformedInputActionReplace() throws Exception {
+    void testMalformedInputActionReplace() throws Exception {
         final byte[] tmp = constructString(SWISS_GERMAN_HELLO).getBytes(StandardCharsets.ISO_8859_1);
         final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         decoder.onMalformedInput(CodingErrorAction.REPLACE);
@@ -667,7 +667,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMalformedInputActionIgnore() throws Exception {
+    void testMalformedInputActionIgnore() throws Exception {
         final byte[] tmp = constructString(SWISS_GERMAN_HELLO).getBytes(StandardCharsets.ISO_8859_1);
         final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         decoder.onMalformedInput(CodingErrorAction.IGNORE);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestAbstractHttp1StreamDuplexerCapacityWindow.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestAbstractHttp1StreamDuplexerCapacityWindow.java
@@ -41,7 +41,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class TestAbstractHttp1StreamDuplexerCapacityWindow {
+class TestAbstractHttp1StreamDuplexerCapacityWindow {
 
     @Mock
     private IOSession ioSession;
@@ -49,17 +49,17 @@ public class TestAbstractHttp1StreamDuplexerCapacityWindow {
     private AutoCloseable closeable;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         closeable = MockitoAnnotations.openMocks(this);
     }
 
     @AfterEach
-    public void releaseMocks() throws Exception {
+    void releaseMocks() throws Exception {
         closeable.close();
     }
 
     @Test
-    public void testWindowUpdate() throws IOException {
+    void testWindowUpdate() throws IOException {
         final CapacityWindow window = new CapacityWindow(0, ioSession);
         window.update(1);
         Assertions.assertEquals(1, window.getWindow());
@@ -68,7 +68,7 @@ public class TestAbstractHttp1StreamDuplexerCapacityWindow {
     }
 
     @Test
-    public void testRemoveCapacity() {
+    void testRemoveCapacity() {
         final CapacityWindow window = new CapacityWindow(1, ioSession);
         window.removeCapacity(1);
         Assertions.assertEquals(0, window.getWindow());
@@ -77,7 +77,7 @@ public class TestAbstractHttp1StreamDuplexerCapacityWindow {
     }
 
     @Test
-    public void noReadsSetAfterWindowIsClosed() throws IOException {
+    void noReadsSetAfterWindowIsClosed() throws IOException {
         final CapacityWindow window = new CapacityWindow(1, ioSession);
         window.close();
         window.update(1);
@@ -85,21 +85,21 @@ public class TestAbstractHttp1StreamDuplexerCapacityWindow {
     }
 
     @Test
-    public void windowCannotUnderflow() {
+    void windowCannotUnderflow() {
         final CapacityWindow window = new CapacityWindow(Integer.MIN_VALUE, ioSession);
         window.removeCapacity(1);
         Assertions.assertEquals(Integer.MIN_VALUE, window.getWindow());
     }
 
     @Test
-    public void windowCannotOverflow() throws IOException{
+    void windowCannotOverflow() throws IOException{
         final CapacityWindow window = new CapacityWindow(Integer.MAX_VALUE, ioSession);
         window.update(1);
         Assertions.assertEquals(Integer.MAX_VALUE, window.getWindow());
     }
 
     @Test
-    public void noChangesIfUpdateIsNonPositive() throws IOException {
+    void noChangesIfUpdateIsNonPositive() throws IOException {
         final CapacityWindow window = new CapacityWindow(1, ioSession);
         window.update(0);
         window.update(-1);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkDecoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkDecoder.java
@@ -48,10 +48,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Simple tests for {@link ChunkDecoder}.
  */
-public class TestChunkDecoder {
+class TestChunkDecoder {
 
     @Test
-    public void testBasicDecoding() throws Exception {
+    void testBasicDecoding() throws Exception {
         final String s = "5\r\n01234\r\n5\r\n56789\r\n6\r\nabcdef\r\n0\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);
@@ -75,7 +75,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testComplexDecoding() throws Exception {
+    void testComplexDecoding() throws Exception {
         final String s = "10;key=\"value\"\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345\r\n0\r\nFooter1: abcde\r\nFooter2: fghij\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -112,7 +112,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testDecodingWithSmallBuffer() throws Exception {
+    void testDecodingWithSmallBuffer() throws Exception {
         final String s1 = "5\r\n01234\r\n5\r\n5678";
         final String s2 = "9\r\n6\r\nabcdef\r\n0\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -147,7 +147,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMalformedChunk() throws Exception {
+    void testMalformedChunk() {
         final String s = "5\r\n01234----------------------------------------------------------" +
                 "-----------------------------------------------------------------------------" +
                 "-----------------------------------------------------------------------------";
@@ -164,7 +164,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testIncompleteChunkDecoding() throws Exception {
+    void testIncompleteChunkDecoding() throws Exception {
         final String[] chunks = {
                 "10;",
                 "key=\"value\"\r",
@@ -211,7 +211,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMalformedChunkSizeDecoding() throws Exception {
+    void testMalformedChunkSizeDecoding() {
         final String s = "5\r\n01234\r\n5zz\r\n56789\r\n6\r\nabcdef\r\n0\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);
@@ -226,7 +226,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMalformedChunkEndingDecoding() throws Exception {
+    void testMalformedChunkEndingDecoding() {
         final String s = "5\r\n01234\r\n5\r\n56789\r\r6\r\nabcdef\r\n0\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);
@@ -241,7 +241,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMalformedChunkTruncatedChunk() throws Exception {
+    void testMalformedChunkTruncatedChunk() throws Exception {
         final String s = "3\r\n12";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);
@@ -257,7 +257,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testFoldedFooters() throws Exception {
+    void testFoldedFooters() throws Exception {
         final String s = "10;key=\"value\"\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345\r\n0\r\nFooter1: abcde\r\n   \r\n  fghij\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -280,7 +280,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMalformedFooters() throws Exception {
+    void testMalformedFooters() {
         final String s = "10;key=\"value\"\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345\r\n0\r\nFooter1 abcde\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -296,7 +296,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMissingLastCRLF() throws Exception {
+    void testMissingLastCRLF() {
         final String s = "10\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -316,7 +316,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testMissingClosingChunk() throws Exception {
+    void testMissingClosingChunk() {
         final String s = "10\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -347,7 +347,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testReadingWitSmallBuffer() throws Exception {
+    void testReadingWitSmallBuffer() throws Exception {
         final String s = "10\r\n1234567890123456\r\n" +
                 "40\r\n12345678901234561234567890123456" +
                 "12345678901234561234567890123456\r\n0\r\n";
@@ -380,7 +380,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testEndOfStreamConditionReadingFooters() throws Exception {
+    void testEndOfStreamConditionReadingFooters() throws Exception {
         final String s = "10\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345\r\n0\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -406,7 +406,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testTooLongChunkHeader() throws Exception {
+    void testTooLongChunkHeader() throws Exception {
         final String s = "5; and some very looooong comment\r\n12345\r\n0\r\n";
         final ReadableByteChannel channel1 = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);
@@ -435,7 +435,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testTooLongFooter() throws Exception {
+    void testTooLongFooter() throws Exception {
         final String s = "10\r\n1234567890123456\r\n" +
                 "0\r\nFooter1: looooooooooooooooooooooooooooooooooooooooooooooooooooooog\r\n\r\n";
         final ReadableByteChannel channel1 = new ReadableByteChannelMock(
@@ -465,7 +465,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testTooLongFoldedFooter() throws Exception {
+    void testTooLongFoldedFooter() throws Exception {
         final String s = "10\r\n1234567890123456\r\n" +
                 "0\r\nFooter1: blah\r\n  blah\r\n  blah\r\n  blah\r\n  blah\r\n  blah\r\n  blah\r\n  blah\r\n\r\n";
         final ReadableByteChannel channel1 = new ReadableByteChannelMock(
@@ -498,7 +498,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testTooManyFooters() throws Exception {
+    void testTooManyFooters() throws Exception {
         final String s = "10\r\n1234567890123456\r\n" +
                 "0\r\nFooter1: blah\r\nFooter2: blah\r\nFooter3: blah\r\nFooter4: blah\r\n\r\n";
         final ReadableByteChannel channel1 = new ReadableByteChannelMock(
@@ -530,7 +530,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testInvalidConstructor() {
+    void testInvalidConstructor() {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -540,7 +540,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testInvalidInput() throws Exception {
+    void testInvalidInput() {
         final String s = "10;key=\"value\"\r\n1234567890123456\r\n" +
                 "5\r\n12345\r\n5\r\n12345\r\n0\r\nFooter1 abcde\r\n\r\n";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
@@ -554,7 +554,7 @@ public class TestChunkDecoder {
     }
 
     @Test
-    public void testHugeChunk() throws Exception {
+    void testHugeChunk() throws Exception {
         final String s = "1234567890abcdef\r\n0123456789abcdef";
         final ReadableByteChannel channel = new ReadableByteChannelMock(new String[] {s}, StandardCharsets.US_ASCII);
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(1024, 256, 0, StandardCharsets.US_ASCII);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkEncoder.java
@@ -44,10 +44,10 @@ import org.mockito.Mockito;
 /**
  * Simple tests for {@link ChunkEncoder}.
  */
-public class TestChunkEncoder {
+class TestChunkEncoder {
 
     @Test
-    public void testBasicCoding() throws Exception {
+    void testBasicCoding() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -68,7 +68,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testChunkNoExceed() throws Exception {
+    void testChunkNoExceed() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 16);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -85,7 +85,7 @@ public class TestChunkEncoder {
     }
 
     @Test // See HTTPCORE-239
-    public void testLimitedChannel() throws Exception {
+    void testLimitedChannel() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(16, 16);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(16, 16);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -118,7 +118,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testBufferFragments() throws Exception {
+    void testBufferFragments() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(1024));
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 1024);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -137,7 +137,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testChunkExceed() throws Exception {
+    void testChunkExceed() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(16, 16);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -155,7 +155,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testCodingEmptyBuffer() throws Exception {
+    void testCodingEmptyBuffer() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -181,7 +181,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testCodingCompleted() throws Exception {
+    void testCodingCompleted() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -197,7 +197,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testInvalidConstructor() {
+    void testInvalidConstructor() {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
 
@@ -207,7 +207,7 @@ public class TestChunkEncoder {
     }
 
     @Test
-    public void testTrailers() throws IOException {
+    void testTrailers() throws IOException {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestChunkEncoder.java
@@ -192,7 +192,9 @@ class TestChunkEncoder {
         encoder.write(CodecTestUtils.wrap("90"));
         encoder.complete();
 
-        Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(CodecTestUtils.wrap("more stuff")));
+        final ByteBuffer wrapped = CodecTestUtils.wrap("more stuff");
+
+        Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(wrapped));
         Assertions.assertThrows(IllegalStateException.class, () -> encoder.complete());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestExpandableBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestExpandableBuffer.java
@@ -32,10 +32,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
-public class TestExpandableBuffer {
+class TestExpandableBuffer {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
         final ExpandableBuffer buffer = new ExpandableBuffer(16);
         assertThat(buffer.mode(), CoreMatchers.equalTo(ExpandableBuffer.Mode.INPUT));
         assertThat(buffer.hasData(), CoreMatchers.equalTo(false));
@@ -67,7 +67,7 @@ public class TestExpandableBuffer {
     }
 
     @Test
-    public void testAdjustCapacity() throws Exception {
+    void testAdjustCapacity() {
         final ExpandableBuffer buffer = new ExpandableBuffer(16);
         assertThat(buffer.capacity(), CoreMatchers.equalTo(16));
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityDecoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityDecoder.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Simple tests for {@link LengthDelimitedDecoder}.
  */
-public class TestIdentityDecoder {
+class TestIdentityDecoder {
 
     private File tmpfile;
 
@@ -55,14 +55,14 @@ public class TestIdentityDecoder {
     }
 
     @AfterEach
-    public void deleteTempFile() {
+    void deleteTempFile() {
         if (this.tmpfile != null && this.tmpfile.exists()) {
             this.tmpfile.delete();
         }
     }
 
     @Test
-    public void testBasicDecoding() throws Exception {
+    void testBasicDecoding() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -101,7 +101,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testDecodingFromSessionBuffer() throws Exception {
+    void testDecodingFromSessionBuffer() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -144,7 +144,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testBasicDecodingFile() throws Exception {
+    void testBasicDecodingFile() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; ", "more stuff; ", "a lot more stuff!"}, StandardCharsets.US_ASCII);
 
@@ -171,7 +171,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testDecodingFileWithBufferedSessionData() throws Exception {
+    void testDecodingFileWithBufferedSessionData() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; ", "more stuff; ", "a lot more stuff!"}, StandardCharsets.US_ASCII);
 
@@ -202,7 +202,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testDecodingFileWithOffsetAndBufferedSessionData() throws Exception {
+    void testDecodingFileWithOffsetAndBufferedSessionData() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; ", "more stuff; ", "a lot more stuff!"}, StandardCharsets.US_ASCII);
 
@@ -249,7 +249,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testDecodingFileWithLimit() throws Exception {
+    void testDecodingFileWithLimit() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; more stuff; ", "a lot more stuff!"}, StandardCharsets.US_ASCII);
 
@@ -313,7 +313,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testWriteBeyondFileSize() throws Exception {
+    void testWriteBeyondFileSize() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"a"}, StandardCharsets.US_ASCII);
 
@@ -331,7 +331,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testInvalidConstructor() {
+    void testInvalidConstructor() {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -342,7 +342,7 @@ public class TestIdentityDecoder {
     }
 
     @Test
-    public void testInvalidInput() throws Exception {
+    void testInvalidInput() {
         final String s = "stuff";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityEncoder.java
@@ -47,7 +47,7 @@ import org.mockito.Mockito;
 /**
  * Simple tests for {@link IdentityEncoder}.
  */
-public class TestIdentityEncoder {
+class TestIdentityEncoder {
 
     private File tmpfile;
 
@@ -57,14 +57,14 @@ public class TestIdentityEncoder {
     }
 
     @AfterEach
-    public void deleteTempFile() {
+    void deleteTempFile() {
         if (this.tmpfile != null && this.tmpfile.exists()) {
             this.tmpfile.delete();
         }
     }
 
     @Test
-    public void testBasicCoding() throws Exception {
+    void testBasicCoding() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -84,7 +84,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingEmptySrcBuffer() throws Exception {
+    void testCodingEmptySrcBuffer() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -106,7 +106,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingCompleted() throws Exception {
+    void testCodingCompleted() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -119,7 +119,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testInvalidConstructor() {
+    void testInvalidConstructor() {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
 
@@ -129,7 +129,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFromFile() throws Exception {
+    void testCodingFromFile() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -160,7 +160,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingEmptyFile() throws Exception {
+    void testCodingEmptyFile() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -189,7 +189,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFromFileSmaller() throws Exception {
+    void testCodingFromFileSmaller() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -253,7 +253,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFromFileChannelSaturated() throws Exception {
+    void testCodingFromFileChannelSaturated() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64, 4);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -287,7 +287,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingNoFragmentBuffering() throws Exception {
+    void testCodingNoFragmentBuffering() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -311,7 +311,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBuffering() throws Exception {
+    void testCodingFragmentBuffering() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -335,7 +335,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingMultipleFragments() throws Exception {
+    void testCodingFragmentBufferingMultipleFragments() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -358,7 +358,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingLargeFragment() throws Exception {
+    void testCodingFragmentBufferingLargeFragment() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -381,7 +381,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingTinyFragments() throws Exception {
+    void testCodingFragmentBufferingTinyFragments() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -406,7 +406,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingTinyFragments2() throws Exception {
+    void testCodingFragmentBufferingTinyFragments2() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -431,7 +431,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingTinyFragments3() throws Exception {
+    void testCodingFragmentBufferingTinyFragments3() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -458,7 +458,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingBufferFlush() throws Exception {
+    void testCodingFragmentBufferingBufferFlush() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -481,7 +481,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingBufferFlush2() throws Exception {
+    void testCodingFragmentBufferingBufferFlush2() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -504,7 +504,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingChannelSaturated() throws Exception {
+    void testCodingFragmentBufferingChannelSaturated() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64, 8));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -534,7 +534,7 @@ public class TestIdentityEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingChannelSaturated2() throws Exception {
+    void testCodingFragmentBufferingChannelSaturated2() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64, 8));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityEncoder.java
@@ -191,37 +191,7 @@ class TestIdentityEncoder {
     }
 
     @Test
-    void testCodingFromFileSmaller() throws Exception {
-        final WritableByteChannelMock channel = new WritableByteChannelMock(64);
-        final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
-        final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
-
-        final IdentityEncoder encoder = new IdentityEncoder(channel, outbuf, metrics);
-
-        createTempFile();
-        RandomAccessFile testfile = new RandomAccessFile(this.tmpfile, "rw");
-        try {
-            testfile.write("stuff;".getBytes(StandardCharsets.US_ASCII));
-            testfile.write("more stuff".getBytes(StandardCharsets.US_ASCII));
-        } finally {
-            testfile.close();
-        }
-
-        testfile = new RandomAccessFile(this.tmpfile, "rw");
-        try {
-            final FileChannel fchannel = testfile.getChannel();
-            encoder.transfer(fchannel, 0, 20);
-        } finally {
-            testfile.close();
-        }
-        final String s = channel.dump(StandardCharsets.US_ASCII);
-
-        Assertions.assertFalse(encoder.isCompleted());
-        Assertions.assertEquals("stuff;more stuff", s);
-    }
-
-    @Test
-    public void testCodingFromFileFlushBuffer() throws Exception {
+    void testCodingFromFileFlushBuffer() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestIdentityEncoder.java
@@ -115,7 +115,9 @@ class TestIdentityEncoder {
         encoder.write(CodecTestUtils.wrap("stuff"));
         encoder.complete();
 
-        Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(CodecTestUtils.wrap("more stuff")));
+        final ByteBuffer wrapped = CodecTestUtils.wrap("more stuff");
+
+        Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(wrapped));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestLengthDelimitedDecoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestLengthDelimitedDecoder.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Simple tests for {@link LengthDelimitedDecoder}.
  */
-public class TestLengthDelimitedDecoder {
+class TestLengthDelimitedDecoder {
 
     private File tmpfile;
 
@@ -56,14 +56,14 @@ public class TestLengthDelimitedDecoder {
     }
 
     @AfterEach
-    public void deleteTempFile() {
+    void deleteTempFile() {
         if (this.tmpfile != null && this.tmpfile.exists()) {
             this.tmpfile.delete();
         }
     }
 
     @Test
-    public void testBasicDecoding() throws Exception {
+    void testBasicDecoding() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -97,7 +97,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testCodingBeyondContentLimit() throws Exception {
+    void testCodingBeyondContentLimit() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {
                         "stuff;",
@@ -131,7 +131,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testBasicDecodingSmallBuffer() throws Exception {
+    void testBasicDecodingSmallBuffer() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -184,7 +184,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testDecodingFromSessionBuffer1() throws Exception {
+    void testDecodingFromSessionBuffer1() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -221,7 +221,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testDecodingFromSessionBuffer2() throws Exception {
+    void testDecodingFromSessionBuffer2() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {
                         "stuff;",
@@ -255,7 +255,7 @@ public class TestLengthDelimitedDecoder {
 
     /* ----------------- FileChannel Part testing --------------------------- */
     @Test
-    public void testBasicDecodingFile() throws Exception {
+    void testBasicDecodingFile() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; ", "more stuff; ", "a lot more stuff!!!"}, StandardCharsets.US_ASCII);
 
@@ -281,7 +281,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testDecodingFileWithBufferedSessionData() throws Exception {
+    void testDecodingFileWithBufferedSessionData() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; ", "more stuff; ", "a lot more stuff!!!"}, StandardCharsets.US_ASCII);
 
@@ -310,7 +310,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testDecodingFileWithOffsetAndBufferedSessionData() throws Exception {
+    void testDecodingFileWithOffsetAndBufferedSessionData() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; ", "more stuff; ", "a lot more stuff!"}, StandardCharsets.US_ASCII);
 
@@ -357,7 +357,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testDecodingFileWithLimit() throws Exception {
+    void testDecodingFileWithLimit() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff; more stuff; ", "a lot more stuff!!!"}, StandardCharsets.US_ASCII);
 
@@ -421,7 +421,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testWriteBeyondFileSize() throws Exception {
+    void testWriteBeyondFileSize() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"a"}, StandardCharsets.US_ASCII);
 
@@ -439,7 +439,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testCodingBeyondContentLimitFile() throws Exception {
+    void testCodingBeyondContentLimitFile() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {
                         "stuff;",
@@ -472,7 +472,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testInvalidConstructor() {
+    void testInvalidConstructor() {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff;", "more stuff"}, StandardCharsets.US_ASCII);
 
@@ -485,7 +485,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testInvalidInput() throws Exception {
+    void testInvalidInput() {
         final String s = "stuff";
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {s}, StandardCharsets.US_ASCII);
@@ -499,7 +499,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testZeroLengthDecoding() throws Exception {
+    void testZeroLengthDecoding() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"stuff"}, StandardCharsets.US_ASCII);
 
@@ -517,7 +517,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testTruncatedContent() throws Exception {
+    void testTruncatedContent() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"1234567890"}, StandardCharsets.US_ASCII);
 
@@ -535,7 +535,7 @@ public class TestLengthDelimitedDecoder {
     }
 
     @Test
-    public void testTruncatedContentWithFile() throws Exception {
+    void testTruncatedContentWithFile() throws Exception {
         final ReadableByteChannel channel = new ReadableByteChannelMock(
                 new String[] {"1234567890"}, StandardCharsets.US_ASCII);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestLengthDelimitedEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestLengthDelimitedEncoder.java
@@ -131,7 +131,9 @@ class TestLengthDelimitedEncoder {
                 channel, outbuf, metrics, 5);
         encoder.write(CodecTestUtils.wrap("stuff"));
 
-        Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(CodecTestUtils.wrap("more stuff")));
+        final ByteBuffer wrapped = CodecTestUtils.wrap("more stuff");
+
+        Assertions.assertThrows(IllegalStateException.class, () -> encoder.write(wrapped));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestLengthDelimitedEncoder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestLengthDelimitedEncoder.java
@@ -47,7 +47,7 @@ import org.mockito.Mockito;
 /**
  * Simple tests for {@link LengthDelimitedEncoder}.
  */
-public class TestLengthDelimitedEncoder {
+class TestLengthDelimitedEncoder {
 
     private File tmpfile;
 
@@ -57,14 +57,14 @@ public class TestLengthDelimitedEncoder {
     }
 
     @AfterEach
-    public void deleteTempFile() {
+    void deleteTempFile() {
         if (this.tmpfile != null && this.tmpfile.exists()) {
             this.tmpfile.delete();
         }
     }
 
     @Test
-    public void testBasicCoding() throws Exception {
+    void testBasicCoding() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -82,7 +82,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingBeyondContentLimit() throws Exception {
+    void testCodingBeyondContentLimit() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -99,7 +99,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingEmptyBuffer() throws Exception {
+    void testCodingEmptyBuffer() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -122,7 +122,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingCompleted() throws Exception {
+    void testCodingCompleted() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -135,7 +135,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testInvalidConstructor() {
+    void testInvalidConstructor() {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -147,7 +147,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingBeyondContentLimitFromFile() throws Exception {
+    void testCodingBeyondContentLimitFromFile() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -179,7 +179,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingEmptyFile() throws Exception {
+    void testCodingEmptyFile() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -209,7 +209,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingCompletedFromFile() throws Exception {
+    void testCodingCompletedFromFile() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -230,7 +230,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFromFileSmaller() throws Exception {
+    void testCodingFromFileSmaller() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -261,7 +261,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFromFileFlushBuffer() throws Exception {
+    void testCodingFromFileFlushBuffer() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -296,7 +296,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFromFileChannelSaturated() throws Exception {
+    void testCodingFromFileChannelSaturated() throws Exception {
         final WritableByteChannelMock channel = new WritableByteChannelMock(64, 4);
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -331,7 +331,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingNoFragmentBuffering() throws Exception {
+    void testCodingNoFragmentBuffering() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -356,7 +356,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBuffering() throws Exception {
+    void testCodingFragmentBuffering() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -381,7 +381,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingMultipleFragments() throws Exception {
+    void testCodingFragmentBufferingMultipleFragments() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -405,7 +405,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingMultipleFragmentsBeyondContentLimit() throws Exception {
+    void testCodingFragmentBufferingMultipleFragmentsBeyondContentLimit() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -429,7 +429,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingLargeFragment() throws Exception {
+    void testCodingFragmentBufferingLargeFragment() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -453,7 +453,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingTinyFragments() throws Exception {
+    void testCodingFragmentBufferingTinyFragments() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -479,7 +479,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingTinyFragments2() throws Exception {
+    void testCodingFragmentBufferingTinyFragments2() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -505,7 +505,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingTinyFragments3() throws Exception {
+    void testCodingFragmentBufferingTinyFragments3() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -533,7 +533,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingBufferFlush() throws Exception {
+    void testCodingFragmentBufferingBufferFlush() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -557,7 +557,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingBufferFlush2() throws Exception {
+    void testCodingFragmentBufferingBufferFlush2() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -581,7 +581,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingChannelSaturated() throws Exception {
+    void testCodingFragmentBufferingChannelSaturated() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64, 8));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();
@@ -612,7 +612,7 @@ public class TestLengthDelimitedEncoder {
     }
 
     @Test
-    public void testCodingFragmentBufferingChannelSaturated2() throws Exception {
+    void testCodingFragmentBufferingChannelSaturated2() throws Exception {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(64, 8));
         final SessionOutputBuffer outbuf = Mockito.spy(new SessionOutputBufferImpl(1024, 128));
         final BasicHttpTransportMetrics metrics = new BasicHttpTransportMetrics();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestSessionInOutBuffers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestSessionInOutBuffers.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Simple tests for {@link SessionInputBuffer} and {@link SessionOutputBuffer}.
  */
-public class TestSessionInOutBuffers {
+class TestSessionInOutBuffers {
 
     private static WritableByteChannel newChannel(final ByteArrayOutputStream outStream) {
         return Channels.newChannel(outStream);
@@ -69,7 +69,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadLineChunks() throws Exception {
+    void testReadLineChunks() throws Exception {
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(16, 16);
 
         ReadableByteChannel channel = newChannel("One\r\nTwo\r\nThree");
@@ -107,7 +107,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testLineLimit() throws Exception {
+    void testLineLimit() throws Exception {
         final String s = "LoooooooooooooooooooooooooOOOOOOOOOOOOOOOOOOoooooooooooooooooooooong line\r\n";
         final CharArrayBuffer line = new CharArrayBuffer(64);
         final SessionInputBuffer inbuf1 = new SessionInputBufferImpl(128, 128);
@@ -124,7 +124,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testLineLimitBufferFull() throws Exception {
+    void testLineLimitBufferFull() throws Exception {
         final String s = "LoooooooooooooooooooooooooOOOOOOOOOOOOOOOOOOoooooooooooooooooooooong line\r\n";
         final CharArrayBuffer line = new CharArrayBuffer(64);
         final SessionInputBuffer inbuf1 = new SessionInputBufferImpl(32, 32);
@@ -141,7 +141,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testWriteLineChunks() throws Exception {
+    void testWriteLineChunks() throws Exception {
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(16, 16);
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(16, 16, 0);
 
@@ -195,7 +195,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testNonASCIIWriteLine() throws Exception {
+    void testNonASCIIWriteLine() throws Exception {
         final String testString = "123\u010Anew-header-from-some-header:injected-value";
         final String expectedResult = "123?new-header-from-some-header:injected-value";
 
@@ -223,7 +223,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testBasicReadWriteLine() throws Exception {
+    void testBasicReadWriteLine() throws Exception {
 
         final String[] teststrs = new String[5];
         teststrs[0] = "Hello";
@@ -269,7 +269,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testComplexReadWriteLine() throws Exception {
+    void testComplexReadWriteLine() throws Exception {
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 16);
         outbuf.write(ByteBuffer.wrap(new byte[] {'a', '\n'}));
         outbuf.write(ByteBuffer.wrap(new byte[] {'\r', '\n'}));
@@ -345,7 +345,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadOneByte() throws Exception {
+    void testReadOneByte() throws Exception {
         // make the buffer larger than that of transmitter
         final byte[] out = new byte[40];
         for (int i = 0; i < out.length; i++) {
@@ -366,7 +366,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadByteBuffer() throws Exception {
+    void testReadByteBuffer() throws Exception {
         final byte[] pattern = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
         final ReadableByteChannel channel = newChannel(pattern);
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(4096, 1024, 0);
@@ -383,7 +383,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadByteBufferWithMaxLen() throws Exception {
+    void testReadByteBufferWithMaxLen() throws Exception {
         final byte[] pattern = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
         final ReadableByteChannel channel = newChannel(pattern);
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(4096, 1024, 0);
@@ -403,7 +403,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadToChannel() throws Exception {
+    void testReadToChannel() throws Exception {
         final byte[] pattern = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
         final ReadableByteChannel channel = newChannel(pattern);
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(4096, 1024, 0);
@@ -418,7 +418,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testReadToChannelWithMaxLen() throws Exception {
+    void testReadToChannelWithMaxLen() throws Exception {
         final byte[] pattern = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
         final ReadableByteChannel channel = newChannel(pattern);
         final SessionInputBuffer inbuf = new SessionInputBufferImpl(4096, 1024, 0);
@@ -435,7 +435,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testWriteByteBuffer() throws Exception {
+    void testWriteByteBuffer() throws Exception {
         final byte[] pattern = "0123456789ABCDEF0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
 
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(4096, 1024);
@@ -450,7 +450,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testWriteFromChannel() throws Exception {
+    void testWriteFromChannel() throws Exception {
         final byte[] pattern = "0123456789ABCDEF0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
 
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(4096, 1024);
@@ -485,7 +485,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMultibyteCodedReadWriteLine() throws Exception {
+    void testMultibyteCodedReadWriteLine() throws Exception {
         final String s1 = constructString(SWISS_GERMAN_HELLO);
         final String s2 = constructString(RUSSIAN_HELLO);
         final String s3 = "Like hello and stuff";
@@ -533,7 +533,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testInputMatchesBufferLength() throws Exception {
+    void testInputMatchesBufferLength() {
         final String s1 = "abcde";
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 5);
         final CharArrayBuffer chbuffer = new CharArrayBuffer(16);
@@ -542,7 +542,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMalformedInputActionReport() throws Exception {
+    void testMalformedInputActionReport() throws Exception {
         final String s = constructString(SWISS_GERMAN_HELLO);
         final byte[] tmp = s.getBytes(StandardCharsets.ISO_8859_1);
 
@@ -559,7 +559,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMalformedInputActionIgnore() throws Exception {
+    void testMalformedInputActionIgnore() throws Exception {
         final String s = constructString(SWISS_GERMAN_HELLO);
         final byte[] tmp = s.getBytes(StandardCharsets.ISO_8859_1);
 
@@ -576,7 +576,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testMalformedInputActionReplace() throws Exception {
+    void testMalformedInputActionReplace() throws Exception {
         final String s = constructString(SWISS_GERMAN_HELLO);
         final byte[] tmp = s.getBytes(StandardCharsets.ISO_8859_1);
 
@@ -593,7 +593,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testUnmappableInputActionReport() throws Exception {
+    void testUnmappableInputActionReport() {
         final String s = "This text contains a circumflex \u0302!!!";
         final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         encoder.onMalformedInput(CodingErrorAction.IGNORE);
@@ -606,7 +606,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testUnmappableInputActionIgnore() throws Exception {
+    void testUnmappableInputActionIgnore() throws Exception {
         final String s = "This text contains a circumflex \u0302!!!";
         final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         encoder.onMalformedInput(CodingErrorAction.IGNORE);
@@ -624,7 +624,7 @@ public class TestSessionInOutBuffers {
     }
 
     @Test
-    public void testUnmappableInputActionReplace() throws Exception {
+    void testUnmappableInputActionReplace() throws Exception {
         final String s = "This text contains a circumflex \u0302 !!!";
         final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         encoder.onMalformedInput(CodingErrorAction.IGNORE);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestSessionInOutBuffers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/nio/TestSessionInOutBuffers.java
@@ -538,7 +538,7 @@ class TestSessionInOutBuffers {
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 5);
         final CharArrayBuffer chbuffer = new CharArrayBuffer(16);
         chbuffer.append(s1);
-        outbuf.writeLine(chbuffer);
+        Assertions.assertDoesNotThrow(() -> outbuf.writeLine(chbuffer));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/routing/TestPathPatternMatcher.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/routing/TestPathPatternMatcher.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.http.impl.routing;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestPathPatternMatcher {
+class TestPathPatternMatcher {
 
     @Test
-    public void testPathMatching() throws Exception {
+    void testPathMatching() {
         final PathPatternMatcher matcher = PathPatternMatcher.INSTANCE;
 
         Assertions.assertTrue(matcher.match("/*", "/foo/request"));
@@ -46,7 +46,7 @@ public class TestPathPatternMatcher {
     }
 
     @Test
-    public void testBetterMatch() throws Exception {
+    void testBetterMatch() {
         final PathPatternMatcher matcher = PathPatternMatcher.INSTANCE;
 
         Assertions.assertTrue(matcher.isBetter("/a*", "/*"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/routing/TestRequestRouter.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/routing/TestRequestRouter.java
@@ -35,10 +35,10 @@ import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestRequestRouter {
+class TestRequestRouter {
 
     @Test
-    public void testRequestRouting() throws Exception {
+    void testRequestRouting() throws Exception {
         final RequestRouter<Long> requestRouter = RequestRouter.<Long>builder(UriPatternType.URI_PATTERN)
                 .addRoute("somehost.somedomain", "/*", 0L)
                 .addRoute("someotherhost.somedomain", "/foo/*", 1L)
@@ -67,7 +67,7 @@ public class TestRequestRouter {
     }
 
     @Test
-    public void testDefaultAuthorityResolution() throws Exception {
+    void testDefaultAuthorityResolution() throws Exception {
         final RequestRouter<Long> requestRouter = RequestRouter.<Long>builder(UriPatternType.URI_PATTERN)
                 .addRoute(new URIAuthority("somehost", -1), "/*", 0L)
                 .addRoute(new URIAuthority("somehost", 80), "/*", 1L)
@@ -89,7 +89,7 @@ public class TestRequestRouter {
     }
 
     @Test
-    public void testCustomAuthorityResolution() throws Exception {
+    void testCustomAuthorityResolution() throws Exception {
         final RequestRouter<Long> requestRouter = RequestRouter.<Long>builder(UriPatternType.URI_PATTERN)
                 .addRoute(new URIAuthority("somehost", -1), "/*", 1L)
                 .addRoute(new URIAuthority("someotherhost", -1), "/*", 2L)
@@ -112,7 +112,7 @@ public class TestRequestRouter {
     }
 
     @Test
-    public void testDownstreamResolution() throws Exception {
+    void testDownstreamResolution() throws Exception {
         final RequestRouter<Long> requestRouter = RequestRouter.<Long>builder(UriPatternType.URI_PATTERN)
                 .addRoute(new URIAuthority("somehost", 80), "/*", 1L)
                 .addRoute(new URIAuthority("someotherhost", 80), "/*", 10L)

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/routing/TestUriPathRouter.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/routing/TestUriPathRouter.java
@@ -34,10 +34,10 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestUriPathRouter {
+class TestUriPathRouter {
 
     @Test
-    public void testBestMatchWildCardMatching() throws Exception {
+    void testBestMatchWildCardMatching() {
         final UriPathRouter.BestMatcher<Long> matcher = new UriPathRouter.BestMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("*", 0L),
@@ -57,7 +57,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testBestMatchWildCardMatchingSuffixPrefixPrecedence() throws Exception {
+    void testBestMatchWildCardMatchingSuffixPrefixPrecedence() {
         final UriPathRouter.BestMatcher<Long> matcher = new UriPathRouter.BestMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("/ma*", 1L),
@@ -66,7 +66,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testBestMatchWildCardMatchingExactMatch() throws Exception {
+    void testBestMatchWildCardMatchingExactMatch() {
         final UriPathRouter.BestMatcher<Long> matcher = new UriPathRouter.BestMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("exact", 1L),
@@ -75,7 +75,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testBestMatchWildCardMatchingNoMatch() throws Exception {
+    void testBestMatchWildCardMatchingNoMatch() {
         final UriPathRouter.BestMatcher<Long> matcher = new UriPathRouter.BestMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("/this/*", 1L),
@@ -84,7 +84,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testOrderedWildCardMatching1() throws Exception {
+    void testOrderedWildCardMatching1() {
         final UriPathRouter.OrderedMatcher<Long> matcher = new UriPathRouter.OrderedMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("*", 0L),
@@ -120,7 +120,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testOrderedWildCardMatchingSuffixPrefixPrecedence() throws Exception {
+    void testOrderedWildCardMatchingSuffixPrefixPrecedence() {
         final UriPathRouter.OrderedMatcher<Long> matcher = new UriPathRouter.OrderedMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("/ma*", 1L),
@@ -129,7 +129,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testOrderedStarAndExact() {
+    void testOrderedStarAndExact() {
         final UriPathRouter.OrderedMatcher<Long> matcher = new UriPathRouter.OrderedMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("*", 0L),
@@ -138,7 +138,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testOrderedExactAndStar() {
+    void testOrderedExactAndStar() {
         final UriPathRouter.OrderedMatcher<Long> matcher = new UriPathRouter.OrderedMatcher<>();
         final List<PathRoute<String, Long>> routes = Arrays.asList(
                 new PathRoute<>("exact", 1L),
@@ -147,7 +147,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testRegExMatching() throws Exception {
+    void testRegExMatching() {
         final UriPathRouter.RegexMatcher<Long> matcher = new UriPathRouter.RegexMatcher<>();
         final List<PathRoute<Pattern, Long>> routes = Arrays.asList(
                 new PathRoute<>(Pattern.compile("/one/two/three/.*"), 3L),
@@ -166,7 +166,7 @@ public class TestUriPathRouter {
     }
 
     @Test
-    public void testRegExWildCardMatchingSuffixPrefixPrecedence() throws Exception {
+    void testRegExWildCardMatchingSuffixPrefixPrecedence() {
         final UriPathRouter.RegexMatcher<Long> matcher = new UriPathRouter.RegexMatcher<>();
         final List<PathRoute<Pattern, Long>> routes = Arrays.asList(
                 new PathRoute<>(Pattern.compile("/ma.*"), 1L),

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStream.java
@@ -75,21 +75,6 @@ class TestEofSensorInputStream {
     }
 
     @Test
-    void testReleaseConnection() throws Exception {
-        Mockito.when(eofwatcher.streamClosed(Mockito.any())).thenReturn(Boolean.TRUE);
-
-        eofstream.close();
-
-        Assertions.assertTrue(eofstream.isSelfClosed());
-        Assertions.assertNull(eofstream.getWrappedStream());
-
-        Mockito.verify(inStream, Mockito.times(1)).close();
-        Mockito.verify(eofwatcher).streamClosed(inStream);
-
-        eofstream.close();
-    }
-
-    @Test
     void testAbortConnection() throws Exception {
         Mockito.when(eofwatcher.streamAbort(Mockito.any())).thenReturn(Boolean.TRUE);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/TestEofSensorInputStream.java
@@ -35,21 +35,21 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 @SuppressWarnings({"boxing","static-access"}) // test code
-public class TestEofSensorInputStream {
+class TestEofSensorInputStream {
 
     private InputStream inStream;
     private EofSensorWatcher eofwatcher;
     private EofSensorInputStream eofstream;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() {
         inStream = Mockito.mock(InputStream.class);
         eofwatcher = Mockito.mock(EofSensorWatcher.class);
         eofstream = new EofSensorInputStream(inStream, eofwatcher);
     }
 
     @Test
-    public void testClose() throws Exception {
+    void testClose() throws Exception {
         Mockito.when(eofwatcher.streamClosed(Mockito.any())).thenReturn(Boolean.TRUE);
 
         eofstream.close();
@@ -64,7 +64,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testCloseIOError() throws Exception {
+    void testCloseIOError() throws Exception {
         Mockito.when(eofwatcher.streamClosed(Mockito.any())).thenThrow(new IOException());
 
         Assertions.assertThrows(IOException.class, () -> eofstream.close());
@@ -75,7 +75,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testReleaseConnection() throws Exception {
+    void testReleaseConnection() throws Exception {
         Mockito.when(eofwatcher.streamClosed(Mockito.any())).thenReturn(Boolean.TRUE);
 
         eofstream.close();
@@ -90,7 +90,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testAbortConnection() throws Exception {
+    void testAbortConnection() throws Exception {
         Mockito.when(eofwatcher.streamAbort(Mockito.any())).thenReturn(Boolean.TRUE);
 
         eofstream.abort();
@@ -105,7 +105,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testAbortConnectionIOError() throws Exception {
+    void testAbortConnectionIOError() throws Exception {
         Mockito.when(eofwatcher.streamAbort(Mockito.any())).thenThrow(new IOException());
 
         Assertions.assertThrows(IOException.class, () -> eofstream.abort());
@@ -116,7 +116,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testRead() throws Exception {
+    void testRead() throws Exception {
         Mockito.when(eofwatcher.eofDetected(Mockito.any())).thenReturn(Boolean.TRUE);
         Mockito.when(inStream.read()).thenReturn(0, -1);
 
@@ -139,7 +139,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testReadIOError() throws Exception {
+    void testReadIOError() throws Exception {
         Mockito.when(eofwatcher.eofDetected(Mockito.any())).thenReturn(Boolean.TRUE);
         Mockito.when(inStream.read()).thenThrow(new IOException());
 
@@ -151,7 +151,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testReadByteArray() throws Exception {
+    void testReadByteArray() throws Exception {
         Mockito.when(eofwatcher.eofDetected(Mockito.any())).thenReturn(Boolean.TRUE);
         Mockito.when(inStream.read(Mockito.any(), Mockito.anyInt(), Mockito.anyInt()))
             .thenReturn(1, -1);
@@ -177,7 +177,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testReadByteArrayIOError() throws Exception {
+    void testReadByteArrayIOError() throws Exception {
         Mockito.when(eofwatcher.eofDetected(Mockito.any())).thenReturn(Boolean.TRUE);
         Mockito.when(inStream.read(Mockito.any(), Mockito.anyInt(), Mockito.anyInt()))
             .thenThrow(new IOException());
@@ -191,7 +191,7 @@ public class TestEofSensorInputStream {
     }
 
     @Test
-    public void testReadAfterAbort() throws Exception {
+    void testReadAfterAbort() throws Exception {
         Mockito.when(eofwatcher.streamAbort(Mockito.any())).thenReturn(Boolean.TRUE);
 
         eofstream.abort();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestBasicHttpEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestBasicHttpEntity.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link BasicHttpEntity}.
  *
  */
-public class TestBasicHttpEntity {
+class TestBasicHttpEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity httpentity = new BasicHttpEntity(new ByteArrayInputStream(bytes), bytes.length, null);
         Assertions.assertEquals(bytes.length, httpentity.getContentLength());
@@ -53,7 +53,7 @@ public class TestBasicHttpEntity {
     }
 
     @Test
-    public void testConstructorNullContent() throws Exception {
+    void testConstructorNullContent() {
         // BasicHttpEntity(InputStream, ContentType)
         Assertions.assertThrows(NullPointerException.class, () -> new BasicHttpEntity(null, ContentType.APPLICATION_ATOM_XML));
         Assertions.assertThrows(NullPointerException.class, () -> new BasicHttpEntity(null, null));
@@ -75,7 +75,7 @@ public class TestBasicHttpEntity {
     }
 
     @Test
-    public void testToString() throws Exception {
+    void testToString() throws Exception {
         try (final BasicHttpEntity httpentity = new BasicHttpEntity(EmptyInputStream.INSTANCE, 10,
                 ContentType.parseLenient("blah"), "yada", true)) {
             Assertions.assertEquals(
@@ -85,7 +85,7 @@ public class TestBasicHttpEntity {
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity httpentity = new BasicHttpEntity(new ByteArrayInputStream(bytes), bytes.length,
                 ContentType.TEXT_PLAIN);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestBufferedHttpEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestBufferedHttpEntity.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link BufferedHttpEntity}.
  *
  */
-public class TestBufferedHttpEntity {
+class TestBufferedHttpEntity {
 
     @Test
-    public void testBufferingEntity() throws Exception {
+    void testBufferingEntity() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BufferedHttpEntity entity = new BufferedHttpEntity(
                 new InputStreamEntity(new ByteArrayInputStream(bytes), -1, null));
@@ -56,7 +56,7 @@ public class TestBufferedHttpEntity {
     }
 
     @Test
-    public void testWrappingEntity() throws Exception {
+    void testWrappingEntity() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final ByteArrayEntity httpentity = new ByteArrayEntity(bytes, null, true);
         try (final BufferedHttpEntity bufentity = new BufferedHttpEntity(httpentity)) {
@@ -72,12 +72,12 @@ public class TestBufferedHttpEntity {
     }
 
     @Test
-    public void testIllegalConstructor() throws Exception {
+    void testIllegalConstructor() {
         Assertions.assertThrows(NullPointerException.class, () -> new BufferedHttpEntity(null));
     }
 
     @Test
-    public void testWriteToBuffered() throws Exception {
+    void testWriteToBuffered() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final InputStreamEntity httpentity = new InputStreamEntity(new ByteArrayInputStream(bytes), -1, null);
         try (final BufferedHttpEntity bufentity = new BufferedHttpEntity(httpentity)) {
@@ -105,7 +105,7 @@ public class TestBufferedHttpEntity {
     }
 
     @Test
-    public void testWriteToWrapped() throws Exception {
+    void testWriteToWrapped() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final ByteArrayEntity httpentity = new ByteArrayEntity(bytes, null);
         try (final BufferedHttpEntity bufentity = new BufferedHttpEntity(httpentity)) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestByteArrayEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestByteArrayEntity.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link ByteArrayEntity}.
  *
  */
-public class TestByteArrayEntity {
+class TestByteArrayEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         try (final ByteArrayEntity entity = new ByteArrayEntity(bytes, null)) {
 
@@ -52,7 +52,7 @@ public class TestByteArrayEntity {
     }
 
     @Test
-    public void testBasicOffLen() throws Exception {
+    void testBasicOffLen() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         try (final ByteArrayEntity entity = new ByteArrayEntity(bytes, 8, 7, null)) {
 
@@ -64,34 +64,34 @@ public class TestByteArrayEntity {
     }
 
     @Test
-    public void testIllegalConstructorNullByteArray() throws Exception {
+    void testIllegalConstructorNullByteArray() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 new ByteArrayEntity(null, null));
     }
 
     @Test
-    public void testIllegalConstructorBadLen() throws Exception {
+    void testIllegalConstructorBadLen() {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 new ByteArrayEntity(bytes, 0, bytes.length + 1, null));
     }
 
     @Test
-    public void testIllegalConstructorBadOff1() throws Exception {
+    void testIllegalConstructorBadOff1() {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 new ByteArrayEntity(bytes, -1, bytes.length, null));
     }
 
     @Test
-    public void testIllegalConstructorBadOff2() throws Exception {
+    void testIllegalConstructorBadOff2() {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 new ByteArrayEntity(bytes, bytes.length + 1, bytes.length, null));
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         try (final ByteArrayEntity entity = new ByteArrayEntity(bytes, null)) {
 
@@ -118,7 +118,7 @@ public class TestByteArrayEntity {
     }
 
     @Test
-    public void testWriteToOffLen() throws Exception {
+    void testWriteToOffLen() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final int off = 8;
         final int len = 7;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestByteBufferEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestByteBufferEntity.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link ByteBufferEntity}.
  *
  */
-public class TestByteBufferEntity {
+class TestByteBufferEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final ByteBuffer bytes = ByteBuffer.wrap("Message content".getBytes(StandardCharsets.US_ASCII));
         try (final ByteBufferEntity httpentity = new ByteBufferEntity(bytes, null)) {
 
@@ -54,7 +54,7 @@ public class TestByteBufferEntity {
 
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final ByteBuffer bytes = ByteBuffer.wrap("Message content".getBytes(StandardCharsets.US_ASCII));
         try (final ByteBufferEntity httpentity = new ByteBufferEntity(bytes, null)) {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -51,16 +51,16 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link EntityUtils}.
  *
  */
-public class TestEntityUtils {
+class TestEntityUtils {
 
     @Test
-    public void testNullEntityToByteArray() throws Exception {
+    void testNullEntityToByteArray() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 EntityUtils.toByteArray(null));
     }
 
     @Test
-    public void testMaxIntContentToByteArray() throws Exception {
+    void testMaxIntContentToByteArray() {
         final byte[] content = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(content),
                 Integer.MAX_VALUE + 100L, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
@@ -69,7 +69,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testUnknownLengthContentToByteArray() throws Exception {
+    void testUnknownLengthContentToByteArray() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), -1, null);
         final byte[] bytes2 = EntityUtils.toByteArray(entity);
@@ -81,7 +81,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testKnownLengthContentToByteArray() throws Exception {
+    void testKnownLengthContentToByteArray() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), bytes.length, null);
         final byte[] bytes2 = EntityUtils.toByteArray(entity);
@@ -93,12 +93,12 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testNullEntityToString() throws Exception {
+    void testNullEntityToString() {
         Assertions.assertThrows(NullPointerException.class, () -> EntityUtils.toString(null));
     }
 
     @Test
-    public void testMaxIntContentToString() throws Exception {
+    void testMaxIntContentToString() {
         final byte[] content = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(content),
                 Integer.MAX_VALUE + 100L, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
@@ -107,7 +107,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testUnknownLengthContentToString() throws Exception {
+    void testUnknownLengthContentToString() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), -1, null);
         final String s = EntityUtils.toString(entity, "US-ASCII");
@@ -115,7 +115,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testKnownLengthContentToString() throws Exception {
+    void testKnownLengthContentToString() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), bytes.length,
                 ContentType.TEXT_PLAIN.withCharset(StandardCharsets.US_ASCII));
@@ -143,7 +143,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testNoCharsetContentToString() throws Exception {
+    void testNoCharsetContentToString() {
         final String content = constructString(SWISS_GERMAN_HELLO);
         final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), ContentType.TEXT_PLAIN);
@@ -151,7 +151,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testDefaultCharsetContentToString() throws Exception {
+    void testDefaultCharsetContentToString() throws Exception {
         final String content = constructString(RUSSIAN_HELLO);
         final byte[] bytes = content.getBytes(Charset.forName("KOI8-R"));
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes),
@@ -161,7 +161,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testContentWithContentTypeToString() throws Exception {
+    void testContentWithContentTypeToString() throws Exception {
         final String content = constructString(RUSSIAN_HELLO);
         final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes),
@@ -171,7 +171,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testContentWithInvalidContentTypeToString() throws Exception {
+    void testContentWithInvalidContentTypeToString() throws Exception {
         final String content = constructString(RUSSIAN_HELLO);
         final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         final HttpEntity entity = new AbstractHttpEntity("text/plain; charset=nosuchcharset", null) {
@@ -209,7 +209,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testParseEntity() throws Exception {
+    void testParseEntity() throws Exception {
         final StringEntity entity1 = new StringEntity("Name1=Value1", ContentType.APPLICATION_FORM_URLENCODED);
         final List<NameValuePair> result = EntityUtils.parse(entity1);
         Assertions.assertEquals(1, result.size());
@@ -220,7 +220,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testParseUTF8Entity() throws Exception {
+    void testParseUTF8Entity() throws Exception {
         final String ru_hello = constructString(RUSSIAN_HELLO);
         final String ch_hello = constructString(SWISS_GERMAN_HELLO);
         final List <NameValuePair> parameters = new ArrayList<>();
@@ -240,7 +240,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testByteArrayMaxResultLength() throws IOException {
+    void testByteArrayMaxResultLength() throws IOException {
         final byte[] allBytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final Map<Integer, byte[]> testCases = new HashMap<>();
         testCases.put(0, new byte[]{});
@@ -262,7 +262,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testByteArrayMaxResultLengthWithNoContentLength() throws IOException {
+    void testByteArrayMaxResultLengthWithNoContentLength() throws IOException {
         final byte b = 'b';
         final byte[] allBytes = new byte[5000];
         Arrays.fill(allBytes, b);
@@ -286,7 +286,7 @@ public class TestEntityUtils {
     }
 
     @Test
-    public void testStringMaxResultLength() throws IOException, ParseException {
+    void testStringMaxResultLength() throws IOException, ParseException {
         final String allMessage = "Message content";
         final byte[] allBytes = allMessage.getBytes(StandardCharsets.US_ASCII);
         final Map<Integer, String> testCases = new HashMap<>();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestEntityUtils.java
@@ -147,7 +147,7 @@ class TestEntityUtils {
         final String content = constructString(SWISS_GERMAN_HELLO);
         final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         final BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(bytes), ContentType.TEXT_PLAIN);
-        final String s = EntityUtils.toString(entity);
+        Assertions.assertDoesNotThrow(() -> EntityUtils.toString(entity));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestFileEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestFileEntity.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link FileEntity}.
  *
  */
-public class TestFileEntity {
+class TestFileEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final File tmpfile = File.createTempFile("testfile", ".txt");
         tmpfile.deleteOnExit();
         try (final FileEntity httpentity = new FileEntity(tmpfile, ContentType.TEXT_PLAIN)) {
@@ -59,12 +59,12 @@ public class TestFileEntity {
     }
 
     @Test
-    public void testNullConstructor() throws Exception {
+    void testNullConstructor() {
         Assertions.assertThrows(NullPointerException.class, () -> new FileEntity(null, ContentType.TEXT_PLAIN));
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final File tmpfile = File.createTempFile("testfile", ".txt");
         tmpfile.deleteOnExit();
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link HttpEntityWrapper}.
  *
  */
-public class TestHttpEntityWrapper {
+class TestHttpEntityWrapper {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final StringEntity entity = new StringEntity("Message content", ContentType.TEXT_PLAIN, "blah", false);
         try (final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity)) {
 
@@ -56,12 +56,12 @@ public class TestHttpEntityWrapper {
     }
 
     @Test
-    public void testIllegalConstructor() throws Exception {
+    void testIllegalConstructor() {
         Assertions.assertThrows(NullPointerException.class, () -> new HttpEntityWrapper(null));
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final String s = "Message content";
         final byte[] bytes = s.getBytes(StandardCharsets.US_ASCII);
         final StringEntity entity = new StringEntity(s);
@@ -90,7 +90,7 @@ public class TestHttpEntityWrapper {
     }
 
     @Test
-    public void testConsumeContent() throws Exception {
+    void testConsumeContent() throws Exception {
         final String s = "Message content";
         final StringEntity entity = new StringEntity(s);
         final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestHttpEntityWrapper.java
@@ -95,7 +95,7 @@ class TestHttpEntityWrapper {
         final StringEntity entity = new StringEntity(s);
         final HttpEntityWrapper wrapped = new HttpEntityWrapper(entity);
         EntityUtils.consume(wrapped);
-        EntityUtils.consume(wrapped);
+        Assertions.assertDoesNotThrow(() -> EntityUtils.consume(wrapped));
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestInputStreamEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestInputStreamEntity.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link InputStreamEntity}.
  *
  */
-public class TestInputStreamEntity {
+class TestInputStreamEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final byte[] bytes = "Message content".getBytes(StandardCharsets.US_ASCII);
         final InputStreamEntity entity = new InputStreamEntity(new ByteArrayInputStream(bytes), bytes.length, null);
 
@@ -54,20 +54,20 @@ public class TestInputStreamEntity {
     }
 
     @Test
-    public void testNullConstructor() throws Exception {
+    void testNullConstructor() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 new InputStreamEntity(null, 0, null));
     }
 
     @Test
-    public void testUnknownLengthConstructor() throws Exception {
+    void testUnknownLengthConstructor() throws Exception {
         try (final InputStreamEntity entity = new InputStreamEntity(EmptyInputStream.INSTANCE, null)) {
             Assertions.assertEquals(-1, entity.getContentLength());
         }
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final String message = "Message content";
         final byte[] bytes = message.getBytes(StandardCharsets.US_ASCII);
         final InputStream inStream = new ByteArrayInputStream(bytes);
@@ -85,7 +85,7 @@ public class TestInputStreamEntity {
     }
 
     @Test
-    public void testWriteToPartialContent() throws Exception {
+    void testWriteToPartialContent() throws Exception {
         final String message = "Message content";
         final byte[] bytes = message.getBytes(StandardCharsets.US_ASCII);
         final InputStream inStream = new ByteArrayInputStream(bytes);
@@ -105,7 +105,7 @@ public class TestInputStreamEntity {
     }
 
     @Test
-    public void testWriteToUnknownLength() throws Exception {
+    void testWriteToUnknownLength() throws Exception {
         final String message = "Message content";
         final byte[] bytes = message.getBytes(StandardCharsets.US_ASCII);
         final InputStreamEntity entity = new InputStreamEntity(new ByteArrayInputStream(bytes),
@@ -122,7 +122,7 @@ public class TestInputStreamEntity {
     }
 
     @Test
-    public void testWriteToNull() throws Exception {
+    void testWriteToNull() throws Exception {
         try (final InputStreamEntity entity = new InputStreamEntity(EmptyInputStream.INSTANCE, 0, null)) {
             Assertions.assertThrows(NullPointerException.class, () -> entity.writeTo(null));
         }}

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestNullEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestNullEntity.java
@@ -38,30 +38,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class TestNullEntity {
+class TestNullEntity {
 
     @Test
-    public void testLength() {
+    void testLength() {
         assertEquals(0, NullEntity.INSTANCE.getContentLength());
     }
 
     @Test
-    public void testContentType() {
+    void testContentType() {
         assertNull(NullEntity.INSTANCE.getContentType());
     }
 
     @Test
-    public void testContentEncoding() {
+    void testContentEncoding() {
         assertNull(NullEntity.INSTANCE.getContentEncoding());
     }
 
     @Test
-    public void testTrailerNames() {
+    void testTrailerNames() {
         assertEquals(Collections.emptySet(), NullEntity.INSTANCE.getTrailerNames());
     }
 
     @Test
-    public void testContentStream() throws IOException {
+    void testContentStream() throws IOException {
         try (InputStream content = NullEntity.INSTANCE.getContent()) {
             assertEquals(-1, content.read());
         }
@@ -72,19 +72,19 @@ public class TestNullEntity {
     }
 
     @Test
-    public void testWriteTo() throws IOException {
+    void testWriteTo() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         NullEntity.INSTANCE.writeTo(baos);
         assertEquals(0, baos.size());
     }
 
     @Test
-    public void testIsStreaming() {
+    void testIsStreaming() {
         assertFalse(NullEntity.INSTANCE.isStreaming());
     }
 
     @Test
-    public void testIsChunked() {
+    void testIsChunked() {
         assertFalse(NullEntity.INSTANCE.isChunked());
     }
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestPathEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestPathEntity.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link PathEntity}.
  */
-public class TestPathEntity {
+class TestPathEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final Path tmpPath = Files.createTempFile("testfile", ".txt");
         // Mark the file for deletion on VM exit if an assertion fails.
         tmpPath.toFile().deleteOnExit();
@@ -60,12 +60,12 @@ public class TestPathEntity {
     }
 
     @Test
-    public void testNullConstructor() throws Exception {
+    void testNullConstructor() {
         Assertions.assertThrows(NullPointerException.class, () -> new PathEntity(null, ContentType.TEXT_PLAIN));
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final Path tmpPath = Files.createTempFile("testfile", ".txt");
         // Mark the file for deletion on VM exit if an assertion fails.
         tmpPath.toFile().deleteOnExit();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestSerializableEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestSerializableEntity.java
@@ -36,7 +36,7 @@ import java.io.Serializable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestSerializableEntity {
+class TestSerializableEntity {
 
     public static class SerializableObject implements Serializable {
 
@@ -50,7 +50,7 @@ public class TestSerializableEntity {
     }
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(baos);
 
@@ -67,7 +67,7 @@ public class TestSerializableEntity {
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final Serializable serializableObj = new SerializableObject();
         try (final SerializableEntity httpentity = new SerializableEntity(serializableObj, null)) {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestStringEntity.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/entity/TestStringEntity.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link StringEntity}.
  */
-public class TestStringEntity {
+class TestStringEntity {
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() throws Exception {
         final String s = "Message content";
         try (final StringEntity httpentity = new StringEntity(s, ContentType.TEXT_PLAIN)) {
 
@@ -54,12 +54,12 @@ public class TestStringEntity {
     }
 
     @Test
-    public void testNullConstructor() throws Exception {
+    void testNullConstructor() {
         Assertions.assertThrows(NullPointerException.class, () -> new StringEntity(null));
     }
 
     @Test
-    public void testDefaultContent() throws Exception {
+    void testDefaultContent() throws Exception {
         final String s = "Message content";
         StringEntity httpentity = new StringEntity(s, ContentType.create("text/csv", "ANSI_X3.4-1968"));
         Assertions.assertEquals("text/csv; charset=US-ASCII", httpentity.getContentType());
@@ -84,7 +84,7 @@ public class TestStringEntity {
         };
 
     @Test
-    public void testNullCharset() throws Exception {
+    void testNullCharset() throws Exception {
         final String s = constructString(SWISS_GERMAN_HELLO);
         StringEntity httpentity = new StringEntity(s, ContentType.create("text/plain", (Charset) null));
         Assertions.assertNotNull(httpentity.getContentType());
@@ -97,7 +97,7 @@ public class TestStringEntity {
     }
 
     @Test
-    public void testWriteTo() throws Exception {
+    void testWriteTo() throws Exception {
         final String s = "Message content";
         final byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         try (final StringEntity httpentity = new StringEntity(s)) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilderTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilderTest.java
@@ -78,13 +78,13 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void create() {
+    void create() {
         final ClassicHttpRequest classicHttpRequest = ClassicRequestBuilder.create(Method.HEAD.name()).build();
         assertEquals(Method.HEAD.name(), classicHttpRequest.getMethod());
     }
 
     @Test
-    public void get() throws UnknownHostException, URISyntaxException {
+    void get() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.get();
         assertEquals(Method.GET.name(), classicRequestBuilder.getMethod());
 
@@ -97,7 +97,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void head() throws UnknownHostException, URISyntaxException {
+    void head() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.head();
         assertEquals(Method.HEAD.name(), classicRequestBuilder.getMethod());
 
@@ -110,7 +110,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void patch() throws UnknownHostException, URISyntaxException {
+    void patch() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.patch();
         assertEquals(Method.PATCH.name(), classicRequestBuilder.getMethod());
 
@@ -123,7 +123,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void post() throws UnknownHostException, URISyntaxException {
+    void post() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.post();
         assertEquals(Method.POST.name(), classicRequestBuilder.getMethod());
 
@@ -136,7 +136,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void put() throws UnknownHostException, URISyntaxException {
+    void put() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.put();
         assertEquals(Method.PUT.name(), classicRequestBuilder.getMethod());
 
@@ -149,7 +149,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void delete() throws UnknownHostException, URISyntaxException {
+    void delete() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.delete();
         assertEquals(Method.DELETE.name(), classicRequestBuilder.getMethod());
 
@@ -162,7 +162,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void trace() throws UnknownHostException, URISyntaxException {
+    void trace() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.trace();
         assertEquals(Method.TRACE.name(), classicRequestBuilder.getMethod());
 
@@ -175,7 +175,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void option() throws UnknownHostException, URISyntaxException {
+    void option() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.options();
         assertEquals(Method.OPTIONS.name(), classicRequestBuilder.getMethod());
 
@@ -188,7 +188,7 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
-    public void builder() {
+    void builder() {
         final Header header = new BasicHeader("header2", "blah");
         final ClassicHttpRequest classicHttpRequest = ClassicRequestBuilder.get()
                 .setVersion(HttpVersion.HTTP_1_1)
@@ -228,7 +228,7 @@ class ClassicRequestBuilderTest {
 
 
     @Test
-    public void builderTraceThrowsIllegalStateException() {
+    void builderTraceThrowsIllegalStateException() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 ClassicRequestBuilder.trace()
                         .setVersion(HttpVersion.HTTP_1_1)

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicResponseBuilderTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicResponseBuilderTest.java
@@ -60,7 +60,7 @@ class ClassicResponseBuilderTest {
     ByteArrayOutputStream outStream;
 
     @BeforeEach
-    public void prepareMocks() throws IOException {
+    void prepareMocks() throws IOException {
         MockitoAnnotations.openMocks(this);
         conn = new DefaultBHttpServerConnection("http", Http1Config.DEFAULT,
                 null, null,

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpRequestWrapperTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpRequestWrapperTest.java
@@ -37,10 +37,10 @@ import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class HttpRequestWrapperTest {
+class HttpRequestWrapperTest {
 
     @Test
-    public void testRequestBasics() throws Exception {
+    void testRequestBasics() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "/stuff");
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
 
@@ -53,7 +53,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testDefaultRequestConstructors() {
+    void testDefaultRequestConstructors() {
         final HttpRequest request1 = new BasicHttpRequest("WHATEVER", "/");
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request1);
         Assertions.assertEquals("WHATEVER", httpRequestWrapper.getMethod());
@@ -70,7 +70,7 @@ public class HttpRequestWrapperTest {
 
 
     @Test
-    public void testRequestWithRelativeURI() throws Exception {
+    void testRequestWithRelativeURI() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("/stuff"));
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -80,7 +80,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestWithAbsoluteURI() throws Exception {
+    void testRequestWithAbsoluteURI() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("https://host:9443/stuff?param=value"));
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -93,7 +93,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestWithAbsoluteURIAsPath() throws Exception {
+    void testRequestWithAbsoluteURIAsPath() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "https://host:9443/stuff?param=value");
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -104,7 +104,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestWithNoPath() throws Exception {
+    void testRequestWithNoPath() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("http://host"));
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -115,7 +115,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestWithUserInfo() throws Exception {
+    void testRequestWithUserInfo() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("https://user:pwd@host:9443/stuff?param=value"));
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -126,7 +126,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestWithAuthority() throws Exception {
+    void testRequestWithAuthority() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new HttpHost("http", "somehost", -1), "/stuff");
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -140,7 +140,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestWithAuthorityRelativePath() throws Exception {
+    void testRequestWithAuthorityRelativePath() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new HttpHost("http", "somehost", -1), "stuff");
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());
@@ -151,7 +151,7 @@ public class HttpRequestWrapperTest {
     }
 
     @Test
-    public void testRequestHostWithReservedChars() throws Exception {
+    void testRequestHostWithReservedChars() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://someuser%21@%21example%21.com/stuff"));
         final HttpRequestWrapper httpRequestWrapper = new HttpRequestWrapper(request);
         Assertions.assertEquals(Method.GET.name(), httpRequestWrapper.getMethod());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpResponseWrapperTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpResponseWrapperTest.java
@@ -34,7 +34,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class HttpResponseWrapperTest {
+class HttpResponseWrapperTest {
 
     @Test
     void testDefaultResponseConstructors() {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpResponseWrapperTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/HttpResponseWrapperTest.java
@@ -57,7 +57,6 @@ class HttpResponseWrapperTest {
         final HttpResponse response1 = new BasicHttpResponse(200, "OK");
         final HttpResponseWrapper httpResponseWrapper1 = new HttpResponseWrapper(response1);
 
-        Assertions.assertNotNull(httpResponseWrapper1.getCode());
         Assertions.assertEquals(200, httpResponseWrapper1.getCode());
 
         final HttpResponse response2 = new BasicHttpResponse(HttpStatus.SC_BAD_REQUEST, "Bad Request");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeader.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeader.java
@@ -33,22 +33,22 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link BasicHeader}.
  */
-public class TestBasicHeader {
+class TestBasicHeader {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final Header param = new BasicHeader("name", "value");
         Assertions.assertEquals("name", param.getName());
         Assertions.assertEquals("value", param.getValue());
     }
 
     @Test
-    public void testInvalidName() {
+    void testInvalidName() {
         Assertions.assertThrows(NullPointerException.class, () -> new BasicHeader(null, null));
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         final Header param1 = new BasicHeader("name1", "value1");
         Assertions.assertEquals("name1: value1", param1.toString());
         final Header param2 = new BasicHeader("name1", null);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderElementIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderElementIterator.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link BasicHeaderElementIterator}.
  *
  */
-public class TestBasicHeaderElementIterator {
+class TestBasicHeaderElementIterator {
 
     @Test
-    public void testMultiHeader() {
+    void testMultiHeader() {
         final Header[] headers = new Header[]{
                 new BasicHeader("Name", "value0"),
                 new BasicHeader("Name", "value1")
@@ -66,7 +66,7 @@ public class TestBasicHeaderElementIterator {
     }
 
     @Test
-    public void testMultiHeaderSameLine() {
+    void testMultiHeaderSameLine() {
         final Header[] headers = new Header[]{
                 new BasicHeader("name", "value0,value1"),
                 new BasicHeader("nAme", "cookie1=1,cookie2=2")
@@ -89,7 +89,7 @@ public class TestBasicHeaderElementIterator {
     }
 
     @Test
-    public void testFringeCases() {
+    void testFringeCases() {
         final Header[] headers = new Header[]{
                 new BasicHeader("Name", null),
                 new BasicHeader("Name", "    "),

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderIterator.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link java.util.Iterator} of {@link org.apache.hc.core5.http.Header}s.
  *
  */
-public class TestBasicHeaderIterator {
+class TestBasicHeaderIterator {
 
     @Test
-    public void testAllSame() {
+    void testAllSame() {
         final Header[] headers = new Header[]{
             new BasicHeader("Name", "value0"),
             new BasicHeader("nAme", "value1, value1.1"),
@@ -76,7 +76,7 @@ public class TestBasicHeaderIterator {
 
 
     @Test
-    public void testFirstLastOneNone() {
+    void testFirstLastOneNone() {
         final Header[] headers = new Header[]{
             new BasicHeader("match"   , "value0"),
             new BasicHeader("mismatch", "value1, value1.1"),
@@ -117,7 +117,7 @@ public class TestBasicHeaderIterator {
 
 
     @Test
-    public void testInterspersed() {
+    void testInterspersed() {
         final Header[] headers = new Header[]{
             new BasicHeader("yellow", "00"),
             new BasicHeader("maroon", "01"),
@@ -215,7 +215,7 @@ public class TestBasicHeaderIterator {
 
 
     @Test
-    public void testInvalid() {
+    void testInvalid() {
         Assertions.assertThrows(NullPointerException.class, () -> new BasicHeaderIterator(null, "whatever"));
         // this is not invalid
         final Iterator<Header> hit = new BasicHeaderIterator(new Header[0], "whatever");
@@ -226,7 +226,7 @@ public class TestBasicHeaderIterator {
     }
 
     @Test
-    public void testRemaining() {
+    void testRemaining() {
         // to satisfy Clover and take coverage to 100%
 
         final Header[] headers = new Header[]{

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueFormatter.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueFormatter.java
@@ -38,17 +38,17 @@ import org.junit.jupiter.api.Test;
  *
  *
  */
-public class TestBasicHeaderValueFormatter {
+class TestBasicHeaderValueFormatter {
 
     private BasicHeaderValueFormatter formatter;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.formatter = BasicHeaderValueFormatter.INSTANCE;
     }
 
     @Test
-    public void testNVPFormatting() throws Exception {
+    void testNVPFormatting() {
         final NameValuePair param1 = new BasicNameValuePair("param", "regular_stuff");
         final NameValuePair param2 = new BasicNameValuePair("param", "this\\that");
         final NameValuePair param3 = new BasicNameValuePair("param", "this,that");
@@ -105,7 +105,7 @@ public class TestBasicHeaderValueFormatter {
     }
 
     @Test
-    public void testParamsFormatting() throws Exception {
+    void testParamsFormatting() {
         final NameValuePair param1 = new BasicNameValuePair("param", "regular_stuff");
         final NameValuePair param2 = new BasicNameValuePair("param", "this\\that");
         final NameValuePair param3 = new BasicNameValuePair("param", "this,that");
@@ -124,7 +124,7 @@ public class TestBasicHeaderValueFormatter {
     }
 
     @Test
-    public void testHEFormatting() throws Exception {
+    void testHEFormatting() {
         final NameValuePair param1 = new BasicNameValuePair("param", "regular_stuff");
         final NameValuePair param2 = new BasicNameValuePair("param", "this\\that");
         final NameValuePair param3 = new BasicNameValuePair("param", "this,that");
@@ -140,7 +140,7 @@ public class TestBasicHeaderValueFormatter {
     }
 
     @Test
-    public void testElementsFormatting() throws Exception {
+    void testElementsFormatting() {
         final NameValuePair param1 = new BasicNameValuePair("param", "regular_stuff");
         final NameValuePair param2 = new BasicNameValuePair("param", "this\\that");
         final NameValuePair param3 = new BasicNameValuePair("param", "this,that");
@@ -162,7 +162,7 @@ public class TestBasicHeaderValueFormatter {
 
 
     @Test
-    public void testInvalidArguments() throws Exception {
+    void testInvalidArguments() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final NameValuePair param = new BasicNameValuePair("param", "regular_stuff");
         final NameValuePair[] params = new NameValuePair[] {param};

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicHeaderValueParser.java
@@ -38,17 +38,17 @@ import org.junit.jupiter.api.Test;
  *
  * @version $Id$
  */
-public class TestBasicHeaderValueParser {
+class TestBasicHeaderValueParser {
 
     private BasicHeaderValueParser parser;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.parser = BasicHeaderValueParser.INSTANCE;
     }
 
     @Test
-    public void testParseHeaderElements() throws Exception {
+    void testParseHeaderElements() {
         final String headerValue = "name1 = value1; name2; name3=\"value3\" , name4=value4; " +
             "name5=value5, name6= ; name7 = value7; name8 = \" value8\"";
         final CharArrayBuffer buf = new CharArrayBuffer(64);
@@ -85,7 +85,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testParseHEEscaped() {
+    void testParseHEEscaped() {
         final String headerValue =
           "test1 =  \"\\\"stuff\\\"\", test2= \"\\\\\", test3 = \"stuff, stuff\"";
         final CharArrayBuffer buf = new CharArrayBuffer(64);
@@ -102,7 +102,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testHEFringeCase1() throws Exception {
+    void testHEFringeCase1() {
         final String headerValue = "name1 = value1,";
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.append(headerValue);
@@ -112,7 +112,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testHEFringeCase2() throws Exception {
+    void testHEFringeCase2() {
         final String headerValue = "name1 = value1, ";
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.append(headerValue);
@@ -122,7 +122,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testHEFringeCase3() throws Exception {
+    void testHEFringeCase3() {
         final String headerValue = ",, ,, ,";
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.append(headerValue);
@@ -132,7 +132,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testNVParse() {
+    void testNVParse() {
 
         String s = "test";
         CharArrayBuffer buffer = new CharArrayBuffer(64);
@@ -247,7 +247,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testNVParseAll() {
+    void testNVParseAll() {
         String s =
             "test; test1 =  stuff   ; test2 =  \"stuff; stuff\"; test3=\"stuff";
         CharArrayBuffer buffer = new CharArrayBuffer(16);
@@ -293,7 +293,7 @@ public class TestBasicHeaderValueParser {
     }
 
     @Test
-    public void testNVParseEscaped() {
+    void testNVParseEscaped() {
         final String headerValue =
           "test1 =  \"\\\"stuff\\\"\"; test2= \"\\\\\"; test3 = \"stuff; stuff\"";
         final CharArrayBuffer buf = new CharArrayBuffer(64);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicLineFormatter.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicLineFormatter.java
@@ -39,24 +39,24 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link BasicLineFormatter}.
  */
-public class TestBasicLineFormatter {
+class TestBasicLineFormatter {
 
     private BasicLineFormatter formatter;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.formatter = BasicLineFormatter.INSTANCE;
     }
 
     @Test
-    public void testHttpVersionFormatting() throws Exception {
+    void testHttpVersionFormatting() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         this.formatter.formatProtocolVersion(buf, HttpVersion.HTTP_1_1);
         Assertions.assertEquals("HTTP/1.1", buf.toString());
     }
 
     @Test
-    public void testRLFormatting() throws Exception {
+    void testRLFormatting() {
         final RequestLine requestline = new RequestLine(Method.GET.name(), "/stuff", HttpVersion.HTTP_1_1);
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         this.formatter.formatRequestLine(buf, requestline);
@@ -64,7 +64,7 @@ public class TestBasicLineFormatter {
     }
 
     @Test
-    public void testRLFormattingInvalidInput() throws Exception {
+    void testRLFormattingInvalidInput() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final RequestLine requestline = new RequestLine(Method.GET.name(), "/stuff", HttpVersion.HTTP_1_1);
         Assertions.assertThrows(NullPointerException.class, () ->
@@ -74,7 +74,7 @@ public class TestBasicLineFormatter {
     }
 
     @Test
-    public void testSLFormatting() throws Exception {
+    void testSLFormatting() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final StatusLine statusline1 = new StatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK");
         this.formatter.formatStatusLine(buf, statusline1);
@@ -89,7 +89,7 @@ public class TestBasicLineFormatter {
     }
 
     @Test
-    public void testSLFormattingInvalidInput() throws Exception {
+    void testSLFormattingInvalidInput() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final StatusLine statusline = new StatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK");
         Assertions.assertThrows(NullPointerException.class, () ->
@@ -99,7 +99,7 @@ public class TestBasicLineFormatter {
     }
 
     @Test
-    public void testHeaderFormatting() throws Exception {
+    void testHeaderFormatting() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final Header header1 = new BasicHeader("name", "value");
         this.formatter.formatHeader(buf, header1);
@@ -112,7 +112,7 @@ public class TestBasicLineFormatter {
     }
 
     @Test
-    public void testHeaderFormattingInvalidInput() throws Exception {
+    void testHeaderFormattingInvalidInput() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final Header header = new BasicHeader("name", "value");
         Assertions.assertThrows(NullPointerException.class, () ->
@@ -122,7 +122,7 @@ public class TestBasicLineFormatter {
     }
 
     @Test
-    public void testHeaderFormattingRequestSplitting() throws Exception {
+    void testHeaderFormattingRequestSplitting() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         final Header header = new BasicHeader("Host", "apache.org\r\nOops: oops");
         formatter.formatHeader(buf, header);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicLineParser.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicLineParser.java
@@ -41,17 +41,17 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link BasicLineParser}.
  *
  */
-public class TestBasicLineParser {
+class TestBasicLineParser {
 
     private BasicLineParser parser;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.parser = BasicLineParser.INSTANCE;
     }
 
     @Test
-    public void testRLParse() throws Exception {
+    void testRLParse() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         //typical request line
         buf.clear();
@@ -81,7 +81,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testRLParseFailure() throws Exception {
+    void testRLParseFailure() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.clear();
         buf.append("    ");
@@ -101,7 +101,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testSLParse() throws Exception {
+    void testSLParse() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         //typical status line
         buf.clear();
@@ -170,7 +170,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testSLParseFailure() throws Exception {
+    void testSLParseFailure() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.clear();
         buf.append("xxx 200 OK");
@@ -196,7 +196,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testHttpVersionParsing() throws Exception {
+    void testHttpVersionParsing() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append("HTTP/1.1");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
@@ -224,7 +224,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testInvalidHttpVersionParsing() throws Exception {
+    void testInvalidHttpVersionParsing() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.clear();
         buffer.append("    ");
@@ -269,7 +269,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testHeaderParse() throws Exception {
+    void testHeaderParse() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         //typical request line
         buf.clear();
@@ -287,7 +287,7 @@ public class TestBasicLineParser {
     }
 
     @Test
-    public void testInvalidHeaderParsing() throws Exception {
+    void testInvalidHeaderParsing() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.clear();
         buffer.append("");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicMessages.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicMessages.java
@@ -58,7 +58,6 @@ class TestBasicMessages {
     @Test
     void testSetResponseStatus() {
         final HttpResponse response1 = new BasicHttpResponse(200, "OK");
-        Assertions.assertNotNull(response1.getCode());
         Assertions.assertEquals(200, response1.getCode());
 
         final HttpResponse response2 = new BasicHttpResponse(HttpStatus.SC_BAD_REQUEST, "Bad Request");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicMessages.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicMessages.java
@@ -43,10 +43,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link org.apache.hc.core5.http.HttpMessage}.
  *
  */
-public class TestBasicMessages {
+class TestBasicMessages {
 
     @Test
-    public void testDefaultResponseConstructors() {
+    void testDefaultResponseConstructors() {
         final HttpResponse response1 = new BasicHttpResponse(HttpStatus.SC_BAD_REQUEST, "Bad Request");
         Assertions.assertEquals(HttpStatus.SC_BAD_REQUEST, response1.getCode());
 
@@ -56,7 +56,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testSetResponseStatus() {
+    void testSetResponseStatus() {
         final HttpResponse response1 = new BasicHttpResponse(200, "OK");
         Assertions.assertNotNull(response1.getCode());
         Assertions.assertEquals(200, response1.getCode());
@@ -73,7 +73,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testDefaultRequestConstructors() {
+    void testDefaultRequestConstructors() {
         final HttpRequest request1 = new BasicHttpRequest("WHATEVER", "/");
         Assertions.assertEquals("WHATEVER", request1.getMethod());
         Assertions.assertEquals("/", request1.getPath());
@@ -87,14 +87,14 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testResponseBasics() {
+    void testResponseBasics() {
         final BasicHttpResponse response = new BasicHttpResponse(200, "OK");
         Assertions.assertEquals(200, response.getCode());
         Assertions.assertEquals("OK", response.getReasonPhrase());
     }
 
     @Test
-    public void testResponseStatusLineMutation() {
+    void testResponseStatusLineMutation() {
         final BasicHttpResponse response = new BasicHttpResponse(200, "OK");
         Assertions.assertEquals(200, response.getCode());
         Assertions.assertEquals("OK", response.getReasonPhrase());
@@ -107,14 +107,14 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testResponseInvalidStatusCode() {
+    void testResponseInvalidStatusCode() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> new BasicHttpResponse(-200, "OK"));
         final BasicHttpResponse response = new BasicHttpResponse(200, "OK");
         Assertions.assertThrows(IllegalArgumentException.class, () -> response.setCode(-1));
     }
 
     @Test
-    public void testRequestBasics() throws Exception {
+    void testRequestBasics() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "/stuff");
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff", request.getPath());
@@ -123,7 +123,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithRelativeURI() throws Exception {
+    void testRequestWithRelativeURI() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("/stuff"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff", request.getPath());
@@ -132,7 +132,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithAbsoluteURI() throws Exception {
+    void testRequestWithAbsoluteURI() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("https://host:9443/stuff?param=value"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff?param=value", request.getPath());
@@ -142,7 +142,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithAbsoluteURIAsPath() throws Exception {
+    void testRequestWithAbsoluteURIAsPath() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, "https://host:9443/stuff?param=value");
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff?param=value", request.getPath());
@@ -152,7 +152,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithNoPath() throws Exception {
+    void testRequestWithNoPath() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("http://host"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/", request.getPath());
@@ -162,7 +162,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithUserInfo() throws Exception {
+    void testRequestWithUserInfo() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new URI("https://user:pwd@host:9443/stuff?param=value"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff?param=value", request.getPath());
@@ -172,7 +172,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithAuthority() throws Exception {
+    void testRequestWithAuthority() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new HttpHost("http", "somehost", -1), "/stuff");
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff", request.getPath());
@@ -181,7 +181,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestWithAuthorityRelativePath() throws Exception {
+    void testRequestWithAuthorityRelativePath() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, new HttpHost("http", "somehost", -1), "stuff");
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("stuff", request.getPath());
@@ -190,7 +190,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestHostWithReservedChars() throws Exception {
+    void testRequestHostWithReservedChars() throws Exception {
         final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("http://someuser%21@%21example%21.com/stuff"));
         Assertions.assertEquals(Method.GET.name(), request.getMethod());
         Assertions.assertEquals("/stuff", request.getPath());
@@ -199,7 +199,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testRequestAbsoluteRequestUri() throws Exception {
+    void testRequestAbsoluteRequestUri() {
         final BasicHttpRequest request = new BasicHttpRequest(Method.GET, new HttpHost("http", "somehost", -1), "stuff");
         Assertions.assertEquals("stuff", request.getRequestUri());
         request.setAbsoluteRequestUri(true);
@@ -207,7 +207,7 @@ public class TestBasicMessages {
     }
 
     @Test
-    public void testModifyingExistingRequest() throws Exception {
+    void testModifyingExistingRequest() throws Exception {
         final URI uri = URI.create("https://example.org");
         final HttpRequest request = new BasicHttpRequest(Method.GET, uri);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicStatusLine.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicStatusLine.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link org.apache.hc.core5.http.message.StatusLine}.
  */
-public class TestBasicStatusLine {
+class TestBasicStatusLine {
 
     @Test
-    public void testGetStatusClass() {
+    void testGetStatusClass() {
         StatusLine statusLine = new StatusLine(new BasicHttpResponse(100, "Continue"));
         Assertions.assertEquals(StatusClass.INFORMATIONAL, statusLine.getStatusClass());
 
@@ -58,7 +58,7 @@ public class TestBasicStatusLine {
     }
 
     @Test
-    public void testGetStatusShorthand() {
+    void testGetStatusShorthand() {
         StatusLine statusLine = new StatusLine(new BasicHttpResponse(100, "Continue"));
         Assertions.assertTrue(statusLine.isInformational());
         Assertions.assertFalse(statusLine.isSuccessful());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicTokenIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicTokenIterator.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link BasicTokenIterator}.
  *
  */
-public class TestBasicTokenIterator {
+class TestBasicTokenIterator {
 
     @Test
-    public void testSingleHeader() {
+    void testSingleHeader() {
         Header[] headers = new Header[]{
             new BasicHeader("Name", "token0,token1, token2 , token3")
         };
@@ -73,7 +73,7 @@ public class TestBasicTokenIterator {
 
 
     @Test
-    public void testMultiHeader() {
+    void testMultiHeader() {
         final Header[] headers = new Header[]{
             new BasicHeader("Name", "token0,token1"),
             new BasicHeader("Name", ""),
@@ -101,7 +101,7 @@ public class TestBasicTokenIterator {
 
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         final Header[] headers = new Header[]{
             new BasicHeader("Name", " "),
             new BasicHeader("Name", ""),
@@ -122,7 +122,7 @@ public class TestBasicTokenIterator {
 
 
     @Test
-    public void testValueStart() {
+    void testValueStart() {
         final Header[] headers = new Header[]{
             new BasicHeader("Name", "token0"),
             new BasicHeader("Name", " token1"),
@@ -151,7 +151,7 @@ public class TestBasicTokenIterator {
 
 
     @Test
-    public void testValueEnd() {
+    void testValueEnd() {
         final Header[] headers = new Header[]{
             new BasicHeader("Name", "token0"),
             new BasicHeader("Name", "token1 "),
@@ -179,7 +179,7 @@ public class TestBasicTokenIterator {
     }
 
     @Test
-    public void testWrongPublic() {
+    void testWrongPublic() {
         Assertions.assertThrows(NullPointerException.class, () -> new BasicTokenIterator(null));
 
         final Header[] headers = new Header[]{

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicTokenIterator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBasicTokenIterator.java
@@ -50,13 +50,13 @@ class TestBasicTokenIterator {
         Iterator<String>  ti  = new BasicTokenIterator(hit);
 
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token0", "token0", ti.next());
+        Assertions.assertEquals("token0", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token1", "token1", ti.next());
+        Assertions.assertEquals("token1", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token2", "token2", ti.next());
+        Assertions.assertEquals("token2", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token3", "token3", ti.next());
+        Assertions.assertEquals("token3", ti.next());
         Assertions.assertFalse(ti.hasNext());
 
 
@@ -67,7 +67,7 @@ class TestBasicTokenIterator {
         ti  = new BasicTokenIterator(hit);
 
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token0", "token0", ti.next());
+        Assertions.assertEquals("token0", ti.next());
         Assertions.assertFalse(ti.hasNext());
     }
 
@@ -87,15 +87,15 @@ class TestBasicTokenIterator {
         final Iterator<String>  ti  = new BasicTokenIterator(hit);
 
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token0", "token0", ti.next());
+        Assertions.assertEquals("token0", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token1", "token1", ti.next());
+        Assertions.assertEquals("token1", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token2", "token2", ti.next());
+        Assertions.assertEquals("token2", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token3", "token3", ti.next());
+        Assertions.assertEquals("token3", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token4", "token4", ti.next());
+        Assertions.assertEquals("token4", ti.next());
         Assertions.assertFalse(ti.hasNext());
     }
 
@@ -135,17 +135,17 @@ class TestBasicTokenIterator {
         final Iterator<String>  ti  = new BasicTokenIterator(hit);
 
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token0", "token0", ti.next());
+        Assertions.assertEquals("token0", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token1", "token1", ti.next());
+        Assertions.assertEquals("token1", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token2", "token2", ti.next());
+        Assertions.assertEquals("token2", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token3", "token3", ti.next());
+        Assertions.assertEquals("token3", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token4", "token4", ti.next());
+        Assertions.assertEquals("token4", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token5", "token5", ti.next());
+        Assertions.assertEquals("token5", ti.next());
         Assertions.assertFalse(ti.hasNext());
     }
 
@@ -164,17 +164,17 @@ class TestBasicTokenIterator {
         final Iterator<String>  ti  = new BasicTokenIterator(hit);
 
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token0", "token0", ti.next());
+        Assertions.assertEquals("token0", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token1", "token1", ti.next());
+        Assertions.assertEquals("token1", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token2", "token2", ti.next());
+        Assertions.assertEquals("token2",  ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token3", "token3", ti.next());
+        Assertions.assertEquals("token3", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token4", "token4", ti.next());
+        Assertions.assertEquals("token4", ti.next());
         Assertions.assertTrue(ti.hasNext());
-        Assertions.assertEquals("token5", "token5", ti.next());
+        Assertions.assertEquals("token5", ti.next());
         Assertions.assertFalse(ti.hasNext());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBufferedHeader.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestBufferedHeader.java
@@ -41,10 +41,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link BufferedHeader}.
  *
  */
-public class TestBufferedHeader {
+class TestBufferedHeader {
 
     @Test
-    public void testBasicConstructor() throws Exception {
+    void testBasicConstructor() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(32);
         buf.append("name: value");
         final BufferedHeader header = new BufferedHeader(buf, false);
@@ -55,7 +55,7 @@ public class TestBufferedHeader {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(32);
         buf.append("name: value");
         final BufferedHeader orig = new BufferedHeader(buf, false);
@@ -72,7 +72,7 @@ public class TestBufferedHeader {
     }
 
     @Test
-    public void testInvalidHeaderParsing() throws Exception {
+    void testInvalidHeaderParsing() {
         final CharArrayBuffer buf = new CharArrayBuffer(16);
         buf.clear();
         buf.append("");
@@ -98,7 +98,7 @@ public class TestBufferedHeader {
     }
 
     @Test
-    public void testCRLFNullInHeaderValue() throws Exception {
+    void testCRLFNullInHeaderValue() throws Exception {
         final CharArrayBuffer buf = new CharArrayBuffer(16);
         buf.clear();
         buf.append("name:  blah\0blah  ");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeader.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeader.java
@@ -39,29 +39,29 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link Header}.
  */
-public class TestHeader {
+class TestHeader {
 
     @Test
-    public void testBasicConstructor() {
+    void testBasicConstructor() {
         final Header header = new BasicHeader("name", "value");
         Assertions.assertEquals("name", header.getName());
         Assertions.assertEquals("value", header.getValue());
     }
 
     @Test
-    public void testBasicConstructorNullValue() {
+    void testBasicConstructorNullValue() {
         final Header header = new BasicHeader("name", null);
         Assertions.assertEquals("name", header.getName());
         Assertions.assertNull(header.getValue());
     }
 
     @Test
-    public void testInvalidName() {
+    void testInvalidName() {
         Assertions.assertThrows(NullPointerException.class, () -> new BasicHeader(null, null));
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         final Header header1 = new BasicHeader("name1", "value1");
         Assertions.assertEquals("name1: value1", header1.toString());
         final Header header2 = new BasicHeader("name2", null);
@@ -69,7 +69,7 @@ public class TestHeader {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final BasicHeader orig = new BasicHeader("name1", "value1");
         final ByteArrayOutputStream outbuffer = new ByteArrayOutputStream();
         final ObjectOutputStream outStream = new ObjectOutputStream(outbuffer);
@@ -85,7 +85,7 @@ public class TestHeader {
 
 
     @Test
-    public void testClone() throws Exception {
+    void testClone() throws Exception {
         final BasicHeader orig = new BasicHeader("name1", "value1");
         final BasicHeader clone = orig.clone();
         Assertions.assertEquals(orig.getName(), clone.getName());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeaderElement.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeaderElement.java
@@ -41,10 +41,8 @@ class TestHeaderElement {
     @Test
     void testConstructor3() {
         final HeaderElement element = new BasicHeaderElement("name", "value",
-                new NameValuePair[] {
-                    new BasicNameValuePair("param1", "value1"),
-                    new BasicNameValuePair("param2", "value2")
-                } );
+                new BasicNameValuePair("param1", "value1"),
+                new BasicNameValuePair("param2", "value2"));
         Assertions.assertEquals("name", element.getName());
         Assertions.assertEquals("value", element.getValue());
         Assertions.assertEquals(2, element.getParameters().length);
@@ -82,10 +80,8 @@ class TestHeaderElement {
     @Test
     void testToString() {
         final BasicHeaderElement element = new BasicHeaderElement("name", "value",
-                new NameValuePair[] {
-                        new BasicNameValuePair("param1", "value1"),
-                        new BasicNameValuePair("param2", "value2")
-                } );
+                new BasicNameValuePair("param1", "value1"),
+                new BasicNameValuePair("param2", "value2"));
         Assertions.assertEquals("name=value; param1=value1; param2=value2", element.toString());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeaderElement.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeaderElement.java
@@ -36,10 +36,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Simple tests for {@link HeaderElement}.
  */
-public class TestHeaderElement {
+class TestHeaderElement {
 
     @Test
-    public void testConstructor3() throws Exception {
+    void testConstructor3() {
         final HeaderElement element = new BasicHeaderElement("name", "value",
                 new NameValuePair[] {
                     new BasicNameValuePair("param1", "value1"),
@@ -53,7 +53,7 @@ public class TestHeaderElement {
     }
 
     @Test
-    public void testConstructor2() throws Exception {
+    void testConstructor2() {
         final HeaderElement element = new BasicHeaderElement("name", "value");
         Assertions.assertEquals("name", element.getName());
         Assertions.assertEquals("value", element.getValue());
@@ -62,12 +62,12 @@ public class TestHeaderElement {
 
 
     @Test
-    public void testInvalidName() {
+    void testInvalidName() {
         Assertions.assertThrows(NullPointerException.class, () -> new BasicHeaderElement(null, null, (NameValuePair[]) null));
     }
 
     @Test
-    public void testParamByName() throws Exception {
+    void testParamByName() {
         final String s = "name = value; param1 = value1; param2 = value2";
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.append(s);
@@ -80,7 +80,7 @@ public class TestHeaderElement {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         final BasicHeaderElement element = new BasicHeaderElement("name", "value",
                 new NameValuePair[] {
                         new BasicNameValuePair("param1", "value1"),

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeaderGroup.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestHeaderGroup.java
@@ -41,17 +41,17 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link HeaderGroup}.
  *
  */
-public class TestHeaderGroup {
+class TestHeaderGroup {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final HeaderGroup headergroup = new HeaderGroup();
         Assertions.assertNotNull(headergroup.getHeaders());
         Assertions.assertEquals(0, headergroup.getHeaders().length);
     }
 
     @Test
-    public void testClear() {
+    void testClear() {
         final HeaderGroup headergroup = new HeaderGroup();
         headergroup.addHeader(new BasicHeader("name", "value"));
         Assertions.assertEquals(1, headergroup.getHeaders().length);
@@ -60,7 +60,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testAddRemoveHeader() {
+    void testAddRemoveHeader() {
         final HeaderGroup headerGroup = new HeaderGroup();
         final Header header = new BasicHeader("name", "value");
         headerGroup.addHeader(header);
@@ -72,7 +72,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testAddRemoveHeaders() {
+    void testAddRemoveHeaders() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Header header = new BasicHeader("name", "value");
         headergroup.addHeader(header);
@@ -85,7 +85,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testAddRemoveHeaderWithDifferentButEqualHeaders() {
+    void testAddRemoveHeaderWithDifferentButEqualHeaders() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Header header = new BasicHeader("name", "value");
         final Header header2 = new BasicHeader("name", "value");
@@ -96,7 +96,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testUpdateHeader() {
+    void testUpdateHeader() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Header header1 = new BasicHeader("name1", "value1");
         final Header header2 = new BasicHeader("name2", "value2");
@@ -112,7 +112,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testSetHeaders() {
+    void testSetHeaders() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Header header1 = new BasicHeader("name1", "value1");
         final Header header2 = new BasicHeader("name2", "value2");
@@ -131,7 +131,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testFirstLastHeaders() {
+    void testFirstLastHeaders() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Header header1 = new BasicHeader("name", "value1");
         final Header header2 = new BasicHeader("name", "value2");
@@ -146,7 +146,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testCondensedHeader() {
+    void testCondensedHeader() {
         final HeaderGroup headergroup = new HeaderGroup();
         Assertions.assertNull(headergroup.getCondensedHeader("name"));
 
@@ -162,7 +162,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testIterator() {
+    void testIterator() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Iterator<Header> i = headergroup.headerIterator();
         Assertions.assertNotNull(i);
@@ -170,7 +170,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testHeaderRemove() {
+    void testHeaderRemove() {
         final HeaderGroup headergroup = new HeaderGroup();
         final Header header1 = new BasicHeader("name", "value1");
         final Header header2 = new BasicHeader("name", "value2");
@@ -192,7 +192,7 @@ public class TestHeaderGroup {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final HeaderGroup orig = new HeaderGroup();
         final Header header1 = new BasicHeader("name", "value1");
         final Header header2 = new BasicHeader("name", "value2");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestMessageSupport.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestMessageSupport.java
@@ -50,7 +50,7 @@ import org.apache.hc.core5.util.CharArrayBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestMessageSupport {
+class TestMessageSupport {
 
     private static Set<String> makeSet(final String... tokens) {
         if (tokens == null) {
@@ -62,35 +62,35 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testTokenSetFormatting() throws Exception {
+    void testTokenSetFormatting() {
         final Header header = MessageSupport.header(HttpHeaders.TRAILER, makeSet("z", "b", "a"));
         Assertions.assertNotNull(header);
         Assertions.assertEquals("z, b, a", header.getValue());
     }
 
     @Test
-    public void testTokenListFormatting() throws Exception {
+    void testTokenListFormatting() {
         final Header header = MessageSupport.headerOfTokens(HttpHeaders.TRAILER, Arrays.asList("z", "b", "a", "a"));
         Assertions.assertNotNull(header);
         Assertions.assertEquals("z, b, a, a", header.getValue());
     }
 
     @Test
-    public void testTokenSetFormattingSameName() throws Exception {
+    void testTokenSetFormattingSameName() {
         final Header header = MessageSupport.header(HttpHeaders.TRAILER, makeSet("a", "a", "a"));
         Assertions.assertNotNull(header);
         Assertions.assertEquals("a", header.getValue());
     }
 
     @Test
-    public void testTokenListFormattingSameName() throws Exception {
+    void testTokenListFormattingSameName() {
         final Header header = MessageSupport.header(HttpHeaders.TRAILER, "a", "a", "a");
         Assertions.assertNotNull(header);
         Assertions.assertEquals("a, a, a", header.getValue());
     }
 
     @Test
-    public void testParseTokensWithConsumer() throws Exception {
+    void testParseTokensWithConsumer() {
         final String s = "a, b, c, c";
         final ParserCursor cursor = new ParserCursor(0, s.length());
         final List<String> tokens = new ArrayList<>();
@@ -99,7 +99,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseTokenHeaderWithConsumer() throws Exception {
+    void testParseTokenHeaderWithConsumer() {
         final Header header = new BasicHeader(HttpHeaders.TRAILER, "a, b, c, c");
         final List<String> tokens = new ArrayList<>();
         MessageSupport.parseTokens(header, tokens::add);
@@ -107,7 +107,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseTokenBufferWithConsumer() throws Exception {
+    void testParseTokenBufferWithConsumer() {
         final CharArrayBuffer buf = new CharArrayBuffer(128);
         buf.append("stuff: a, b, c, c");
         final Header header = BufferedHeader.create(buf);
@@ -115,20 +115,20 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseTokens() throws Exception {
+    void testParseTokens() {
         final String s = "a, b, c, c";
         final ParserCursor cursor = new ParserCursor(0, s.length());
         Assertions.assertEquals(makeSet("a", "b", "c"), MessageSupport.parseTokens(s, cursor));
     }
 
     @Test
-    public void testParseTokenHeader() throws Exception {
+    void testParseTokenHeader() {
         final Header header = new BasicHeader(HttpHeaders.TRAILER, "a, b, c, c");
         Assertions.assertEquals(makeSet("a", "b", "c"), MessageSupport.parseTokens(header));
     }
 
     @Test
-    public void testParseTokenBuffer() throws Exception {
+    void testParseTokenBuffer() {
         final CharArrayBuffer buf = new CharArrayBuffer(128);
         buf.append("stuff: a, b, c, c");
         final Header header = BufferedHeader.create(buf);
@@ -136,7 +136,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testElementListFormatting() throws Exception {
+    void testElementListFormatting() {
         final List<HeaderElement> elements = Arrays.asList(
                 new BasicHeaderElement("name1", "value1", new BasicNameValuePair("param", "regular_stuff")),
                 new BasicHeaderElement("name2", "value2", new BasicNameValuePair("param", "this\\that")),
@@ -152,7 +152,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testElementArrayFormatting() throws Exception {
+    void testElementArrayFormatting() {
         final HeaderElement[] elements = {
                 new BasicHeaderElement("name1", "value1", new BasicNameValuePair("param", "regular_stuff")),
                 new BasicHeaderElement("name2", "value2", new BasicNameValuePair("param", "this\\that")),
@@ -168,7 +168,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseElementsBufferWithConsumer() throws Exception {
+    void testParseElementsBufferWithConsumer() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         buf.append("name1 = value1; name2; name3=\"value3\" , name4=value4; " +
                 "name5=value5, name6= ; name7 = value7; name8 = \" value8\"");
@@ -205,7 +205,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseElementsHeaderWithConsumer() throws Exception {
+    void testParseElementsHeaderWithConsumer() {
         final Header header = new BasicHeader("Some-Header",
                 "name1 = value1; name2; name3=\"value3\" , name4=value4; " +
                 "name5=value5, name6= ; name7 = value7; name8 = \" value8\"");
@@ -241,7 +241,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseElementsHeader() throws Exception {
+    void testParseElementsHeader() {
         final Header header = new BasicHeader("Some-Header",
                 "name1 = value1; name2; name3=\"value3\" , name4=value4; " +
                         "name5=value5, name6= ; name7 = value7; name8 = \" value8\"");
@@ -276,7 +276,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParamListFormatting() throws Exception {
+    void testParamListFormatting() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         MessageSupport.formatParameters(buf, Arrays.asList(
                 new BasicNameValuePair("param", "regular_stuff"),
@@ -288,7 +288,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParamArrayFormatting() throws Exception {
+    void testParamArrayFormatting() {
         final CharArrayBuffer buf = new CharArrayBuffer(64);
         MessageSupport.formatParameters(buf,
                 new BasicNameValuePair("param", "regular_stuff"),
@@ -300,7 +300,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testParseParams() {
+    void testParseParams() {
         final String s =
                 "test; test1 =  stuff   ; test2 =  \"stuff; stuff\"; test3=stuff,123";
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
@@ -322,7 +322,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testAddContentHeaders() throws Exception {
+    void testAddContentHeaders() {
         final HttpEntity entity = HttpEntities.create("some stuff with trailers", StandardCharsets.US_ASCII,
                 new BasicHeader("z", "this"), new BasicHeader("b", "that"), new BasicHeader("a", "this and that"));
         final HttpMessage message = new BasicHttpResponse(200);
@@ -339,7 +339,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testContentHeadersAlreadyPresent() throws Exception {
+    void testContentHeadersAlreadyPresent() {
         final HttpEntity entity = HttpEntities.create("some stuff with trailers", StandardCharsets.US_ASCII,
                 new BasicHeader("z", "this"), new BasicHeader("b", "that"), new BasicHeader("a", "this and that"));
         final HttpMessage message = new BasicHttpResponse(200);
@@ -359,7 +359,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testHopByHopHeaders() {
+    void testHopByHopHeaders() {
         Assertions.assertTrue(MessageSupport.isHopByHop("Connection"));
         Assertions.assertTrue(MessageSupport.isHopByHop("connection"));
         Assertions.assertTrue(MessageSupport.isHopByHop("coNNection"));
@@ -368,7 +368,7 @@ public class TestMessageSupport {
     }
 
     @Test
-    public void testHopByHopHeadersConnectionSpecific() {
+    void testHopByHopHeadersConnectionSpecific() {
         final HttpResponse response = BasicResponseBuilder.create(HttpStatus.SC_OK)
                 .addHeader(HttpHeaders.CONNECTION, "blah, blah, this, that")
                 .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.TEXT_PLAIN.toString())

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestNameValuePair.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/message/TestNameValuePair.java
@@ -35,22 +35,22 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link NameValuePair}.
  *
  */
-public class TestNameValuePair {
+class TestNameValuePair {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final NameValuePair param = new BasicNameValuePair("name", "value");
         Assertions.assertEquals("name", param.getName());
         Assertions.assertEquals("value", param.getValue());
     }
 
     @Test
-    public void testInvalidName() {
+    void testInvalidName() {
         Assertions.assertThrows(NullPointerException.class, () -> new BasicNameValuePair(null, null));
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         final NameValuePair param1 = new BasicNameValuePair("name1", "value1");
         Assertions.assertEquals("name1=value1", param1.toString());
         final NameValuePair param2 = new BasicNameValuePair("name1", null);
@@ -58,21 +58,21 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testNullNotEqual() throws Exception {
+    void testNullNotEqual() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
 
         Assertions.assertNotEquals(null, NameValuePair);
     }
 
     @Test
-    public void testObjectNotEqual() throws Exception {
+    void testObjectNotEqual() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
 
         Assertions.assertNotEquals(NameValuePair, new Object());
     }
 
     @Test
-    public void testNameEquals() throws Exception {
+    void testNameEquals() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
         final NameValuePair NameValuePair2 = new BasicNameValuePair("NAME", "value");
 
@@ -87,7 +87,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testValueEquals() throws Exception {
+    void testValueEquals() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name", "value");
 
@@ -96,7 +96,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testNameNotEqual() throws Exception {
+    void testNameNotEqual() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name2", "value");
 
@@ -104,7 +104,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testValueNotEqual() throws Exception {
+    void testValueNotEqual() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name", "value2");
 
@@ -122,7 +122,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testNullValuesEquals() throws Exception {
+    void testNullValuesEquals() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", null);
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name", null);
 
@@ -131,7 +131,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testNullValueNotEqual() throws Exception {
+    void testNullValueNotEqual() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", null);
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name", "value");
 
@@ -139,7 +139,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testNullValue2NotEqual() throws Exception {
+    void testNullValue2NotEqual() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name", null);
 
@@ -147,7 +147,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    void testEquals() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", "value");
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name", "value");
 
@@ -160,7 +160,7 @@ public class TestNameValuePair {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    void testHashCode() {
         final NameValuePair NameValuePair = new BasicNameValuePair("name", null);
         final NameValuePair NameValuePair2 = new BasicNameValuePair("name2", null);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityConsumer.java
@@ -40,7 +40,7 @@ import org.apache.hc.core5.util.ByteArrayBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestAbstractBinAsyncEntityConsumer {
+class TestAbstractBinAsyncEntityConsumer {
 
     static private class ByteArrayAsyncEntityConsumer extends AbstractBinAsyncEntityConsumer<byte[]> {
 
@@ -77,7 +77,7 @@ public class TestAbstractBinAsyncEntityConsumer {
     }
 
     @Test
-    public void testConsumeData() throws Exception {
+    void testConsumeData() throws Exception {
 
         final AsyncEntityConsumer<byte[]> consumer = new ByteArrayAsyncEntityConsumer();
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractBinAsyncEntityProducer.java
@@ -40,7 +40,7 @@ import org.apache.hc.core5.http.nio.StreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestAbstractBinAsyncEntityProducer {
+class TestAbstractBinAsyncEntityProducer {
 
     static private class ChunkByteAsyncEntityProducer extends AbstractBinAsyncEntityProducer {
 
@@ -83,7 +83,7 @@ public class TestAbstractBinAsyncEntityProducer {
     }
 
     @Test
-    public void testProduceDataNoBuffering() throws Exception {
+    void testProduceDataNoBuffering() throws Exception {
 
         final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
                 0, ContentType.TEXT_PLAIN,
@@ -109,7 +109,7 @@ public class TestAbstractBinAsyncEntityProducer {
     }
 
     @Test
-    public void testProduceDataWithBuffering1() throws Exception {
+    void testProduceDataWithBuffering1() throws Exception {
 
         final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
                 5, ContentType.TEXT_PLAIN,
@@ -139,7 +139,7 @@ public class TestAbstractBinAsyncEntityProducer {
     }
 
     @Test
-    public void testProduceDataWithBuffering2() throws Exception {
+    void testProduceDataWithBuffering2() throws Exception {
 
         final AsyncEntityProducer producer = new ChunkByteAsyncEntityProducer(
                 5, ContentType.TEXT_PLAIN,

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityConsumer.java
@@ -42,7 +42,7 @@ import org.apache.hc.core5.util.ByteArrayBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestAbstractCharAsyncEntityConsumer {
+class TestAbstractCharAsyncEntityConsumer {
 
     static private class StringBuilderAsyncEntityConsumer extends AbstractCharAsyncEntityConsumer<String> {
 
@@ -80,7 +80,7 @@ public class TestAbstractCharAsyncEntityConsumer {
     }
 
     @Test
-    public void testConsumeData() throws Exception {
+    void testConsumeData() throws Exception {
 
         final AsyncEntityConsumer<String> consumer = new StringBuilderAsyncEntityConsumer();
 
@@ -116,7 +116,7 @@ public class TestAbstractCharAsyncEntityConsumer {
     }
 
     @Test
-    public void testConsumeIncompleteData() throws Exception {
+    void testConsumeIncompleteData() throws Exception {
 
         final AsyncEntityConsumer<String> consumer = new StringBuilderAsyncEntityConsumer();
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAbstractCharAsyncEntityProducer.java
@@ -40,7 +40,7 @@ import org.apache.hc.core5.http.nio.StreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestAbstractCharAsyncEntityProducer {
+class TestAbstractCharAsyncEntityProducer {
 
     static private class ChunkCharAsyncEntityProducer extends AbstractCharAsyncEntityProducer {
 
@@ -84,7 +84,7 @@ public class TestAbstractCharAsyncEntityProducer {
     }
 
     @Test
-    public void testProduceDataNoBuffering() throws Exception {
+    void testProduceDataNoBuffering() throws Exception {
 
         final AsyncEntityProducer producer = new ChunkCharAsyncEntityProducer(
                 256, 0, ContentType.TEXT_PLAIN, "this", "this and that");
@@ -108,7 +108,7 @@ public class TestAbstractCharAsyncEntityProducer {
     }
 
     @Test
-    public void testProduceDataWithBuffering() throws Exception {
+    void testProduceDataWithBuffering() throws Exception {
 
         final AsyncEntityProducer producer = new ChunkCharAsyncEntityProducer(
                 256, 5, ContentType.TEXT_PLAIN, "this", " and that", "all", " sorts of stuff");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAsyncEntityProducers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestAsyncEntityProducers.java
@@ -44,10 +44,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link AsyncEntityProducers}.
  */
-public class TestAsyncEntityProducers {
+class TestAsyncEntityProducers {
 
     @Test
-    public void testPathEntityProducer() throws IOException {
+    void testPathEntityProducer() throws IOException {
         final Path path = Paths.get("src/test/resources/test-ssl.txt");
         final AsyncEntityProducer producer = AsyncEntityProducers.create(path, ContentType.APPLICATION_OCTET_STREAM,
                 StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
@@ -61,7 +61,7 @@ public class TestAsyncEntityProducers {
     }
 
     @Test
-    public void testPathEntityProducerWithTrailers() throws IOException {
+    void testPathEntityProducerWithTrailers() throws IOException {
         final Path path = Paths.get("src/test/resources/test-ssl.txt");
         final Header header1 = new BasicHeader("Tailer1", "Value1");
         final Header header2 = new BasicHeader("Tailer2", "Value2");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestBasicAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestBasicAsyncEntityProducer.java
@@ -37,10 +37,10 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestBasicAsyncEntityProducer {
+class TestBasicAsyncEntityProducer {
 
     @Test
-    public void testBinaryContent() throws Exception {
+    void testBinaryContent() throws Exception {
 
         final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
                 new byte[] { 'a', 'b', 'c' }, ContentType.DEFAULT_BINARY);
@@ -59,7 +59,7 @@ public class TestBasicAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContent() throws Exception {
+    void testTextContent() throws Exception {
 
         final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
                 "abc", ContentType.TEXT_PLAIN);
@@ -78,7 +78,7 @@ public class TestBasicAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContentRepeatable() throws Exception {
+    void testTextContentRepeatable() throws Exception {
         final AsyncEntityProducer producer = new BasicAsyncEntityProducer(
                 "abc", ContentType.TEXT_PLAIN);
 
@@ -100,7 +100,7 @@ public class TestBasicAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContentRepeatableUTF() throws Exception {
+    void testTextContentRepeatableUTF() throws Exception {
         final String content = "<testtag></testtag>";
         final AsyncEntityProducer producer = new BasicAsyncEntityProducer(content, ContentType.TEXT_XML);
         for (int i = 0; i < 3; i++) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityConsumer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityConsumer.java
@@ -33,10 +33,10 @@ import org.apache.hc.core5.util.TextUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDigestingEntityConsumer {
+class TestDigestingEntityConsumer {
 
     @Test
-    public void testConsumeData() throws Exception {
+    void testConsumeData() throws Exception {
 
         final DigestingEntityConsumer<String> consumer = new DigestingEntityConsumer<>("MD5",
                 new StringAsyncEntityConsumer());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestDigestingEntityProducer.java
@@ -37,10 +37,10 @@ import org.apache.hc.core5.http.nio.BasicDataStreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDigestingEntityProducer {
+class TestDigestingEntityProducer {
 
     @Test
-    public void testProduceData() throws Exception {
+    void testProduceData() throws Exception {
 
         final DigestingEntityProducer producer = new DigestingEntityProducer("MD5",
                 new StringAsyncEntityProducer("12345", ContentType.TEXT_PLAIN));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileAsyncEntityProducer.java
@@ -43,12 +43,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestFileAsyncEntityProducer {
+class TestFileAsyncEntityProducer {
 
     private File tempFile;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         tempFile = File.createTempFile("testing", ".txt");
         try (final Writer writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.US_ASCII)) {
             writer.append("abcdef");
@@ -57,14 +57,14 @@ public class TestFileAsyncEntityProducer {
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         if (tempFile != null) {
             tempFile.delete();
             tempFile = null;
         }
     }
     @Test
-    public void testTextContent() throws Exception {
+    void testTextContent() throws Exception {
 
         final AsyncEntityProducer producer = new FileEntityProducer(tempFile, ContentType.TEXT_PLAIN);
 
@@ -83,7 +83,7 @@ public class TestFileAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContentRepeatable() throws Exception {
+    void testTextContentRepeatable() throws Exception {
         final AsyncEntityProducer producer = new FileEntityProducer(tempFile, ContentType.TEXT_PLAIN);
 
         Assertions.assertEquals(6, producer.getContentLength());

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestFileEntityProducer.java
@@ -38,10 +38,10 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @since 5.0
  */
-public class TestFileEntityProducer {
+class TestFileEntityProducer {
 
     @Test
-    public void testFileLengthMaxIntPlusOne(@TempDir final Path tempFolder) throws IOException {
+    void testFileLengthMaxIntPlusOne(@TempDir final Path tempFolder) throws IOException {
         final Path path = Files.createFile(tempFolder.resolve("test.bin"));
         try (RandomAccessFile raFile = new RandomAccessFile(path.toFile(), "rw")) {
             final long expectedLength = 1L + Integer.MAX_VALUE;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathAsyncEntityProducer.java
@@ -45,12 +45,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestPathAsyncEntityProducer {
+class TestPathAsyncEntityProducer {
 
     private File tempFile;
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         if (tempFile != null) {
             tempFile.delete();
             tempFile = null;
@@ -58,7 +58,7 @@ public class TestPathAsyncEntityProducer {
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         tempFile = File.createTempFile("testing", ".txt");
         try (final Writer writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.US_ASCII)) {
             writer.append("abcdef");
@@ -67,7 +67,7 @@ public class TestPathAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContent() throws Exception {
+    void testTextContent() throws Exception {
 
         final Path tempPath = tempFile.toPath();
         final AsyncEntityProducer producer = new PathEntityProducer(tempPath, ContentType.TEXT_PLAIN, StandardOpenOption.READ);
@@ -87,7 +87,7 @@ public class TestPathAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContentRepeatable() throws Exception {
+    void testTextContentRepeatable() throws Exception {
         final Path tempPath = tempFile.toPath();
         final AsyncEntityProducer producer = new PathEntityProducer(tempPath, ContentType.TEXT_PLAIN, StandardOpenOption.READ);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestPathEntityProducer.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @since 5.0
  */
-public class TestPathEntityProducer {
+class TestPathEntityProducer {
 
     @Test
-    public void testFileLengthMaxIntPlusOne(@TempDir final Path tempFolder) throws IOException {
+    void testFileLengthMaxIntPlusOne(@TempDir final Path tempFolder) throws IOException {
         final Path path = Files.createFile(tempFolder.resolve("test.bin"));
         try (RandomAccessFile raFile = new RandomAccessFile(path.toFile(), "rw")) {
             final long expectedLength = 1L + Integer.MAX_VALUE;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestStringAsyncEntityProducer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/entity/TestStringAsyncEntityProducer.java
@@ -37,10 +37,10 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestStringAsyncEntityProducer {
+class TestStringAsyncEntityProducer {
 
     @Test
-    public void testTextContent() throws Exception {
+    void testTextContent() throws Exception {
 
         final AsyncEntityProducer producer = new StringAsyncEntityProducer(
                 "abc", ContentType.TEXT_PLAIN);
@@ -59,7 +59,7 @@ public class TestStringAsyncEntityProducer {
     }
 
     @Test
-    public void testTextContentRepeatable() throws Exception {
+    void testTextContentRepeatable() throws Exception {
         final AsyncEntityProducer producer = new StringAsyncEntityProducer(
                 "abc", ContentType.TEXT_PLAIN);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/ssl/BasicClientTlsStrategyTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/ssl/BasicClientTlsStrategyTest.java
@@ -41,7 +41,7 @@ class BasicClientTlsStrategyTest {
     private SSLSessionVerifier sslSessionVerifier;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/ssl/BasicServerTlsStrategyTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/ssl/BasicServerTlsStrategyTest.java
@@ -41,7 +41,7 @@ class BasicServerTlsStrategyTest {
     private SSLSessionVerifier sslSessionVerifier;
 
     @BeforeEach
-    public void prepareMocks() {
+    void prepareMocks() {
         MockitoAnnotations.openMocks(this);
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/support/classic/TestSharedInputBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/support/classic/TestSharedInputBuffer.java
@@ -43,12 +43,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestSharedInputBuffer {
+class TestSharedInputBuffer {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
     @Test
-    public void testBasis() throws Exception {
+    void testBasis() throws Exception {
 
         final Charset charset = StandardCharsets.US_ASCII;
         final SharedInputBuffer inputBuffer = new SharedInputBuffer(10);
@@ -85,7 +85,7 @@ public class TestSharedInputBuffer {
     }
 
     @Test
-    public void testMultithreadingRead() throws Exception {
+    void testMultithreadingRead() throws Exception {
 
         final SharedInputBuffer inputBuffer = new SharedInputBuffer(10);
 
@@ -112,7 +112,7 @@ public class TestSharedInputBuffer {
     }
 
     @Test
-    public void testMultithreadingSingleRead() throws Exception {
+    void testMultithreadingSingleRead() throws Exception {
 
         final SharedInputBuffer inputBuffer = new SharedInputBuffer(10);
 
@@ -136,7 +136,7 @@ public class TestSharedInputBuffer {
     }
 
     @Test
-    public void testMultithreadingReadStream() throws Exception {
+    void testMultithreadingReadStream() throws Exception {
 
         final SharedInputBuffer inputBuffer = new SharedInputBuffer(10);
 
@@ -175,7 +175,7 @@ public class TestSharedInputBuffer {
     }
 
     @Test
-    public void testMultithreadingReadStreamAbort() throws Exception {
+    void testMultithreadingReadStreamAbort() throws Exception {
 
         final SharedInputBuffer inputBuffer = new SharedInputBuffer(10);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/nio/support/classic/TestSharedOutputBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/nio/support/classic/TestSharedOutputBuffer.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestSharedOutputBuffer {
+class TestSharedOutputBuffer {
 
     private static final Timeout TIMEOUT = Timeout.ofMinutes(1);
 
@@ -113,7 +113,7 @@ public class TestSharedOutputBuffer {
     }
 
     @Test
-    public void testBasis() throws Exception {
+    void testBasis() throws Exception {
 
         final Charset charset = StandardCharsets.US_ASCII;
         final SharedOutputBuffer outputBuffer = new SharedOutputBuffer(30);
@@ -140,7 +140,7 @@ public class TestSharedOutputBuffer {
     }
 
     @Test
-    public void testFlush() throws Exception {
+    void testFlush() throws Exception {
 
         final Charset charset = StandardCharsets.US_ASCII;
         final SharedOutputBuffer outputBuffer = new SharedOutputBuffer(30);
@@ -165,7 +165,7 @@ public class TestSharedOutputBuffer {
     }
 
     @Test
-    public void testMultithreadingWriteStream() throws Exception {
+    void testMultithreadingWriteStream() throws Exception {
 
         final Charset charset = StandardCharsets.US_ASCII;
         final SharedOutputBuffer outputBuffer = new SharedOutputBuffer(20);
@@ -207,7 +207,7 @@ public class TestSharedOutputBuffer {
     }
 
     @Test
-    public void testMultithreadingWriteStreamAbort() throws Exception {
+    void testMultithreadingWriteStreamAbort() throws Exception {
 
         final Charset charset = StandardCharsets.US_ASCII;
         final SharedOutputBuffer outputBuffer = new SharedOutputBuffer(20);
@@ -236,7 +236,7 @@ public class TestSharedOutputBuffer {
     }
 
     @Test
-    public void testEndStreamOnlyCalledOnce() throws IOException {
+    void testEndStreamOnlyCalledOnce() throws IOException {
 
         final DataStreamChannel channel = Mockito.mock(DataStreamChannel.class);
         final SharedOutputBuffer outputBuffer = new SharedOutputBuffer(20);

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestChainBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestChainBuilder.java
@@ -34,10 +34,10 @@ import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestChainBuilder {
+class TestChainBuilder {
 
     @Test
-    public void testBuildChain() throws Exception {
+    void testBuildChain() {
         final ChainBuilder<HttpRequestInterceptor> cb = new ChainBuilder<>();
         final HttpRequestInterceptor i1 = RequestContent.INSTANCE;
         final HttpRequestInterceptor i2 = RequestTargetHost.INSTANCE;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestForwardedRequest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestForwardedRequest.java
@@ -49,14 +49,14 @@ import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Test;
 
-public class TesForwardedRequest {
+class TestForwardedRequest {
     private final HttpRequest request = new BasicHttpRequest("GET", "/");
     private final HttpContext context = mock(HttpContext.class);
 
     private static final String FORWARDED_HEADER_NAME = "Forwarded";
 
     @Test
-    public void testProcess() throws IOException, HttpException {
+    void testProcess() throws IOException, HttpException {
         final HttpRequestInterceptor processor = new ForwardedRequest();
 
         // Create a mock endpoint with a remote address
@@ -91,7 +91,7 @@ public class TesForwardedRequest {
 
 
     @Test
-    public void testProcessWithIPv6() throws IOException, HttpException {
+    void testProcessWithIPv6() throws IOException, HttpException {
         final HttpRequestInterceptor processor = new ForwardedRequest();
 
         // Create a mock endpoint with a remote IPv6 address
@@ -150,7 +150,7 @@ public class TesForwardedRequest {
     }
 
     @Test
-    public void testWithForwardedHeader() throws Exception {
+    void testWithForwardedHeader() throws Exception {
         final HttpRequestInterceptor processor = new ForwardedRequest();
 
         // Create a mock HTTP request with a host and port
@@ -177,19 +177,19 @@ public class TesForwardedRequest {
     }
 
     @Test
-    public void testProcessWithNullHttpRequest() {
+    void testProcessWithNullHttpRequest() {
         final ForwardedRequest httpRequestModifier = new ForwardedRequest();
         assertThrows(NullPointerException.class, () -> httpRequestModifier.process(null, null, context));
     }
 
     @Test
-    public void testProcessWithNullHttpContext() {
+    void testProcessWithNullHttpContext() {
         final ForwardedRequest httpRequestModifier = new ForwardedRequest();
         assertThrows(NullPointerException.class, () -> httpRequestModifier.process(request, null, null));
     }
 
     @Test
-    public void testProcessWithNullAuthority() {
+    void testProcessWithNullAuthority() {
         final ForwardedRequest httpRequestModifier = new ForwardedRequest();
         assertThrows(ProtocolException.class, () -> httpRequestModifier.process(request, null, context));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestHttpExecutionContext.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestHttpExecutionContext.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
 
 // the name of this test is historic, the implementation classes of HttpContext
 // have been renamed to BasicHttpContext and SyncBasicHttpContext
-public class TestHttpExecutionContext {
+class TestHttpExecutionContext {
 
     @Test
-    public void testContextOperations() {
+    void testContextOperations() {
         final HttpCoreContext parentContext = new HttpCoreContext();
         final HttpCoreContext currentContext = new HttpCoreContext(parentContext);
 
@@ -65,7 +65,7 @@ public class TestHttpExecutionContext {
     }
 
     @Test
-    public void testEmptyContextOperations() {
+    void testEmptyContextOperations() {
         final HttpCoreContext currentContext = new HttpCoreContext();
         Assertions.assertNull(currentContext.getAttribute("param1"));
         currentContext.removeAttribute("param1");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -54,10 +54,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestStandardInterceptors {
+class TestStandardInterceptors {
 
     @Test
-    public void testRequestConnControlGenerated() throws Exception {
+    void testRequestConnControlGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final HttpRequestInterceptor interceptor = RequestConnControl.INSTANCE;
@@ -68,7 +68,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConnControlConnectMethod() throws Exception {
+    void testRequestConnControlConnectMethod() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.CONNECT, "/");
         final HttpRequestInterceptor interceptor = RequestConnControl.INSTANCE;
@@ -78,7 +78,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConnControlCustom() throws Exception {
+    void testRequestConnControlCustom() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final Header myheader = new BasicHeader(HttpHeaders.CONNECTION, "close");
@@ -92,7 +92,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConnControlUpgrade() throws Exception {
+    void testRequestConnControlUpgrade() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(HttpHeaders.UPGRADE, "HTTP/2");
@@ -104,13 +104,13 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConnControlInvalidInput() throws Exception {
+    void testRequestConnControlInvalidInput() {
         final HttpRequestInterceptor interceptor = RequestConnControl.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () -> interceptor.process(null, null, null));
     }
 
     @Test
-    public void testRequestContentProtocolException() throws Exception {
+    void testRequestContentProtocolException() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request1 = new BasicClassicHttpRequest(Method.POST, "/");
         request1.addHeader(new BasicHeader(HttpHeaders.TRANSFER_ENCODING, "chunked"));
@@ -125,7 +125,7 @@ public class TestStandardInterceptors {
    }
 
     @Test
-    public void testRequestContentNullEntity() throws Exception {
+    void testRequestContentNullEntity() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
 
@@ -138,7 +138,7 @@ public class TestStandardInterceptors {
    }
 
     @Test
-    public void testRequestContentNullEntityNonEnclosingMethod() throws Exception {
+    void testRequestContentNullEntityNonEnclosingMethod() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
 
@@ -149,7 +149,7 @@ public class TestStandardInterceptors {
         Assertions.assertNull(request.getFirstHeader(HttpHeaders.TRANSFER_ENCODING));
     }
     @Test
-    public void testRequestContentEntityContentLengthDelimitedHTTP11() throws Exception {
+    void testRequestContentEntityContentLengthDelimitedHTTP11() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new StringEntity("whatever", StandardCharsets.US_ASCII));
@@ -163,7 +163,7 @@ public class TestStandardInterceptors {
    }
 
     @Test
-    public void testRequestContentEntityChunkedHTTP11() throws Exception {
+    void testRequestContentEntityChunkedHTTP11() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new StringEntity("whatever", StandardCharsets.US_ASCII, true));
@@ -177,7 +177,7 @@ public class TestStandardInterceptors {
    }
 
     @Test
-    public void testRequestContentEntityUnknownLengthHTTP11() throws Exception {
+    void testRequestContentEntityUnknownLengthHTTP11() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, -1, null));
@@ -191,7 +191,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentEntityChunkedHTTP10() throws Exception {
+    void testRequestContentEntityChunkedHTTP10() {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
@@ -203,7 +203,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentTypeAndEncoding() throws Exception {
+    void testRequestContentTypeAndEncoding() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE,
@@ -220,7 +220,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentNullTypeAndEncoding() throws Exception {
+    void testRequestContentNullTypeAndEncoding() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null, null));
@@ -232,7 +232,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentEntityUnknownLengthHTTP10() throws Exception {
+    void testRequestContentEntityUnknownLengthHTTP10() {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
@@ -244,14 +244,14 @@ public class TestStandardInterceptors {
    }
 
     @Test
-    public void testRequestContentInvalidInput() throws Exception {
+    void testRequestContentInvalidInput() {
         final HttpRequestInterceptor interceptor = RequestContent.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, null));
     }
 
     @Test
-    public void testRequestContentIgnoreNonenclosingRequests() throws Exception {
+    void testRequestContentIgnoreNonenclosingRequests() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         final HttpRequestInterceptor interceptor = RequestContent.INSTANCE;
@@ -260,7 +260,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentOverwriteHeaders() throws Exception {
+    void testRequestContentOverwriteHeaders() throws Exception {
         final RequestContent interceptor = new RequestContent(true);
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
@@ -274,7 +274,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentAddHeaders() throws Exception {
+    void testRequestContentAddHeaders() throws Exception {
         final RequestContent interceptor = new RequestContent(true);
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
@@ -288,7 +288,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentEntityWithTrailers() throws Exception {
+    void testRequestContentEntityWithTrailers() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(HttpEntities.create("whatever", StandardCharsets.US_ASCII,
@@ -304,7 +304,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestContentTraceWithEntity() throws Exception {
+    void testRequestContentTraceWithEntity() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.TRACE, "/");
         request.setEntity(new StringEntity("stuff"));
@@ -314,7 +314,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestExpectContinueGenerated() throws Exception {
+    void testRequestExpectContinueGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new StringEntity("whatever", StandardCharsets.US_ASCII));
@@ -326,7 +326,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestExpectContinueHTTP10() throws Exception {
+    void testRequestExpectContinueHTTP10() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
@@ -338,7 +338,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestExpectContinueZeroContent() throws Exception {
+    void testRequestExpectContinueZeroContent() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new StringEntity("", StandardCharsets.US_ASCII));
@@ -349,14 +349,14 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestExpectContinueInvalidInput() throws Exception {
+    void testRequestExpectContinueInvalidInput() {
         final RequestExpectContinue interceptor = RequestExpectContinue.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, null));
     }
 
     @Test
-    public void testRequestExpectContinueIgnoreNonenclosingRequests() throws Exception {
+    void testRequestExpectContinueIgnoreNonenclosingRequests() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         final RequestExpectContinue interceptor = RequestExpectContinue.INSTANCE;
@@ -365,7 +365,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostGenerated() throws Exception {
+    void testRequestTargetHostGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setAuthority(new URIAuthority("somehost", 8080));
@@ -377,7 +377,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostNotGenerated() throws Exception {
+    void testRequestTargetHostNotGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setAuthority(new URIAuthority("somehost", 8080));
@@ -390,7 +390,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostMissingHostHTTP10() throws Exception {
+    void testRequestTargetHostMissingHostHTTP10() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -401,7 +401,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostMissingHostHTTP11() throws Exception {
+    void testRequestTargetHostMissingHostHTTP11() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final HttpRequestInterceptor interceptor = RequestTargetHost.INSTANCE;
@@ -410,7 +410,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostInvalidInput() throws Exception {
+    void testRequestTargetHostInvalidInput() {
         final HttpRequestInterceptor interceptor = RequestTargetHost.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, null));
@@ -419,7 +419,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostConnectHttp11() throws Exception {
+    void testRequestTargetHostConnectHttp11() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.CONNECT, "/");
         request.setAuthority(new URIAuthority("somehost", 8080));
@@ -431,7 +431,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestTargetHostConnectHttp10() throws Exception {
+    void testRequestTargetHostConnectHttp10() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.CONNECT, "/");
@@ -443,7 +443,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestUserAgentGenerated() throws Exception {
+    void testRequestUserAgentGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final RequestUserAgent interceptor = new RequestUserAgent("some agent");
@@ -454,7 +454,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestUserAgentNotGenerated() throws Exception {
+    void testRequestUserAgentNotGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.USER_AGENT, "whatever"));
@@ -466,7 +466,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestUserAgentMissingUserAgent() throws Exception {
+    void testRequestUserAgentMissingUserAgent() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final HttpRequestInterceptor interceptor = RequestUserAgent.INSTANCE;
@@ -476,13 +476,13 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestUserAgentInvalidInput() throws Exception {
+    void testRequestUserAgentInvalidInput() {
         final HttpRequestInterceptor interceptor = RequestUserAgent.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () -> interceptor.process(null, null, null));
     }
 
     @Test
-    public void testResponseConnControlNoEntity() throws Exception {
+    void testResponseConnControlNoEntity() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         final ResponseConnControl interceptor = new ResponseConnControl();
@@ -492,7 +492,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlEntityContentLength() throws Exception {
+    void testResponseConnControlEntityContentLength() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new StringEntity("whatever"));
@@ -503,7 +503,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlEntityUnknownContentLengthExplicitKeepAlive() throws Exception {
+    void testResponseConnControlEntityUnknownContentLengthExplicitKeepAlive() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
@@ -518,7 +518,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlEntityChunked() throws Exception {
+    void testResponseConnControlEntityChunked() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null, true));
@@ -529,7 +529,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlEntityUnknownContentLengthHTTP10() throws Exception {
+    void testResponseConnControlEntityUnknownContentLengthHTTP10() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -546,7 +546,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlClientRequest() throws Exception {
+    void testResponseConnControlClientRequest() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
@@ -562,7 +562,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlClientRequest2() throws Exception {
+    void testResponseConnControlClientRequest2() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         context.setRequest(request);
@@ -576,7 +576,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControl10Client11Response() throws Exception {
+    void testResponseConnControl10Client11Response() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -592,7 +592,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlStatusCode() throws Exception {
+    void testResponseConnControlStatusCode() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
@@ -620,7 +620,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlExplicitClose() throws Exception {
+    void testResponseConnControlExplicitClose() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "keep-alive"));
@@ -637,7 +637,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlClientRequestMixUp() throws Exception {
+    void testResponseConnControlClientRequestMixUp() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(new BasicHeader(HttpHeaders.CONNECTION, "blah, keep-alive, close"));
@@ -653,7 +653,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlUpgrade() throws Exception {
+    void testResponseConnControlUpgrade() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
 
         final ResponseConnControl interceptor = new ResponseConnControl();
@@ -667,7 +667,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConnControlHostInvalidInput() throws Exception {
+    void testResponseConnControlHostInvalidInput() {
         final ResponseConnControl interceptor = new ResponseConnControl();
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, null));
@@ -677,7 +677,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentNoEntity() throws Exception {
+    void testResponseContentNoEntity() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         final ResponseContent interceptor = new ResponseContent();
@@ -688,7 +688,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentStatusNoContent() throws Exception {
+    void testResponseContentStatusNoContent() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setCode(HttpStatus.SC_NO_CONTENT);
@@ -699,7 +699,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentStatusNotModified() throws Exception {
+    void testResponseContentStatusNotModified() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setCode(HttpStatus.SC_NOT_MODIFIED);
@@ -710,7 +710,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityChunked() throws Exception {
+    void testResponseContentEntityChunked() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null, true));
@@ -724,7 +724,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityContentLenghtDelimited() throws Exception {
+    void testResponseContentEntityContentLenghtDelimited() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, 10, null));
@@ -738,7 +738,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityUnknownContentLength() throws Exception {
+    void testResponseContentEntityUnknownContentLength() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null));
@@ -752,8 +752,8 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityChunkedHTTP10() throws Exception {
-        final HttpCoreContext context = HttpCoreContext.create();
+    void testResponseContentEntityChunkedHTTP10() throws Exception {
+    final HttpCoreContext context = HttpCoreContext.create();
         context.setProtocolVersion(HttpVersion.HTTP_1_0);
         final BasicClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null, true));
@@ -766,7 +766,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityNoContentTypeAndEncoding() throws Exception {
+    void testResponseContentEntityNoContentTypeAndEncoding() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE, null));
@@ -779,7 +779,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityContentTypeAndEncoding() throws Exception {
+    void testResponseContentEntityContentTypeAndEncoding() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(new BasicHttpEntity(EmptyInputStream.INSTANCE,
@@ -795,13 +795,13 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentInvalidInput() throws Exception {
+    void testResponseContentInvalidInput() {
         final ResponseContent interceptor = new ResponseContent();
         Assertions.assertThrows(NullPointerException.class, () -> interceptor.process(null, null, null));
     }
 
     @Test
-    public void testResponseContentInvalidResponseState() throws Exception {
+    void testResponseContentInvalidResponseState() {
         final ResponseContent interceptor = new ResponseContent();
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
@@ -815,7 +815,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentOverwriteHeaders() throws Exception {
+    void testResponseContentOverwriteHeaders() throws Exception {
         final ResponseContent interceptor = new ResponseContent(true);
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
@@ -826,7 +826,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentAddHeaders() throws Exception {
+    void testResponseContentAddHeaders() throws Exception {
         final ResponseContent interceptor = new ResponseContent(true);
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
@@ -836,7 +836,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseContentEntityWithTrailers() throws Exception {
+    void testResponseContentEntityWithTrailers() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setEntity(HttpEntities.create("whatever", StandardCharsets.US_ASCII,
@@ -852,7 +852,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseDateGenerated() throws Exception {
+    void testResponseDateGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         final ResponseDate interceptor = new ResponseDate();
@@ -865,7 +865,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseDateNotGenerated() throws Exception {
+    void testResponseDateNotGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setCode(199);
@@ -876,14 +876,14 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseDateInvalidInput() throws Exception {
+    void testResponseDateInvalidInput() {
         final ResponseDate interceptor = new ResponseDate();
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, null));
     }
 
     @Test
-    public void testRequestDateGenerated() throws Exception {
+    void testRequestDateGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.POST, "/");
         request.setEntity(new StringEntity("stuff"));
@@ -898,7 +898,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestDateNotGenerated() throws Exception {
+    void testRequestDateNotGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
 
@@ -909,14 +909,14 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestDateInvalidInput() throws Exception {
+    void testRequestDateInvalidInput() {
         final HttpRequestInterceptor interceptor = RequestDate.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, null));
     }
 
     @Test
-    public void testResponseServerGenerated() throws Exception {
+    void testResponseServerGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         final ResponseServer interceptor = new ResponseServer("some server");
@@ -927,7 +927,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseServerNotGenerated() throws Exception {
+    void testResponseServerNotGenerated() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         response.addHeader(new BasicHeader(HttpHeaders.SERVER, "whatever"));
@@ -939,7 +939,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseServerMissing() throws Exception {
+    void testResponseServerMissing() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "OK");
         final ResponseServer interceptor = new ResponseServer();
@@ -949,13 +949,13 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseServerInvalidInput() throws Exception {
+    void testResponseServerInvalidInput() {
         final ResponseServer interceptor = new ResponseServer();
         Assertions.assertThrows(NullPointerException.class, () -> interceptor.process(null, null, null));
     }
 
     @Test
-    public void testRequestHttp10HostHeaderAbsent() throws Exception {
+    void testRequestHttp10HostHeaderAbsent() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setVersion(HttpVersion.HTTP_1_0);
@@ -964,7 +964,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestHttpHostHeader() throws Exception {
+    void testRequestHttpHostHeader() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setVersion(HttpVersion.HTTP_1_1);
@@ -975,7 +975,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestHttpHostHeaderNoPort() throws Exception {
+    void testRequestHttpHostHeaderNoPort() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setVersion(HttpVersion.HTTP_1_1);
@@ -986,7 +986,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestHttp11HostHeaderPresent() throws Exception {
+    void testRequestHttp11HostHeaderPresent() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setHeader(HttpHeaders.HOST, "blah");
@@ -995,7 +995,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestHttp11HostHeaderAbsent() throws Exception {
+    void testRequestHttp11HostHeaderAbsent() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         final RequestValidateHost interceptor = new RequestValidateHost();
@@ -1004,7 +1004,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestHttp11MultipleHostHeaders() throws Exception {
+    void testRequestHttp11MultipleHostHeaders() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.addHeader(HttpHeaders.HOST, "blah");
@@ -1015,7 +1015,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestAbsoluteRequestURITakesPrecedenceOverHostHeader() throws Exception {
+    void testRequestAbsoluteRequestURITakesPrecedenceOverHostHeader() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "https://somehost/blah?huh");
         request.setHeader(HttpHeaders.HOST, "blah");
@@ -1025,7 +1025,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConformance() throws Exception {
+    void testRequestConformance() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setScheme("http");
@@ -1036,7 +1036,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConformanceSchemeMissing() throws Exception {
+    void testRequestConformanceSchemeMissing() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setAuthority(new URIAuthority("somehost", 8888));
@@ -1047,7 +1047,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConformancePathMissing() throws Exception {
+    void testRequestConformancePathMissing() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setScheme("http");
@@ -1059,7 +1059,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConformanceHostMissing() throws Exception {
+    void testRequestConformanceHostMissing() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setScheme("http");
@@ -1071,7 +1071,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConformanceHttps() throws Exception {
+    void testRequestConformanceHttps() {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setSSLSession(Mockito.mock(SSLSession.class));
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -1083,7 +1083,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testRequestConformanceHttpsInsecureConnection() throws Exception {
+    void testRequestConformanceHttpsInsecureConnection() {
         final HttpCoreContext context = HttpCoreContext.create();
         context.setSSLSession(null);
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -1096,7 +1096,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConformanceNoContent() throws Exception {
+    void testResponseConformanceNoContent() {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         final ResponseConformance interceptor = new ResponseConformance();
@@ -1104,7 +1104,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConformanceNotModified() throws Exception {
+    void testResponseConformanceNotModified() {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NOT_MODIFIED, "Not Modified");
         final ResponseConformance interceptor = new ResponseConformance();
@@ -1112,7 +1112,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConformanceNoContentWithEntity() throws Exception {
+    void testResponseConformanceNoContentWithEntity() {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         response.setEntity(new StringEntity("stuff"));
@@ -1122,7 +1122,7 @@ public class TestStandardInterceptors {
     }
 
     @Test
-    public void testResponseConformanceNotModifiedWithEntity() throws Exception {
+    void testResponseConformanceNotModifiedWithEntity() {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NOT_MODIFIED, "Not Modified");
         response.setEntity(new StringEntity("stuff"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -986,7 +986,7 @@ class TestStandardInterceptors {
     }
 
     @Test
-    void testRequestHttp11HostHeaderPresent() {
+    void testRequestHttp11HostHeaderPresent() throws Exception {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setHeader(HttpHeaders.HOST, "blah");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -960,7 +960,7 @@ class TestStandardInterceptors {
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         request.setVersion(HttpVersion.HTTP_1_0);
         final RequestValidateHost interceptor = new RequestValidateHost();
-        interceptor.process(request, request.getEntity(), context);
+        Assertions.assertDoesNotThrow(() -> interceptor.process(request, request.getEntity(), context));
     }
 
     @Test
@@ -1032,7 +1032,7 @@ class TestStandardInterceptors {
         request.setAuthority(new URIAuthority("somehost", 8888));
         request.setPath("/path");
         final RequestConformance interceptor = new RequestConformance();
-        interceptor.process(request, request.getEntity(), context);
+        Assertions.assertDoesNotThrow(() -> interceptor.process(request, request.getEntity(), context));
     }
 
     @Test
@@ -1079,7 +1079,7 @@ class TestStandardInterceptors {
         request.setAuthority(new URIAuthority("somehost", 8888));
         request.setPath("/path");
         final RequestConformance interceptor = new RequestConformance();
-        interceptor.process(request, request.getEntity(), context);
+        Assertions.assertDoesNotThrow(() -> interceptor.process(request, request.getEntity(), context));
     }
 
     @Test
@@ -1100,7 +1100,7 @@ class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         final ResponseConformance interceptor = new ResponseConformance();
-        interceptor.process(response, response.getEntity(), context);
+        Assertions.assertDoesNotThrow(() -> interceptor.process(response, response.getEntity(), context));
     }
 
     @Test
@@ -1108,7 +1108,7 @@ class TestStandardInterceptors {
         final HttpCoreContext context = HttpCoreContext.create();
         final ClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_NOT_MODIFIED, "Not Modified");
         final ResponseConformance interceptor = new ResponseConformance();
-        interceptor.process(response, response.getEntity(), context);
+        Assertions.assertDoesNotThrow(() -> interceptor.process(response, response.getEntity(), context));
     }
 
     @Test

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/ViaRequestTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/ViaRequestTest.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
-public class ViaRequestTest {
+class ViaRequestTest {
 
     @Test
-    public void testViaRequestGenerated() throws Exception {
+    void testViaRequestGenerated() throws Exception {
 
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -59,7 +59,7 @@ public class ViaRequestTest {
     }
 
     @Test
-    public void testViaRequestGeneratedWithOutPort() throws Exception {
+    void testViaRequestGeneratedWithOutPort() throws Exception {
 
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
@@ -75,7 +75,7 @@ public class ViaRequestTest {
 
 
         @Test
-    public void testViaRequestInvalidHttpVersion() {
+    void testViaRequestInvalidHttpVersion() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         context.setProtocolVersion(HttpVersion.HTTP_0_9);
@@ -87,7 +87,7 @@ public class ViaRequestTest {
     }
 
     @Test
-    public void testViaRequestInvalidAuthority() {
+    void testViaRequestInvalidAuthority() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
         context.setProtocolVersion(HttpVersion.HTTP_1_1);
@@ -98,7 +98,7 @@ public class ViaRequestTest {
     }
 
     @Test
-    public void testViaRequestNotCreatedAlreadyAdded() throws Exception {
+    void testViaRequestNotCreatedAlreadyAdded() throws Exception {
 
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/ViaRequestTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/ViaRequestTest.java
@@ -52,9 +52,9 @@ class ViaRequestTest {
         final ViaRequest interceptor = new ViaRequest();
         interceptor.process(request, request.getEntity(), context);
 
-        assertEquals(request.getHeader(HttpHeaders.VIA).getName(), HttpHeaders.VIA);
+        assertEquals(HttpHeaders.VIA, request.getHeader(HttpHeaders.VIA).getName());
         assertNotNull(request.getHeader(HttpHeaders.VIA));
-        assertEquals(request.getHeader(HttpHeaders.VIA).getValue(), "HTTP 1.1 somehost:8888");
+        assertEquals("HTTP 1.1 somehost:8888", request.getHeader(HttpHeaders.VIA).getValue());
 
     }
 
@@ -68,9 +68,9 @@ class ViaRequestTest {
         final ViaRequest interceptor = new ViaRequest();
         interceptor.process(request, request.getEntity(), context);
 
-        assertEquals(request.getHeader(HttpHeaders.VIA).getName(), HttpHeaders.VIA);
+        assertEquals(HttpHeaders.VIA, request.getHeader(HttpHeaders.VIA).getName());
         assertNotNull(request.getHeader(HttpHeaders.VIA));
-        assertEquals(request.getHeader(HttpHeaders.VIA).getValue(), "HTTP 1.1 somehost");
+        assertEquals("HTTP 1.1 somehost", request.getHeader(HttpHeaders.VIA).getValue());
     }
 
 
@@ -109,7 +109,7 @@ class ViaRequestTest {
         final ViaRequest interceptor = new ViaRequest();
         interceptor.process(request, request.getEntity(), context);
 
-        assertEquals(request.getHeader(HttpHeaders.VIA).getName(), HttpHeaders.VIA);
+        assertEquals(HttpHeaders.VIA, request.getHeader(HttpHeaders.VIA).getName());
         assertNotNull(request.getHeader(HttpHeaders.VIA));
         assertEquals(request.getHeader(HttpHeaders.VIA).getValue(), viaValue);
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/ssl/TLSTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/ssl/TLSTest.java
@@ -92,7 +92,7 @@ class TLSTest {
     }
 
     @Test
-    public void testParseBasic() throws Exception {
+    void testParseBasic() throws Exception {
         assertThat(TLS.parse("TLSv1"), CoreMatchers.equalTo(TLS.V_1_0.getVersion()));
         assertThat(TLS.parse("TLSv1.1"), CoreMatchers.equalTo(TLS.V_1_1.getVersion()));
         assertThat(TLS.parse("TLSv1.2"), CoreMatchers.equalTo(TLS.V_1_2.getVersion()));
@@ -101,7 +101,7 @@ class TLSTest {
     }
 
     @Test
-    public void testParseBuffer() throws Exception {
+    void testParseBuffer() throws Exception {
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(1, 13);
         assertThat(TLS.parse(" TLSv1.2,0000", cursor, Tokenizer.delimiters(',')),
                 CoreMatchers.equalTo(TLS.V_1_2.getVersion()));
@@ -109,7 +109,7 @@ class TLSTest {
     }
 
     @Test
-    public void testParseFailure() throws Exception {
+    void testParseFailure() {
         Assertions.assertThrows(ParseException.class, () -> TLS.parse("Tlsv1"));
         Assertions.assertThrows(ParseException.class, () -> TLS.parse("TLSV1"));
         Assertions.assertThrows(ParseException.class, () -> TLS.parse("TLSv"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/ssl/TestTlsCiphers.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/ssl/TestTlsCiphers.java
@@ -33,10 +33,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link TlsCiphers}.
  */
-public class TestTlsCiphers {
+class TestTlsCiphers {
 
     @Test
-    public void testStrongCipherSuites() {
+    void testStrongCipherSuites() {
         final String[] strongCipherSuites = {
                 "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
                 "TLS_RSA_WITH_AES_256_CBC_SHA256",
@@ -51,7 +51,7 @@ public class TestTlsCiphers {
     }
 
     @Test
-    public void testWeakCiphersDisabledByDefault() {
+    void testWeakCiphersDisabledByDefault() {
         final String[] weakCiphersSuites = {
                 "SSL_RSA_WITH_RC4_128_SHA",
                 "SSL_RSA_WITH_3DES_EDE_CBC_SHA",

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestBasicMessageBuilders.java
@@ -51,10 +51,10 @@ import java.util.Arrays;
 /**
  * Simple tests for {@link BasicResponseBuilder} and {@link BasicRequestBuilder}.
  */
-public class TestBasicMessageBuilders {
+class TestBasicMessageBuilders {
 
     @Test
-    public void testResponseBasics() throws Exception {
+    void testResponseBasics() {
         final BasicResponseBuilder builder = BasicResponseBuilder.create(200);
         Assertions.assertEquals(200, builder.getStatus());
         Assertions.assertNull(builder.getHeaders());
@@ -112,7 +112,7 @@ public class TestBasicMessageBuilders {
     }
 
     @Test
-    public void testRequestBasics() throws Exception {
+    void testRequestBasics() throws Exception {
         final BasicRequestBuilder builder = BasicRequestBuilder.get();
         Assertions.assertEquals(URI.create("/"), builder.getUri());
         Assertions.assertEquals("GET", builder.getMethod());
@@ -206,7 +206,7 @@ public class TestBasicMessageBuilders {
     }
 
     @Test
-    public void testResponseCopy() throws Exception {
+    void testResponseCopy() {
         final HttpResponse response = new BasicHttpResponse(400);
         response.addHeader("h1", "v1");
         response.addHeader("h1", "v2");
@@ -221,7 +221,7 @@ public class TestBasicMessageBuilders {
     }
 
     @Test
-    public void testRequestCopy() throws Exception {
+    void testRequestCopy() {
         final HttpRequest request = new BasicHttpRequest(Method.GET, URI.create("https://host:3456/stuff?blah")) ;
         request.addHeader("h1", "v1");
         request.addHeader("h1", "v2");

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestExpectSupport.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/support/TestExpectSupport.java
@@ -34,10 +34,10 @@ import org.apache.hc.core5.http.impl.BasicEntityDetails;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestExpectSupport {
+class TestExpectSupport {
 
     @Test
-    public void testExpectParsingBasics() throws Exception {
+    void testExpectParsingBasics() throws Exception {
         Assertions.assertEquals(Expectation.CONTINUE,
                 ExpectSupport.parse(
                         BasicRequestBuilder.post()
@@ -47,7 +47,7 @@ public class TestExpectSupport {
     }
 
     @Test
-    public void testExpectParsingTolerateEmptyTokens() throws Exception {
+    void testExpectParsingTolerateEmptyTokens() throws Exception {
         Assertions.assertEquals(Expectation.CONTINUE,
                 ExpectSupport.parse(
                         BasicRequestBuilder.post()
@@ -59,7 +59,7 @@ public class TestExpectSupport {
     }
 
     @Test
-    public void testExpectParsingMissingEntity() throws Exception {
+    void testExpectParsingMissingEntity() {
         Assertions.assertThrows(ProtocolException.class,
                 () -> ExpectSupport.parse(
                         BasicRequestBuilder.post()
@@ -69,7 +69,7 @@ public class TestExpectSupport {
     }
 
     @Test
-    public void testExpectParsingUnknownExpectation() throws Exception {
+    void testExpectParsingUnknownExpectation() throws Exception {
         Assertions.assertEquals(Expectation.UNKNOWN,
                 ExpectSupport.parse(
                         BasicRequestBuilder.post()
@@ -80,7 +80,7 @@ public class TestExpectSupport {
     }
 
     @Test
-    public void testExpectParsingUnknownExpectation2() throws Exception {
+    void testExpectParsingUnknownExpectation2() throws Exception {
         Assertions.assertEquals(Expectation.UNKNOWN,
                 ExpectSupport.parse(
                         BasicRequestBuilder.post()
@@ -90,7 +90,7 @@ public class TestExpectSupport {
     }
 
     @Test
-    public void testExpectParsingNoExpectation() throws Exception {
+    void testExpectParsingNoExpectation() throws Exception {
         Assertions.assertNull(ExpectSupport.parse(
                         BasicRequestBuilder.post()
                                 .build(),
@@ -98,7 +98,7 @@ public class TestExpectSupport {
     }
 
     @Test
-    public void testExpectParsingIgnoreHTTP10() throws Exception {
+    void testExpectParsingIgnoreHTTP10() throws Exception {
         Assertions.assertNull(ExpectSupport.parse(
                 BasicRequestBuilder.post()
                         .setVersion(HttpVersion.HTTP_1_0)

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestHost.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link Host}.
  *
  */
-public class TestHost {
+class TestHost {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final Host host1 = new Host("somehost", 8080);
         Assertions.assertEquals("somehost", host1.getHostName());
         Assertions.assertEquals(8080, host1.getPort());
@@ -63,7 +63,7 @@ public class TestHost {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    void testHashCode() {
         final Host host1 = new Host("somehost", 8080);
         final Host host2 = new Host("somehost", 80);
         final Host host3 = new Host("someotherhost", 8080);
@@ -76,7 +76,7 @@ public class TestHost {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    void testEquals() {
         final Host host1 = new Host("somehost", 8080);
         final Host host2 = new Host("somehost", 80);
         final Host host3 = new Host("someotherhost", 8080);
@@ -89,13 +89,13 @@ public class TestHost {
     }
 
     @Test
-    public void testToString() throws Exception {
+    void testToString() {
         final Host host1 = new Host("somehost", 8888);
         Assertions.assertEquals("somehost:8888", host1.toString());
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final Host orig = new Host("somehost", 8080);
         final ByteArrayOutputStream outbuffer = new ByteArrayOutputStream();
         final ObjectOutputStream outStream = new ObjectOutputStream(outbuffer);
@@ -109,7 +109,7 @@ public class TestHost {
     }
 
     @Test
-    public void testCreateFromString() throws Exception {
+    void testCreateFromString() throws Exception {
         Assertions.assertEquals(new Host("somehost", 8080), Host.create("somehost:8080"));
         Assertions.assertEquals(new Host("somehost", 1234), Host.create("somehost:1234"));
         Assertions.assertEquals(new Host("somehost", 0), Host.create("somehost:0"));
@@ -118,32 +118,32 @@ public class TestHost {
     }
 
     @Test
-    public void testCreateFromStringInvalid() throws Exception {
+    void testCreateFromStringInvalid() {
         Assertions.assertThrows(URISyntaxException.class, () -> Host.create(" host "));
         Assertions.assertThrows(URISyntaxException.class, () -> Host.create("host :8080"));
         Assertions.assertThrows(IllegalArgumentException.class, () -> Host.create(""));
     }
 
     @Test
-    public void testIpv6HostAndPort() throws Exception {
+    void testIpv6HostAndPort() throws Exception {
         final Host host = Host.create("[::1]:80");
         Assertions.assertEquals("::1", host.getHostName());
         Assertions.assertEquals(80, host.getPort());
     }
 
     @Test
-    public void testIpv6HostAndPortWithoutBrackets() {
+    void testIpv6HostAndPortWithoutBrackets() {
         // ambiguous
         Assertions.assertThrows(URISyntaxException.class, () -> Host.create("::1:80"));
     }
 
     @Test
-    public void testIpv6HostWithoutPort() {
+    void testIpv6HostWithoutPort() {
         Assertions.assertThrows(URISyntaxException.class, () -> Host.create("::1"));
     }
 
     @Test
-    public void testIpv6HostToString() {
+    void testIpv6HostToString() {
         Assertions.assertEquals("[::1]:80", new Host("::1", 80).toString());
         Assertions.assertEquals("[::1]", new Host("::1", -1).toString());
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestHost.java
@@ -70,8 +70,8 @@ class TestHost {
         final Host host4 = new Host("somehost", 80);
 
         Assertions.assertEquals(host1.hashCode(), host1.hashCode());
-        Assertions.assertTrue(host1.hashCode() != host2.hashCode());
-        Assertions.assertTrue(host1.hashCode() != host3.hashCode());
+        Assertions.assertNotEquals(host1.hashCode(), host2.hashCode());
+        Assertions.assertNotEquals(host1.hashCode(), host3.hashCode());
         Assertions.assertEquals(host2.hashCode(), host4.hashCode());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
@@ -33,17 +33,17 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for InetAddressUtils.
  */
-public class TestInetAddressUtils {
+class TestInetAddressUtils {
 
     @Test
-    public void testValidIPv4Address() {
+    void testValidIPv4Address() {
         Assertions.assertTrue(InetAddressUtils.isIPv4("127.0.0.1"));
         Assertions.assertTrue(InetAddressUtils.isIPv4("192.168.0.0"));
         Assertions.assertTrue(InetAddressUtils.isIPv4("255.255.255.255"));
     }
 
     @Test
-    public void testInvalidIPv4Address() {
+    void testInvalidIPv4Address() {
         Assertions.assertFalse(InetAddressUtils.isIPv4(" 127.0.0.1 "));  // Blanks not allowed
         Assertions.assertFalse(InetAddressUtils.isIPv4("g.ar.ba.ge"));
         Assertions.assertFalse(InetAddressUtils.isIPv4("192.168.0"));
@@ -52,7 +52,7 @@ public class TestInetAddressUtils {
     }
 
     @Test
-    public void testValidIPv6Address() {
+    void testValidIPv6Address() {
         Assertions.assertTrue(InetAddressUtils.isIPv6Std("2001:0db8:0000:0000:0000:0000:1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6Std("2001:db8:0:0:0:0:1428:57ab"));
         Assertions.assertTrue(InetAddressUtils.isIPv6Std("0:0:0:0:0:0:0:0"));
@@ -81,7 +81,7 @@ public class TestInetAddressUtils {
     }
 
     @Test
-    public void testInvalidIPv6Address() {
+    void testInvalidIPv6Address() {
         Assertions.assertFalse(InetAddressUtils.isIPv6("2001:0db8:0000:garb:age0:0000:1428:57ab"));
         Assertions.assertFalse(InetAddressUtils.isIPv6("2001:0gb8:0000:0000:0000:0000:1428:57ab"));
         Assertions.assertFalse(InetAddressUtils.isIPv6Std("0:0:0:0:0:0:0:0:0")); // Too many
@@ -109,7 +109,7 @@ public class TestInetAddressUtils {
     }
 
     @Test
-    public void testValidIPv6BracketAddress() {
+    void testValidIPv6BracketAddress() {
         Assertions.assertTrue(InetAddressUtils.isIPv6URLBracketed("[2001:0db8:0000:0000:0000:0000:1428:57ab]"));
         Assertions.assertTrue(InetAddressUtils.isIPv6URLBracketed("[2001:db8:0:0:0:0:1428:57ab]"));
         Assertions.assertTrue(InetAddressUtils.isIPv6URLBracketed("[0:0:0:0:0:0:0:0]"));
@@ -123,7 +123,7 @@ public class TestInetAddressUtils {
     }
 
     @Test
-    public void testInvalidIPv6BracketAddress() {
+    void testInvalidIPv6BracketAddress() {
         Assertions.assertFalse(InetAddressUtils.isIPv6URLBracketed("2001:0db8:0000:garb:age0:0000:1428:57ab"));
         Assertions.assertFalse(InetAddressUtils.isIPv6URLBracketed("[2001:0db8:0000:garb:age0:0000:1428:57ab]"));
         Assertions.assertFalse(InetAddressUtils.isIPv6URLBracketed("2001:0gb8:0000:0000:0000:0000:1428:57ab"));
@@ -160,13 +160,13 @@ public class TestInetAddressUtils {
 
     @Test
     // Test HTTPCLIENT-1319
-    public void testInvalidIPv6AddressIncorrectGroupCount() {
+    void testInvalidIPv6AddressIncorrectGroupCount() {
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressed("1:2::4:5:6:7:8:9")); // too many fields in total
         Assertions.assertFalse(InetAddressUtils.isIPv6HexCompressed("1:2:3:4:5:6::8:9")); // too many fields in total
     }
 
     @Test
-    public void testHasValidIPv6ColonCount() {
+    void testHasValidIPv6ColonCount() {
         Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount(""));
         Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount(":"));
         Assertions.assertFalse(InetAddressUtils.hasValidIPv6ColonCount("127.0.0.1"));
@@ -187,13 +187,13 @@ public class TestInetAddressUtils {
     }
 
     @Test
-    public void testValidIPv4MappedIPv6Address() {
+    void testValidIPv4MappedIPv6Address() {
         Assertions.assertTrue(InetAddressUtils.isIPv4MappedIPv6("::FFFF:1.2.3.4"));
         Assertions.assertTrue(InetAddressUtils.isIPv4MappedIPv6("::ffff:255.255.255.255"));
     }
 
     @Test
-    public void testInValidIPv4MappedIPv6Address() {
+    void testInValidIPv4MappedIPv6Address() {
         Assertions.assertFalse(InetAddressUtils.isIPv4MappedIPv6("2001:0db8:0000:0000:0000:0000:1428:57ab"));
         Assertions.assertFalse(InetAddressUtils.isIPv4MappedIPv6("::ffff:1:2:3:4"));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestPercentCodec.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestPercentCodec.java
@@ -41,10 +41,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * Unit tests for {@link PercentCodec}.
  */
-public class TestPercentCodec {
+class TestPercentCodec {
 
     @Test
-    public void testCoding() {
+    void testCoding() {
         final StringBuilder buf = new StringBuilder();
         PercentCodec.encode(buf, "blah!", StandardCharsets.UTF_8);
         PercentCodec.encode(buf, " ~ ", StandardCharsets.UTF_8);
@@ -53,7 +53,7 @@ public class TestPercentCodec {
     }
 
     @Test
-    public void testDecoding() {
+    void testDecoding() {
         assertThat(PercentCodec.decode("blah%21%20~%20huh%3F", StandardCharsets.UTF_8),
                 CoreMatchers.equalTo("blah! ~ huh?"));
         assertThat(PercentCodec.decode("blah%21+~%20huh%3F", StandardCharsets.UTF_8),
@@ -63,7 +63,7 @@ public class TestPercentCodec {
     }
 
     @Test
-    public void testDecodingPartialContent() {
+    void testDecodingPartialContent() {
         assertThat(PercentCodec.decode("blah%21%20%", StandardCharsets.UTF_8),
                 CoreMatchers.equalTo("blah! %"));
         assertThat(PercentCodec.decode("blah%21%20%a", StandardCharsets.UTF_8),
@@ -74,7 +74,7 @@ public class TestPercentCodec {
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testRfc5987EncodingDecoding(final String input, final String expected) {
+    void testRfc5987EncodingDecoding(final String input, final String expected) {
         assertEquals(expected, PercentCodec.RFC5987.encode(input));
         assertEquals(input, PercentCodec.RFC5987.decode(expected));
     }
@@ -93,7 +93,7 @@ public class TestPercentCodec {
     }
 
     @Test
-    public void verifyRfc5987EncodingandDecoding() {
+    void verifyRfc5987EncodingandDecoding() {
         final String s = "!\"$£%^&*()_-+={[}]:@~;'#,./<>?\\|✓éèæðŃœ";
         assertThat(PercentCodec.RFC5987.decode(PercentCodec.RFC5987.encode(s)), CoreMatchers.equalTo(s));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
@@ -69,11 +69,11 @@ class TestURIAuthority {
         final URIAuthority host7 = new URIAuthority("user", "somehost", 80);
 
         Assertions.assertEquals(host1.hashCode(), host1.hashCode());
-        Assertions.assertTrue(host1.hashCode() != host2.hashCode());
-        Assertions.assertTrue(host1.hashCode() != host3.hashCode());
+        Assertions.assertNotEquals(host1.hashCode(), host2.hashCode());
+        Assertions.assertNotEquals(host1.hashCode(), host3.hashCode());
         Assertions.assertEquals(host2.hashCode(), host4.hashCode());
         Assertions.assertEquals(host2.hashCode(), host5.hashCode());
-        Assertions.assertTrue(host5.hashCode() != host6.hashCode());
+        Assertions.assertNotEquals(host5.hashCode(), host6.hashCode());
         Assertions.assertEquals(host6.hashCode(), host7.hashCode());
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIAuthority.java
@@ -43,10 +43,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link URIAuthority}.
  *
  */
-public class TestURIAuthority {
+class TestURIAuthority {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         final URIAuthority host1 = new URIAuthority("somehost");
         Assertions.assertEquals("somehost", host1.getHostName());
         Assertions.assertEquals(-1, host1.getPort());
@@ -59,7 +59,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    void testHashCode() {
         final URIAuthority host1 = new URIAuthority("somehost", 8080);
         final URIAuthority host2 = new URIAuthority("somehost", 80);
         final URIAuthority host3 = new URIAuthority("someotherhost", 8080);
@@ -78,7 +78,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testEquals() throws Exception {
+    void testEquals() {
         final URIAuthority host1 = new URIAuthority("somehost", 8080);
         final URIAuthority host2 = new URIAuthority("somehost", 80);
         final URIAuthority host3 = new URIAuthority("someotherhost", 8080);
@@ -97,7 +97,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testToString() throws Exception {
+    void testToString() {
         final URIAuthority host1 = new URIAuthority("somehost");
         Assertions.assertEquals("somehost", host1.toString());
         final URIAuthority host2 = new URIAuthority("somehost", -1);
@@ -107,7 +107,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final URIAuthority orig = new URIAuthority("somehost", 8080);
         final ByteArrayOutputStream outbuffer = new ByteArrayOutputStream();
         final ObjectOutputStream outStream = new ObjectOutputStream(outbuffer);
@@ -121,7 +121,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testParse() throws Exception {
+    void testParse() throws Exception {
         assertThat(URIAuthority.parse("somehost"),
                 CoreMatchers.equalTo(new URIAuthority("somehost", -1)));
         assertThat(URIAuthority.parse("somehost/blah"),
@@ -182,7 +182,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testCreateFromString() throws Exception {
+    void testCreateFromString() throws Exception {
         Assertions.assertEquals(new URIAuthority("somehost", 8080), URIAuthority.create("somehost:8080"));
         Assertions.assertEquals(new URIAuthority("SomeHost", 8080), URIAuthority.create("SomeHost:8080"));
         Assertions.assertEquals(new URIAuthority("somehost", 1234), URIAuthority.create("somehost:1234"));
@@ -195,7 +195,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testCreateFromIPv6String() throws Exception {
+    void testCreateFromIPv6String() throws Exception {
         Assertions.assertEquals(new URIAuthority("::1", 8080), URIAuthority.create("[::1]:8080"));
         Assertions.assertEquals(new URIAuthority("::1", -1), URIAuthority.create("[::1]"));
         Assertions.assertThrows(URISyntaxException.class, () -> URIAuthority.create("::1"));
@@ -204,7 +204,7 @@ public class TestURIAuthority {
     }
 
     @Test
-    public void testIpv6HostToString() {
+    void testIpv6HostToString() {
         Assertions.assertEquals("[::1]:80", new URIAuthority("::1", 80).toString());
         Assertions.assertEquals("user@[::1]:80", new URIAuthority("user", "::1", 80).toString());
         Assertions.assertEquals("[::1]", new URIAuthority("::1", -1).toString());

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
-public class TestURIBuilder {
+class TestURIBuilder {
 
     private static final String CH_HELLO = "\u0047\u0072\u00FC\u0065\u007A\u0069\u005F\u007A\u00E4\u006D\u00E4";
     private static final String RU_HELLO = "\u0412\u0441\u0435\u043C\u005F\u043F\u0440\u0438\u0432\u0435\u0442";
@@ -58,7 +58,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testParseSegments() throws Exception {
+    void testParseSegments() {
         assertThat(parsePath("/this/that"), CoreMatchers.equalTo(Arrays.asList("this", "that")));
         assertThat(parsePath("this/that"), CoreMatchers.equalTo(Arrays.asList("this", "that")));
         assertThat(parsePath("this//that"), CoreMatchers.equalTo(Arrays.asList("this", "", "that")));
@@ -78,7 +78,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testFormatSegments() throws Exception {
+    void testFormatSegments() {
         assertThat(formatPath("this", "that"), CoreMatchers.equalTo("/this/that"));
         assertThat(formatPath("this", "", "that"), CoreMatchers.equalTo("/this//that"));
         assertThat(formatPath("this", "", "that", "/this and that"),
@@ -94,7 +94,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testParseQuery() throws Exception {
+    void testParseQuery() {
         assertThat(parseQuery(""), NameValuePairListMatcher.isEmpty());
         assertThat(parseQuery("Name0"),
                 NameValuePairListMatcher.equalsTo(new BasicNameValuePair("Name0", null)));
@@ -141,7 +141,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testFormatQuery() throws Exception {
+    void testFormatQuery() {
         assertThat(formatQuery(new BasicNameValuePair("Name0", null)), CoreMatchers.equalTo("Name0"));
         assertThat(formatQuery(new BasicNameValuePair("Name1", "Value1")), CoreMatchers.equalTo("Name1=Value1"));
         assertThat(formatQuery(new BasicNameValuePair("Name2", "")), CoreMatchers.equalTo("Name2="));
@@ -169,7 +169,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testHierarchicalUri() throws Exception {
+    void testHierarchicalUri() throws Exception {
         final URI uri = new URI("http", "stuff", "localhost", 80, "/some stuff", "param=stuff", "fragment");
         final URIBuilder uribuilder = new URIBuilder(uri);
         final URI result = uribuilder.build();
@@ -177,28 +177,28 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testMutationRemoveFragment() throws Exception {
+    void testMutationRemoveFragment() throws Exception {
         final URI uri = new URI("http://stuff@localhost:80/stuff?param=stuff#fragment");
         final URI result = new URIBuilder(uri).setFragment(null).build();
         Assertions.assertEquals(new URI("http://stuff@localhost:80/stuff?param=stuff"), result);
     }
 
     @Test
-    public void testMutationRemoveUserInfo() throws Exception {
+    void testMutationRemoveUserInfo() throws Exception {
         final URI uri = new URI("http://stuff@localhost:80/stuff?param=stuff#fragment");
         final URI result = new URIBuilder(uri).setUserInfo(null).build();
         Assertions.assertEquals(new URI("http://localhost:80/stuff?param=stuff#fragment"), result);
     }
 
     @Test
-    public void testMutationRemovePort() throws Exception {
+    void testMutationRemovePort() throws Exception {
         final URI uri = new URI("http://stuff@localhost:80/stuff?param=stuff#fragment");
         final URI result = new URIBuilder(uri).setPort(-1).build();
         Assertions.assertEquals(new URI("http://stuff@localhost/stuff?param=stuff#fragment"), result);
     }
 
     @Test
-    public void testOpaqueUri() throws Exception {
+    void testOpaqueUri() throws Exception {
         final URI uri = new URI("stuff", "some-stuff", "fragment");
         final URIBuilder uribuilder = new URIBuilder(uri);
         final URI result = uribuilder.build();
@@ -206,20 +206,20 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testOpaqueUriMutation() throws Exception {
+    void testOpaqueUriMutation() throws Exception {
         final URI uri = new URI("stuff", "some-stuff", "fragment");
         final URIBuilder uribuilder = new URIBuilder(uri).setCustomQuery("param1&param2=stuff").setFragment(null);
         Assertions.assertEquals(new URI("stuff:?param1&param2=stuff"), uribuilder.build());
     }
 
     @Test
-    public void testHierarchicalUriMutation() throws Exception {
+    void testHierarchicalUriMutation() throws Exception {
         final URIBuilder uribuilder = new URIBuilder("/").setScheme("http").setHost("localhost").setPort(80).setPath("/stuff");
         Assertions.assertEquals(new URI("http://localhost:80/stuff"), uribuilder.build());
     }
 
     @Test
-   public void testLocalhost() throws Exception {
+    void testLocalhost() throws Exception {
        // Check that the URI generated by URI builder agrees with that generated by using URI directly
        final String scheme="https";
        final InetAddress host=InetAddress.getLocalHost();
@@ -243,10 +243,10 @@ public class TestURIBuilder {
        Assertions.assertEquals(uri.getQuery(), bld.getQuery());
 
        Assertions.assertEquals(uri.getFragment(), bld.getFragment());
-   }
+    }
 
     @Test
-   public void testLoopbackAddress() throws Exception {
+    void testLoopbackAddress() throws Exception {
        // Check that the URI generated by URI builder agrees with that generated by using URI directly
        final String scheme="https";
        final InetAddress host=InetAddress.getLoopbackAddress();
@@ -270,23 +270,23 @@ public class TestURIBuilder {
        Assertions.assertEquals(uri.getQuery(), bld.getQuery());
 
        Assertions.assertEquals(uri.getFragment(), bld.getFragment());
-   }
+    }
 
     @Test
-    public void testEmpty() throws Exception {
+    void testEmpty() throws Exception {
         final URIBuilder uribuilder = new URIBuilder();
         final URI result = uribuilder.build();
         Assertions.assertEquals(new URI(""), result);
     }
 
     @Test
-    public void testEmptyPath() throws Exception {
+    void testEmptyPath() throws Exception {
         final URIBuilder uribuilder = new URIBuilder("http://thathost");
         Assertions.assertTrue(uribuilder.isPathEmpty());
     }
 
     @Test
-    public void testRemoveParameter() throws Exception {
+    void testRemoveParameter() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
         final URIBuilder uribuilder = new URIBuilder(uri);
         Assertions.assertFalse(uribuilder.isQueryEmpty());
@@ -311,7 +311,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testRemoveQuery() throws Exception {
+    void testRemoveQuery() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff", null);
         final URIBuilder uribuilder = new URIBuilder(uri).removeQuery();
         final URI result = uribuilder.build();
@@ -319,7 +319,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetAuthorityFromNamedEndpointHost() throws Exception {
+    void testSetAuthorityFromNamedEndpointHost() throws Exception {
         final Host host = Host.create("localhost:88");
         final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(host);
         // Check builder
@@ -334,7 +334,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetAuthorityFromNamedEndpointHttpHost() throws Exception {
+    void testSetAuthorityFromNamedEndpointHttpHost() throws Exception {
         final HttpHost httpHost = HttpHost.create("localhost:88");
         final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(httpHost);
         // Check builder
@@ -349,7 +349,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetAuthorityFromURIAuthority() throws Exception {
+    void testSetAuthorityFromURIAuthority() throws Exception {
         final URIAuthority authority = URIAuthority.create("u:p@localhost:88");
         final URIBuilder uribuilder = new URIBuilder().setScheme(URIScheme.HTTP.id).setAuthority(authority);
         // Check builder
@@ -366,7 +366,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetParameter() throws Exception {
+    void testSetParameter() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameter("param", "some other stuff")
                 .setParameter("blah", "blah")
@@ -376,7 +376,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testGetFirstNamedParameter() throws Exception {
+    void testGetFirstNamedParameter() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
         URIBuilder uribuilder = new URIBuilder(uri).setParameter("param", "some other stuff")
             .setParameter("blah", "blah");
@@ -391,7 +391,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetParametersWithEmptyArrayArg() throws Exception {
+    void testSetParametersWithEmptyArrayArg() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameters();
         final URI result = uribuilder.build();
@@ -399,7 +399,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetParametersWithNullArrayArg() throws Exception {
+    void testSetParametersWithNullArrayArg() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameters((NameValuePair[]) null);
         final URI result = uribuilder.build();
@@ -407,7 +407,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetParametersWithEmptyList() throws Exception {
+    void testSetParametersWithEmptyList() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameters(Collections.emptyList());
         final URI result = uribuilder.build();
@@ -415,7 +415,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetParametersWithNullList() throws Exception {
+    void testSetParametersWithNullList() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/test", "param=test", null);
         final URIBuilder uribuilder = new URIBuilder(uri).setParameters((List<NameValuePair>) null);
         final URI result = uribuilder.build();
@@ -423,7 +423,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testParameterWithSpecialChar() throws Exception {
+    void testParameterWithSpecialChar() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff", null);
         final URIBuilder uribuilder = new URIBuilder(uri).addParameter("param", "1 + 1 = 2")
             .addParameter("param", "blah&blah");
@@ -433,7 +433,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAddParameter() throws Exception {
+    void testAddParameter() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
         final URIBuilder uribuilder = new URIBuilder(uri).addParameter("param", "some other stuff")
             .addParameter("blah", "blah");
@@ -443,7 +443,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testQueryEncoding() throws Exception {
+    void testQueryEncoding() throws Exception {
         final URI uri1 = new URI("https://somehost.com/stuff?client_id=1234567890" +
                 "&redirect_uri=https%3A%2F%2Fsomehost.com%2Fblah%20blah%2F");
         final URI uri2 = new URIBuilder("https://somehost.com/stuff")
@@ -453,7 +453,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testQueryAndParameterEncoding() throws Exception {
+    void testQueryAndParameterEncoding() throws Exception {
         final URI uri1 = new URI("https://somehost.com/stuff?param1=12345&param2=67890");
         final URI uri2 = new URIBuilder("https://somehost.com/stuff")
             .setCustomQuery("this&that")
@@ -463,7 +463,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testPathEncoding() throws Exception {
+    void testPathEncoding() throws Exception {
         final URI uri1 = new URI("https://somehost.com/some%20path%20with%20blanks/");
         final URI uri2 = new URIBuilder()
             .setScheme("https")
@@ -474,7 +474,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAgainstURI() throws Exception {
+    void testAgainstURI() throws Exception {
         // Check that the URI generated by URI builder agrees with that generated by using URI directly
         final String scheme="https";
         final String host="localhost";
@@ -503,16 +503,16 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testBuildAddParametersUTF8() throws Exception {
+    void testBuildAddParametersUTF8() throws Exception {
         assertAddParameters(StandardCharsets.UTF_8);
     }
 
     @Test
-    public void testBuildAddParametersISO88591() throws Exception {
+    void testBuildAddParametersISO88591() throws Exception {
         assertAddParameters(StandardCharsets.ISO_8859_1);
     }
 
-    public void assertAddParameters(final Charset charset) throws Exception {
+    void assertAddParameters(final Charset charset) throws Exception {
         final URI uri = new URIBuilder("https://somehost.com/stuff")
                 .setCharset(charset)
                 .addParameters(createParameterList()).build();
@@ -527,16 +527,16 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testBuildSetParametersUTF8() throws Exception {
+    void testBuildSetParametersUTF8() throws Exception {
         assertSetParameters(StandardCharsets.UTF_8);
     }
 
     @Test
-    public void testBuildSetParametersISO88591() throws Exception {
+    void testBuildSetParametersISO88591() throws Exception {
         assertSetParameters(StandardCharsets.ISO_8859_1);
     }
 
-    public void assertSetParameters(final Charset charset) throws Exception {
+    void assertSetParameters(final Charset charset) throws Exception {
         final URI uri = new URIBuilder("https://somehost.com/stuff")
                 .setCharset(charset)
                 .setParameters(createParameterList()).build();
@@ -544,7 +544,7 @@ public class TestURIBuilder {
         assertBuild(charset, uri);
     }
 
-    public void assertBuild(final Charset charset, final URI uri) throws Exception {
+    void assertBuild(final Charset charset, final URI uri) {
         final String encodedData1 = PercentCodec.encode("\"1\u00aa position\"", charset);
         final String encodedData2 = PercentCodec.encode("Jos\u00e9 Abra\u00e3o", charset);
 
@@ -562,26 +562,26 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testMalformedPath() throws Exception {
+    void testMalformedPath() throws Exception {
         final String path = "@notexample.com/mypath";
         final URI uri = new URIBuilder(path).setHost("example.com").build();
         Assertions.assertEquals("example.com", uri.getHost());
     }
 
     @Test
-    public void testRelativePath() throws Exception {
+    void testRelativePath() throws Exception {
         final URI uri = new URIBuilder("./mypath").build();
         Assertions.assertEquals(new URI("./mypath"), uri);
     }
 
     @Test
-    public void testRelativePathWithAuthority() throws Exception {
+    void testRelativePathWithAuthority() throws Exception {
         final URI uri = new URIBuilder("./mypath").setHost("somehost").setScheme("http").build();
         Assertions.assertEquals(new URI("http://somehost/./mypath"), uri);
     }
 
     @Test
-    public void testTolerateNullInput() throws Exception {
+    void testTolerateNullInput() throws Exception {
         assertThat(new URIBuilder()
                         .setScheme(null)
                         .setHost("localhost")
@@ -595,7 +595,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testTolerateBlankInput() throws Exception {
+    void testTolerateBlankInput() throws Exception {
         assertThat(new URIBuilder()
                         .setScheme("")
                         .setHost("localhost")
@@ -610,7 +610,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testHttpHost() throws Exception {
+    void testHttpHost() throws Exception {
         final HttpHost httpHost = new HttpHost("http", "example.com", 1234);
         final URIBuilder uribuilder = new URIBuilder();
         uribuilder.setHttpHost(httpHost);
@@ -618,21 +618,21 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetHostWithReservedChars() throws Exception {
+    void testSetHostWithReservedChars() throws Exception {
         final URIBuilder uribuilder = new URIBuilder();
         uribuilder.setScheme("http").setHost("!example!.com");
         Assertions.assertEquals(URI.create("http://%21example%21.com"), uribuilder.build());
     }
 
     @Test
-    public void testGetHostWithReservedChars() throws Exception {
+    void testGetHostWithReservedChars() throws Exception {
         final URIBuilder uribuilder = new URIBuilder("http://someuser%21@%21example%21.com/");
         Assertions.assertEquals("!example!.com", uribuilder.getHost());
         Assertions.assertEquals("someuser!", uribuilder.getUserInfo());
     }
 
     @Test
-    public void testMultipleLeadingPathSlashes() throws Exception {
+    void testMultipleLeadingPathSlashes() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("ftp")
                 .setHost("somehost")
@@ -642,7 +642,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testNoAuthorityAndPath() throws Exception {
+    void testNoAuthorityAndPath() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("file")
                 .setPath("/blah")
@@ -651,7 +651,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetPathSegmentList() throws Exception {
+    void testSetPathSegmentList() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -661,7 +661,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetPathSegmentsVarargs() throws Exception {
+    void testSetPathSegmentsVarargs() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -671,7 +671,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetPathSegmentsRootlessList() throws Exception {
+    void testSetPathSegmentsRootlessList() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("file")
             .setPathSegmentsRootless(Arrays.asList("dir", "foo"))
@@ -680,7 +680,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSetPathSegmentsRootlessVarargs() throws Exception {
+    void testSetPathSegmentsRootlessVarargs() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("file")
             .setPathSegmentsRootless("dir", "foo")
@@ -689,7 +689,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendToExistingPath() throws Exception {
+    void testAppendToExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -701,7 +701,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendToNonExistingPath() throws Exception {
+    void testAppendToNonExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -712,7 +712,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendNullToExistingPath() throws Exception {
+    void testAppendNullToExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -723,7 +723,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendNullToNonExistingPath() throws Exception {
+    void testAppendNullToNonExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -733,7 +733,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendSegmentsVarargsToExistingPath() throws Exception {
+    void testAppendSegmentsVarargsToExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("myhost")
@@ -745,7 +745,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendSegmentsVarargsToNonExistingPath() throws Exception {
+    void testAppendSegmentsVarargsToNonExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("https")
             .setHost("somehost")
@@ -756,7 +756,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendNullSegmentsVarargs() throws Exception {
+    void testAppendNullSegmentsVarargs() throws Exception {
         final String pathSegment = null;
         final URI uri = new URIBuilder()
             .setScheme("https")
@@ -767,7 +767,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendSegmentsListToExistingPath() throws Exception {
+    void testAppendSegmentsListToExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("http")
             .setHost("myhost")
@@ -778,7 +778,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendSegmentsListToNonExistingPath() throws Exception {
+    void testAppendSegmentsListToNonExistingPath() throws Exception {
         final URI uri = new URIBuilder()
             .setScheme("http")
             .setHost("myhost")
@@ -788,7 +788,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAppendNullSegmentsList() throws Exception {
+    void testAppendNullSegmentsList() throws Exception {
         final List<String> pathSegments = null;
         final URI uri = new URIBuilder()
             .setScheme("http")
@@ -799,7 +799,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testNoAuthorityAndPathSegments() throws Exception {
+    void testNoAuthorityAndPathSegments() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("file")
                 .setPathSegments("this", "that")
@@ -808,7 +808,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testNoAuthorityAndRootlessPath() throws Exception {
+    void testNoAuthorityAndRootlessPath() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("file")
                 .setPath("blah")
@@ -817,7 +817,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testNoAuthorityAndRootlessPathSegments() throws Exception {
+    void testNoAuthorityAndRootlessPathSegments() throws Exception {
         final URI uri = new URIBuilder()
                 .setScheme("file")
                 .setPathSegmentsRootless("this", "that")
@@ -826,14 +826,14 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testOpaque() throws Exception {
+    void testOpaque() throws Exception {
         final URIBuilder uriBuilder = new URIBuilder("http://host.com");
         final URI uri = uriBuilder.build();
         assertThat(uriBuilder.isOpaque(), CoreMatchers.equalTo(uri.isOpaque()));
     }
 
     @Test
-    public void testAddParameterEncodingEquivalence() throws Exception {
+    void testAddParameterEncodingEquivalence() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/",
                 "param=stuff with spaces", null);
         final URIBuilder uribuilder = new URIBuilder().setScheme("http").setHost("localhost").setPort(80).setPath("/").addParameter(
@@ -843,21 +843,21 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testSchemeSpecificPartParametersNull() throws Exception {
+    void testSchemeSpecificPartParametersNull() throws Exception {
        final URIBuilder uribuilder = new URIBuilder("http://host.com").setParameter("par", "parvalue")
                .setSchemeSpecificPart("", (NameValuePair)null);
        Assertions.assertEquals(new URI("http://host.com?par=parvalue"), uribuilder.build());
     }
 
     @Test
-    public void testSchemeSpecificPartSetGet() throws Exception {
+    void testSchemeSpecificPartSetGet() {
        final URIBuilder uribuilder = new URIBuilder().setSchemeSpecificPart("specificpart");
        Assertions.assertEquals("specificpart", uribuilder.getSchemeSpecificPart());
     }
 
     /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
     @Test
-    public void testSchemeSpecificPartNameValuePairByRFC6068Sample() throws Exception {
+    void testSchemeSpecificPartNameValuePairByRFC6068Sample() throws Exception {
        final URIBuilder uribuilder = new URIBuilder().setScheme("mailto")
                .setSchemeSpecificPart("my@email.server", new BasicNameValuePair("subject", "mail subject"));
        final String result = uribuilder.build().toString();
@@ -867,7 +867,7 @@ public class TestURIBuilder {
 
     /** Common use case: mailto: scheme. See https://tools.ietf.org/html/rfc6068#section-2 */
     @Test
-    public void testSchemeSpecificPartNameValuePairListByRFC6068Sample() throws Exception {
+    void testSchemeSpecificPartNameValuePairListByRFC6068Sample() throws Exception {
         final List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("subject", "mail subject"));
 
@@ -878,7 +878,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testOptimize() throws Exception {
+    void testOptimize() throws Exception {
         Assertions.assertEquals("example://a/b/c/%7Bfoo%7D",
                 new URIBuilder("eXAMPLE://a/./b/../b/%63/%7bfoo%7d").optimize().build().toASCIIString());
         Assertions.assertEquals("http://www.example.com/%3C",
@@ -905,7 +905,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testIpv6Host() throws Exception {
+    void testIpv6Host() throws Exception {
         final URIBuilder builder = new URIBuilder("https://[::1]:432/path");
         final URI uri = builder.build();
         Assertions.assertEquals(432, builder.getPort());
@@ -919,7 +919,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testIpv6HostWithPortUpdate() throws Exception {
+    void testIpv6HostWithPortUpdate() throws Exception {
         // Updating the port clears URIBuilder.encodedSchemeSpecificPart
         // and bypasses the fast/simple path which preserves input.
         final URIBuilder builder = new URIBuilder("https://[::1]:432/path").setPort(123);
@@ -935,7 +935,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testBuilderWithUnbracketedIpv6Host() throws Exception {
+    void testBuilderWithUnbracketedIpv6Host() throws Exception {
         final URIBuilder builder = new URIBuilder().setScheme("https").setHost("::1").setPort(443).setPath("/path");
         final URI uri = builder.build();
         Assertions.assertEquals("https", builder.getScheme());
@@ -949,7 +949,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testHttpsUriWithEmptyHost() {
+    void testHttpsUriWithEmptyHost() {
         final URIBuilder uribuilder = new URIBuilder()
                 .setScheme("https")
                 .setUserInfo("stuff")
@@ -962,7 +962,7 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testHttpUriWithEmptyHost() {
+    void testHttpUriWithEmptyHost() {
         final URIBuilder uribuilder = new URIBuilder()
                 .setScheme("http")
                 .setUserInfo("stuff")

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestWWWFormCodec.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestWWWFormCodec.java
@@ -39,7 +39,7 @@ import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
-public class TestWWWFormCodec {
+class TestWWWFormCodec {
 
     private static final String CH_HELLO = "\u0047\u0072\u00FC\u0065\u007A\u0069\u005F\u007A\u00E4\u006D\u00E4";
     private static final String RU_HELLO = "\u0412\u0441\u0435\u043C\u005F\u043F\u0440\u0438\u0432\u0435\u0442";
@@ -49,7 +49,7 @@ public class TestWWWFormCodec {
     }
 
     @Test
-    public void testParse() throws Exception {
+    void testParse() {
         assertThat(parse(""), NameValuePairListMatcher.isEmpty());
         assertThat(parse("Name0"),
                 NameValuePairListMatcher.equalsTo(new BasicNameValuePair("Name0", null)));
@@ -94,7 +94,7 @@ public class TestWWWFormCodec {
     }
 
     @Test
-    public void testFormat() throws Exception {
+    void testFormat() {
         assertThat(format(new BasicNameValuePair("Name0", null)), CoreMatchers.equalTo("Name0"));
         assertThat(format(new BasicNameValuePair("Name1", "Value1")), CoreMatchers.equalTo("Name1=Value1"));
         assertThat(format(new BasicNameValuePair("Name2", "")), CoreMatchers.equalTo("Name2="));

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestLaxConnPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestLaxConnPool.java
@@ -45,10 +45,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestLaxConnPool {
+class TestLaxConnPool {
 
     @Test
-    public void testEmptyPool() throws Exception {
+    void testEmptyPool() {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
             final PoolStats totals = pool.getTotalStats();
             Assertions.assertEquals(0, totals.getAvailable());
@@ -66,13 +66,13 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testInvalidConstruction() throws Exception {
+    void testInvalidConstruction() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 new LaxConnPool<String, HttpConnection>(-1));
     }
 
     @Test
-    public void testLeaseRelease() throws Exception {
+    void testLeaseRelease() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn3 = Mockito.mock(HttpConnection.class);
@@ -107,7 +107,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testLeaseReleaseMultiThreaded() throws Exception {
+    void testLeaseReleaseMultiThreaded() throws Exception {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
 
             final int c = 10;
@@ -152,21 +152,21 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testLeaseInvalid() throws Exception {
+    void testLeaseInvalid() {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
             Assertions.assertThrows(NullPointerException.class,
                     () -> pool.lease(null, null, Timeout.ZERO_MILLISECONDS, null));
         }}
 
     @Test
-    public void testReleaseUnknownEntry() throws Exception {
+    void testReleaseUnknownEntry() {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
             Assertions.assertThrows(IllegalStateException.class, () -> pool.release(new PoolEntry<>("somehost"), true));
         }
     }
 
     @Test
-    public void testMaxLimits() throws Exception {
+    void testMaxLimits() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn3 = Mockito.mock(HttpConnection.class);
@@ -246,7 +246,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testCreateNewIfExpired() throws Exception {
+    void testCreateNewIfExpired() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
 
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
@@ -280,7 +280,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testCloseExpired() throws Exception {
+    void testCloseExpired() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
 
@@ -323,7 +323,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testCloseIdle() throws Exception {
+    void testCloseIdle() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
 
@@ -381,7 +381,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testLeaseRequestTimeout() throws Exception {
+    void testLeaseRequestTimeout() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
 
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(1)) {
@@ -407,7 +407,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testLeaseRequestCanceled() throws Exception {
+    void testLeaseRequestCanceled() throws Exception {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(1)) {
 
             final Future<PoolEntry<String, HttpConnection>> future1 = pool.lease("somehost", null,
@@ -431,14 +431,14 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testGetStatsInvalid() throws Exception {
+    void testGetStatsInvalid() {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
             Assertions.assertThrows(NullPointerException.class, () -> pool.getStats(null));
         }
     }
 
     @Test
-    public void testSetMaxInvalid() throws Exception {
+    void testSetMaxInvalid() {
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {
             Assertions.assertThrows(NullPointerException.class, () -> pool.setMaxPerRoute(null, 1));
             Assertions.assertThrows(IllegalArgumentException.class, () -> pool.setDefaultMaxPerRoute(-1));
@@ -446,7 +446,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testShutdown() throws Exception {
+    void testShutdown() {
         final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2);
         pool.close(CloseMode.GRACEFUL);
         Assertions.assertThrows(IllegalStateException.class, () -> pool.lease("somehost", null));
@@ -455,7 +455,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testClose() {
+    void testClose() {
         final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2);
         pool.setMaxPerRoute("someRoute", 2);
         pool.close();
@@ -466,7 +466,7 @@ public class TestLaxConnPool {
     }
 
     @Test
-    public void testGetMaxPerRoute() {
+    void testGetMaxPerRoute() {
         final String route = "someRoute";
         final int max = 2;
         try (final LaxConnPool<String, HttpConnection> pool = new LaxConnPool<>(2)) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestPoolEntry.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestPoolEntry.java
@@ -39,19 +39,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestPoolEntry {
+class TestPoolEntry {
 
     private AtomicLong count;
     private Supplier<Long> currentTimeSupplier;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         count = new AtomicLong(1);
         currentTimeSupplier = () -> count.addAndGet(1);
     }
 
     @Test
-    public void testBasics() throws Exception {
+    void testBasics() {
         final PoolEntry<String, HttpConnection> entry1 = new PoolEntry<>(
                 "route1", TimeValue.of(10L, TimeUnit.MILLISECONDS), currentTimeSupplier);
 
@@ -72,13 +72,13 @@ public class TestPoolEntry {
     }
 
     @Test
-    public void testNullConstructor() throws Exception {
+    void testNullConstructor() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 new PoolEntry<String, HttpConnection>(null));
     }
 
     @Test
-    public void testValidInfinitely() throws Exception {
+    void testValidInfinitely() {
         final PoolEntry<String, HttpConnection> entry1 = new PoolEntry<>(
                 "route1", TimeValue.ZERO_MILLISECONDS, currentTimeSupplier);
         entry1.assignConnection(Mockito.mock(HttpConnection.class));
@@ -87,7 +87,7 @@ public class TestPoolEntry {
     }
 
     @Test
-    public void testExpiry() throws Exception {
+    void testExpiry() {
         final PoolEntry<String, HttpConnection> entry1 = new PoolEntry<>(
                 "route1", TimeValue.ZERO_MILLISECONDS, currentTimeSupplier);
         entry1.assignConnection(Mockito.mock(HttpConnection.class));
@@ -109,7 +109,7 @@ public class TestPoolEntry {
     }
 
     @Test
-    public void testInvalidExpiry() throws Exception {
+    void testInvalidExpiry() {
         final PoolEntry<String, HttpConnection> entry = new PoolEntry<>(
                 "route1", TimeValue.of(0L, TimeUnit.MILLISECONDS), currentTimeSupplier);
         Assertions.assertThrows(NullPointerException.class, () ->
@@ -117,7 +117,7 @@ public class TestPoolEntry {
     }
 
     @Test
-    public void testExpiryDoesNotOverflow() {
+    void testExpiryDoesNotOverflow() {
         final PoolEntry<String, HttpConnection> entry = new PoolEntry<>(
                 "route1", TimeValue.of(Long.MAX_VALUE, TimeUnit.MILLISECONDS), currentTimeSupplier);
         entry.assignConnection(Mockito.mock(HttpConnection.class));

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestStrictConnPool.java
@@ -48,10 +48,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-public class TestStrictConnPool {
+class TestStrictConnPool {
 
     @Test
-    public void testEmptyPool() throws Exception {
+    void testEmptyPool() {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 10)) {
             final PoolStats totals = pool.getTotalStats();
             Assertions.assertEquals(0, totals.getAvailable());
@@ -69,7 +69,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testInvalidConstruction() throws Exception {
+    void testInvalidConstruction() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 new StrictConnPool<String, HttpConnection>(-1, 1));
         Assertions.assertThrows(IllegalArgumentException.class, () ->
@@ -77,7 +77,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseRelease() throws Exception {
+    void testLeaseRelease() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn3 = Mockito.mock(HttpConnection.class);
@@ -112,7 +112,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseReleaseMultiThreaded() throws Exception {
+    void testLeaseReleaseMultiThreaded() throws Exception {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 10)) {
 
             final int c = 10;
@@ -157,7 +157,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseInvalid() throws Exception {
+    void testLeaseInvalid() {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 10)) {
             Assertions.assertThrows(NullPointerException.class, () ->
                     pool.lease(null, null, Timeout.ZERO_MILLISECONDS, null));
@@ -167,7 +167,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testReleaseUnknownEntry() throws Exception {
+    void testReleaseUnknownEntry() {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 2)) {
                 Assertions.assertThrows(IllegalStateException.class, () ->
                     pool.release(new PoolEntry<>("somehost"), true));
@@ -175,7 +175,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testMaxLimits() throws Exception {
+    void testMaxLimits() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn3 = Mockito.mock(HttpConnection.class);
@@ -256,7 +256,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testConnectionRedistributionOnTotalMaxLimit() throws Exception {
+    void testConnectionRedistributionOnTotalMaxLimit() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn3 = Mockito.mock(HttpConnection.class);
@@ -343,7 +343,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testStatefulConnectionRedistributionOnPerRouteMaxLimit() throws Exception {
+    void testStatefulConnectionRedistributionOnPerRouteMaxLimit() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
 
@@ -407,7 +407,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testCreateNewIfExpired() throws Exception {
+    void testCreateNewIfExpired() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
 
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 2)) {
@@ -441,7 +441,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testCloseExpired() throws Exception {
+    void testCloseExpired() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
 
@@ -484,7 +484,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testCloseIdle() throws Exception {
+    void testCloseIdle() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
         final HttpConnection conn2 = Mockito.mock(HttpConnection.class);
 
@@ -540,7 +540,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseRequestTimeout() throws Exception {
+    void testLeaseRequestTimeout() throws Exception {
         final HttpConnection conn1 = Mockito.mock(HttpConnection.class);
 
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(1, 1)) {
@@ -581,7 +581,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseRequestLockTimeout() throws Exception {
+    void testLeaseRequestLockTimeout() throws Exception {
         final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(1, 1);
         final CountDownLatch lockHeld = new CountDownLatch(1);
         final Thread holdInternalLock = new HoldInternalLockThread(pool, lockHeld);
@@ -599,7 +599,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseRequestInterrupted() throws Exception {
+    void testLeaseRequestInterrupted() throws Exception {
         final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(1, 1);
         final CountDownLatch lockHeld = new CountDownLatch(1);
         final Thread holdInternalLock = new HoldInternalLockThread(pool, lockHeld);
@@ -617,7 +617,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testLeaseRequestCanceled() throws Exception {
+    void testLeaseRequestCanceled() throws Exception {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(1, 1)) {
 
             final Future<PoolEntry<String, HttpConnection>> future1 = pool.lease("somehost", null,
@@ -641,14 +641,14 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testGetStatsInvalid() throws Exception {
+    void testGetStatsInvalid() {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 2)) {
             Assertions.assertThrows(NullPointerException.class, () -> pool.getStats(null));
         }
     }
 
     @Test
-    public void testSetMaxInvalid() throws Exception {
+    void testSetMaxInvalid() {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 2)) {
             Assertions.assertThrows(IllegalArgumentException.class, () ->
                     pool.setMaxTotal(-1));
@@ -660,7 +660,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testSetMaxPerRoute() throws Exception {
+    void testSetMaxPerRoute() {
         try (final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 2)) {
             pool.setMaxPerRoute("somehost", 1);
             Assertions.assertEquals(1, pool.getMaxPerRoute("somehost"));
@@ -672,7 +672,7 @@ public class TestStrictConnPool {
     }
 
     @Test
-    public void testShutdown() throws Exception {
+    void testShutdown() {
         final StrictConnPool<String, HttpConnection> pool = new StrictConnPool<>(2, 2);
         pool.close(CloseMode.GRACEFUL);
         Assertions.assertThrows(IllegalStateException.class, () -> pool.lease("somehost", null));

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/IOReactorConfigTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/IOReactorConfigTest.java
@@ -33,9 +33,9 @@ import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class IOReactorConfigTest {
+class IOReactorConfigTest {
     @Test
-    public void testCustomIOReactorConfig() throws Exception {
+    void testCustomIOReactorConfig() {
         final IOReactorConfig reactorConfig = IOReactorConfig.custom()
                 .setSelectInterval(TimeValue.ofMilliseconds(500))
                 .setIoThreadCount(2)

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/IOWorkersTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/IOWorkersTest.java
@@ -30,10 +30,10 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 
-public class IOWorkersTest {
+class IOWorkersTest {
 
     @Test
-    public void testIndexOverflow() {
+    void testIndexOverflow() {
         final SingleCoreIOReactor reactor = new SingleCoreIOReactor(null, mock(IOEventHandlerFactory.class), IOReactorConfig.DEFAULT, null, null, null);
         final IOWorkers.Selector selector = IOWorkers.newSelector(new SingleCoreIOReactor[]{reactor, reactor, reactor});
         for (long i = Integer.MAX_VALUE - 10; i < (long) Integer.MAX_VALUE + 10; i++) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/TestAbstractIOSessionPool.java
@@ -48,7 +48,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class TestAbstractIOSessionPool {
+class TestAbstractIOSessionPool {
 
     @Mock
     private Future<IOSession> connectFuture;
@@ -66,7 +66,7 @@ public class TestAbstractIOSessionPool {
     private AbstractIOSessionPool<String> impl;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         MockitoAnnotations.openMocks(this);
         impl = Mockito.mock(AbstractIOSessionPool.class, Mockito.withSettings()
                 .defaultAnswer(Answers.CALLS_REAL_METHODS)
@@ -74,7 +74,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testGetSessions() throws Exception {
+    void testGetSessions() throws Exception {
 
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
@@ -134,7 +134,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testGetSessionConnectFailure() throws Exception {
+    void testGetSessionConnectFailure() {
 
         Mockito.when(impl.connectSession(
                 ArgumentMatchers.anyString(),
@@ -166,7 +166,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testShutdownPool() throws Exception {
+    void testShutdownPool() {
         final AbstractIOSessionPool.PoolEntry entry1 = impl.getPoolEntry("host1");
         assertThat(entry1, CoreMatchers.notNullValue());
         entry1.session = ioSession1;
@@ -191,7 +191,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testCloseIdleSessions() throws Exception {
+    void testCloseIdleSessions() {
         final AbstractIOSessionPool.PoolEntry entry1 = impl.getPoolEntry("host1");
         assertThat(entry1, CoreMatchers.notNullValue());
         entry1.session = ioSession1;
@@ -210,7 +210,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testEnumSessions() throws Exception {
+    void testEnumSessions() {
         final AbstractIOSessionPool.PoolEntry entry1 = impl.getPoolEntry("host1");
         assertThat(entry1, CoreMatchers.notNullValue());
         entry1.session = ioSession1;
@@ -225,7 +225,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testGetSessionReconnectAfterValidate() throws Exception {
+    void testGetSessionReconnectAfterValidate() {
         final AbstractIOSessionPool.PoolEntry entry1 = impl.getPoolEntry("somehost");
         assertThat(entry1, CoreMatchers.notNullValue());
         entry1.session = ioSession1;
@@ -246,7 +246,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testGetSessionReconnectIfClosed() throws Exception {
+    void testGetSessionReconnectIfClosed() {
         final AbstractIOSessionPool.PoolEntry entry1 = impl.getPoolEntry("somehost");
         assertThat(entry1, CoreMatchers.notNullValue());
         entry1.session = ioSession1;
@@ -262,7 +262,7 @@ public class TestAbstractIOSessionPool {
     }
 
     @Test
-    public void testGetSessionConnectUnknownHost() throws Exception {
+    void testGetSessionConnectUnknownHost() {
 
         Mockito.when(connectFuture.isDone()).thenReturn(true);
         Mockito.when(impl.connectSession(

--- a/httpcore5/src/test/java/org/apache/hc/core5/reactor/ssl/SSLIOSessionTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/reactor/ssl/SSLIOSessionTest.java
@@ -71,7 +71,7 @@ class SSLIOSessionTest {
     private SSLSession sslSession;
 
     @BeforeEach
-    public void setUp() throws SSLException {
+    void setUp() throws SSLException {
         final String protocol = "TestProtocol";
 
         // Arrange

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/SSLContextsTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/SSLContextsTest.java
@@ -43,7 +43,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.junit.jupiter.api.Test;
 
-public class SSLContextsTest {
+class SSLContextsTest {
 
     @Test
     void createDefault() {

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
@@ -525,11 +525,11 @@ class TestSSLContextBuilder {
         try (final SSLSocket clientSocket = (SSLSocket) clientSslContext.getSocketFactory().createSocket()) {
             clientSocket.connect(new InetSocketAddress("localhost", localPort), TIMEOUT.toMillisecondsIntBound());
             clientSocket.setSoTimeout(TIMEOUT.toMillisecondsIntBound());
-
-            clientSocket.startHandshake();
-            final InputStream inputStream = clientSocket.getInputStream();
-
-            Assertions.assertThrows(IOException.class, inputStream::read);
+            Assertions.assertThrows(IOException.class, () -> {
+                clientSocket.startHandshake();
+                final InputStream inputStream = clientSocket.getInputStream();
+                inputStream.read();
+            });
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
@@ -525,11 +525,11 @@ class TestSSLContextBuilder {
         try (final SSLSocket clientSocket = (SSLSocket) clientSslContext.getSocketFactory().createSocket()) {
             clientSocket.connect(new InetSocketAddress("localhost", localPort), TIMEOUT.toMillisecondsIntBound());
             clientSocket.setSoTimeout(TIMEOUT.toMillisecondsIntBound());
-            Assertions.assertThrows(IOException.class, () -> {
-                clientSocket.startHandshake();
-                final InputStream inputStream = clientSocket.getInputStream();
-                inputStream.read();
-            });
+
+            clientSocket.startHandshake();
+            final InputStream inputStream = clientSocket.getInputStream();
+
+            Assertions.assertThrows(IOException.class, inputStream::read);
         }
     }
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/ssl/TestSSLContextBuilder.java
@@ -69,7 +69,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link SSLContextBuilder}.
  */
-public class TestSSLContextBuilder {
+class TestSSLContextBuilder {
 
     static final String PROVIDER_SUN_JSSE = "SunJSSE";
     static final String PROVIDER_SUN_JCE = "SunJCE";
@@ -82,7 +82,7 @@ public class TestSSLContextBuilder {
     private ExecutorService executorService;
 
     @AfterEach
-    public void cleanup() throws Exception {
+    void cleanup() throws Exception {
         if (this.executorService != null) {
             this.executorService.shutdown();
             this.executorService.awaitTermination(5, TimeUnit.SECONDS);
@@ -94,7 +94,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildAllDefaults() throws Exception {
+    void testBuildAllDefaults() throws Exception {
         final SSLContext sslContext = SSLContextBuilder.create()
                 .setKeyStoreType(KeyStore.getDefaultType())
                 .setKeyManagerFactoryAlgorithm(KeyManagerFactory.getDefaultAlgorithm())
@@ -111,7 +111,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildAllNull() throws Exception {
+    void testBuildAllNull() throws Exception {
         final SSLContext sslContext = SSLContextBuilder.create()
                 .setKeyStoreType(null)
                 .setKeyManagerFactoryAlgorithm(null)
@@ -128,7 +128,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildAllNull_deprecated() throws Exception {
+    void testBuildAllNull_deprecated() throws Exception {
         final SSLContext sslContext = SSLContextBuilder.create()
                 .setProtocol(null)
                 .setSecureRandom(null)
@@ -140,12 +140,12 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildDefault() throws Exception {
-        new SSLContextBuilder().build();
+    void testBuildDefault() {
+        Assertions.assertDoesNotThrow(() -> new SSLContextBuilder().build());
     }
 
     @Test
-    public void testBuildNoSuchKeyManagerFactoryAlgorithm() throws Exception {
+    void testBuildNoSuchKeyManagerFactoryAlgorithm() {
         final URL resource1 = getResource("/test-keypasswd.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "password";
@@ -157,7 +157,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildNoSuchKeyStoreType() throws Exception {
+    void testBuildNoSuchKeyStoreType() {
         final URL resource1 = getResource("/test-keypasswd.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "password";
@@ -169,7 +169,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildNoSuchTrustManagerFactoryAlgorithm() throws Exception {
+    void testBuildNoSuchTrustManagerFactoryAlgorithm() {
         final URL resource1 = getResource("/test-keypasswd.p12");
         final String storePassword = "nopassword";
         Assertions.assertThrows(NoSuchAlgorithmException.class, () ->
@@ -180,7 +180,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildWithProvider() throws Exception {
+    void testBuildWithProvider() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -193,7 +193,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildWithProviderName() throws Exception {
+    void testBuildWithProviderName() throws Exception {
 
         final DummyProvider provider = new DummyProvider();
         Security.insertProviderAt(provider, 1);
@@ -214,7 +214,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildKSWithNoSuchProvider() {
+    void testBuildKSWithNoSuchProvider() {
         Assertions.assertThrows(NoSuchProviderException.class,
                 () -> SSLContextBuilder.create()
                 .setKeyStoreProvider("no-such-provider")
@@ -222,7 +222,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildKSWithProvider() throws Exception {
+    void testBuildKSWithProvider() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -235,7 +235,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildKSWithProviderName() throws Exception {
+    void testBuildKSWithProviderName() throws Exception {
 
         final DummyProvider provider = new DummyProvider();
         Security.insertProviderAt(provider, 1);
@@ -256,7 +256,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildTSWithNoSuchProvider() {
+    void testBuildTSWithNoSuchProvider() {
         Assertions.assertThrows(NoSuchProviderException.class, ()->
             SSLContextBuilder.create()
                     .setTrustStoreProvider("no-such-provider")
@@ -264,7 +264,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildTSWithProvider() throws Exception {
+    void testBuildTSWithProvider() throws Exception {
         final DummyProvider provider = new DummyProvider();
         SSLContextBuilder.create()
                 .setTrustStoreProvider(provider)
@@ -274,7 +274,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testBuildTSWithProviderName() throws Exception {
+    void testBuildTSWithProviderName() throws Exception {
 
         final DummyProvider provider = new DummyProvider();
         Security.insertProviderAt(provider, 1);
@@ -293,7 +293,7 @@ public class TestSSLContextBuilder {
 
 
     @Test
-    public void testKeyWithAlternatePasswordInvalid() throws Exception {
+    void testKeyWithAlternatePasswordInvalid() {
         final URL resource1 = getResource("/test-keypasswd.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "!password";
@@ -305,7 +305,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeServerTrusted() throws Exception {
+    void testSSLHandshakeServerTrusted() throws Exception {
         final URL resource1 = getResource("/test.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -345,7 +345,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeServerNotTrusted() throws Exception {
+    void testSSLHandshakeServerNotTrusted() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -377,7 +377,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeServerCustomTrustStrategy() throws Exception {
+    void testSSLHandshakeServerCustomTrustStrategy() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -444,7 +444,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeClientUnauthenticated() throws Exception {
+    void testSSLHandshakeClientUnauthenticated() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -496,7 +496,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeClientUnauthenticatedError() throws Exception {
+    void testSSLHandshakeClientUnauthenticatedError() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -534,7 +534,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeClientAuthenticated() throws Exception {
+    void testSSLHandshakeClientAuthenticated() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -580,7 +580,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeClientAuthenticatedPrivateKeyStrategy() throws Exception {
+    void testSSLHandshakeClientAuthenticatedPrivateKeyStrategy() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -631,7 +631,7 @@ public class TestSSLContextBuilder {
 
 
     @Test
-    public void testSSLHandshakeProtocolMismatch1() throws Exception {
+    void testSSLHandshakeProtocolMismatch1() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -674,7 +674,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testSSLHandshakeProtocolMismatch2() throws Exception {
+    void testSSLHandshakeProtocolMismatch2() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";
@@ -718,7 +718,7 @@ public class TestSSLContextBuilder {
     }
 
     @Test
-    public void testJSSEEndpointIdentification() throws Exception {
+    void testJSSEEndpointIdentification() throws Exception {
         final URL resource1 = getResource("/test-server.p12");
         final String storePassword = "nopassword";
         final String keyPassword = "nopassword";

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestArgs.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestArgs.java
@@ -42,226 +42,226 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link Args}.
  */
-public class TestArgs {
+class TestArgs {
 
     @Test
-    public void testArgCheckPass() {
+    void testArgCheckPass() {
         Args.check(true, "All is well");
     }
 
     @Test
-    public void testArgCheckFail() {
+    void testArgCheckFail() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.check(false, "Oopsie"));
     }
 
     @Test
-    public void testArgNotNullPass() {
+    void testArgNotNullPass() {
         final String stuff = "stuff";
         Assertions.assertSame(stuff, Args.notNull(stuff, "Stuff"));
     }
 
     @Test
-    public void testArgNotNullFail() {
+    void testArgNotNullFail() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 Args.notNull(null, "Stuff"));
     }
 
     @Test
-    public void testArgNotEmptyPass() {
+    void testArgNotEmptyPass() {
         final String stuff = "stuff";
         Assertions.assertSame(stuff, Args.notEmpty(stuff, "Stuff"));
     }
 
     @Test
-    public void testArgNotEmptyFail1() {
+    void testArgNotEmptyFail1() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 Args.notEmpty((String) null, "Stuff"));
     }
 
     @Test
-    public void testArgNotEmptyFail2() {
+    void testArgNotEmptyFail2() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.notEmpty("", "Stuff"));
     }
 
     @Test
-    public void testArgNotBlankFail1() {
+    void testArgNotBlankFail1() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 Args.notBlank((String) null, "Stuff"));
     }
 
     @Test
-    public void testArgNotBlankFail2() {
+    void testArgNotBlankFail2() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.notBlank("", "Stuff"));
     }
 
     @Test
-    public void testArgNotBlankFail3() {
+    void testArgNotBlankFail3() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.notBlank(" \t \n\r", "Stuff"));
     }
 
     @Test
-    public void testArgCollectionNotEmptyPass() {
+    void testArgCollectionNotEmptyPass() {
         final List<String> list = Collections.singletonList("stuff");
         Assertions.assertSame(list, Args.notEmpty(list, "List"));
     }
 
     @Test
-    public void testArgCollectionNotEmptyFail1() {
+    void testArgCollectionNotEmptyFail1() {
         Assertions.assertThrows(NullPointerException.class, () ->
                 Args.notEmpty((List<?>) null, "List"));
     }
 
     @Test
-    public void testArgCollectionNotEmptyFail2() {
+    void testArgCollectionNotEmptyFail2() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.notEmpty(Collections.emptyList(), "List"));
     }
 
     @Test
-    public void testPositiveIntPass() {
+    void testPositiveIntPass() {
         Assertions.assertEquals(1, Args.positive(1, "Number"));
     }
 
     @Test
-    public void testPositiveIntFail1() {
+    void testPositiveIntFail1() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.positive(-1, "Number"));
     }
 
     @Test
-    public void testPositiveIntFail2() {
+    void testPositiveIntFail2() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.positive(0, "Number"));
     }
 
     @Test
-    public void testPositiveLongPass() {
+    void testPositiveLongPass() {
         Assertions.assertEquals(1L, Args.positive(1L, "Number"));
     }
 
     @Test
-    public void testPositiveTimeValuePass() throws ParseException {
+    void testPositiveTimeValuePass() throws ParseException {
         final Timeout timeout = Timeout.parse("1200 MILLISECONDS");
         Assertions.assertEquals(timeout, Args.positive(timeout, "No Error"));
     }
     @Test
-    public void testPositiveLongFail1() {
+    void testPositiveLongFail1() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.positive(-1L, "Number"));
     }
 
     @Test
-    public void testPositiveLongFail2() {
+    void testPositiveLongFail2() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.positive(0L, "Number"));
     }
 
     @Test
-    public void testNotNegativeIntPass1() {
+    void testNotNegativeIntPass1() {
         Assertions.assertEquals(1, Args.notNegative(1, "Number"));
     }
 
     @Test
-    public void testNotNegativeIntPass2() {
+    void testNotNegativeIntPass2() {
         Assertions.assertEquals(0, Args.notNegative(0, "Number"));
     }
 
     @Test
-    public void testNotNegativeIntFail1() {
+    void testNotNegativeIntFail1() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.notNegative(-1, "Number"));
     }
 
     @Test
-    public void testNotNegativeLongPass1() {
+    void testNotNegativeLongPass1() {
         Assertions.assertEquals(1L, Args.notNegative(1L, "Number"));
     }
 
     @Test
-    public void testNotNegativeLongPass2() {
+    void testNotNegativeLongPass2() {
         Assertions.assertEquals(0L, Args.notNegative(0L, "Number"));
     }
 
     @Test
-    public void testNotNegativeLongFail1() {
+    void testNotNegativeLongFail1() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.notNegative(-1L, "Number"));
     }
 
     @Test
-    public void testIntSmallestRangeOK() {
+    void testIntSmallestRangeOK() {
         Args.checkRange(0, 0, 0, "Number");
     }
 
     @Test
-    public void testIntSmallestRangeFailLow() {
+    void testIntSmallestRangeFailLow() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(-1, 0, 0, "Number"));
     }
 
     @Test
-    public void testIntRangeFailLow() {
+    void testIntRangeFailLow() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(-101, -100, 100, "Number"));
     }
 
     @Test
-    public void testIntRangeFailHigh() {
+    void testIntRangeFailHigh() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(101, -100, 100, "Number"));
     }
 
     @Test
-    public void testIntSmallestRangeFailHigh() {
+    void testIntSmallestRangeFailHigh() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(1, 0, 0, "Number"));
     }
 
     @Test
-    public void testIntFullRangeOK() {
+    void testIntFullRangeOK() {
         Args.checkRange(0, Integer.MIN_VALUE, Integer.MAX_VALUE, "Number");
     }
 
     @Test
-    public void testLongSmallestRangeOK() {
+    void testLongSmallestRangeOK() {
         Args.checkRange(0L, 0L, 0L, "Number");
     }
 
     @Test
-    public void testLongSmallestRangeFailLow() {
+    void testLongSmallestRangeFailLow() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(-1L, 0L, 0L, "Number"));
     }
 
     @Test
-    public void testLongRangeFailLow() {
+    void testLongRangeFailLow() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(-101L, -100L, 100L, "Number"));
     }
 
     @Test
-    public void testLongRangeFailHigh() {
+    void testLongRangeFailHigh() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(101L, -100L, 100L, "Number"));
     }
 
     @Test
-    public void testLongSmallestRangeFailHigh() {
+    void testLongSmallestRangeFailHigh() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.checkRange(1L, 0L, 0L, "Number"));
     }
 
     @Test
-    public void testLongFullRangeOK() {
+    void testLongFullRangeOK() {
         Args.checkRange(0L, Long.MIN_VALUE, Long.MAX_VALUE, "Number");
     }
 
     @Test
-    public void testIsEmpty() {
+    void testIsEmpty() {
 
         final String[] NON_EMPTY_ARRAY = new String[] { "ABG", "NML", };
 
@@ -288,13 +288,13 @@ public class TestArgs {
     }
 
     @Test
-    public void testcontainsNoBlanks() {
+    void testContainsNoBlanks() {
         final String stuff = "abg";
         Assertions.assertSame(stuff, Args.containsNoBlanks(stuff, "abg"));
     }
 
     @Test
-    public void check() {
+    void check() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Args.check(false, "Error,", "ABG"));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestAsserts.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestAsserts.java
@@ -33,51 +33,51 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link Asserts}.
  */
-public class TestAsserts {
+class TestAsserts {
 
     @Test
-    public void testExpressionCheckPass() {
+    void testExpressionCheckPass() {
         Asserts.check(true, "All is well");
     }
 
     @Test
-    public void testExpressionCheckFail() {
+    void testExpressionCheckFail() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.check(false, "Oopsie"));
     }
 
     @Test
-    public void testExpressionNotNullFail() {
+    void testExpressionNotNullFail() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.notNull(null, "Stuff"));
     }
 
     @Test
-    public void testExpressionNotEmptyFail1() {
+    void testExpressionNotEmptyFail1() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.notEmpty(null, "Stuff"));
     }
 
     @Test
-    public void testExpressionNotEmptyFail2() {
+    void testExpressionNotEmptyFail2() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.notEmpty("", "Stuff"));
     }
 
     @Test
-    public void testExpressionNotEmptyBlank1() {
+    void testExpressionNotEmptyBlank1() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.notBlank(null, "Stuff"));
     }
 
     @Test
-    public void testExpressionNotEmptyBlank2() {
+    void testExpressionNotEmptyBlank2() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.notBlank("", "Stuff"));
     }
 
     @Test
-    public void testExpressionNotBlankFail3() {
+    void testExpressionNotBlankFail3() {
         Assertions.assertThrows(IllegalStateException.class, () ->
                 Asserts.notBlank(" \t \n\r", "Stuff"));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestByteArrayBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestByteArrayBuffer.java
@@ -41,10 +41,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link ByteArrayBuffer}.
  *
  */
-public class TestByteArrayBuffer {
+class TestByteArrayBuffer {
 
     @Test
-    public void testConstructor() throws Exception {
+    void testConstructor() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
         Assertions.assertEquals(16, buffer.capacity());
         Assertions.assertEquals(0, buffer.length());
@@ -54,7 +54,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testSimpleAppend() throws Exception {
+    void testSimpleAppend() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(16);
         Assertions.assertEquals(16, buffer.capacity());
         Assertions.assertEquals(0, buffer.length());
@@ -86,7 +86,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testExpandAppend() throws Exception {
+    void testExpandAppend() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         Assertions.assertEquals(4, buffer.capacity());
 
@@ -105,7 +105,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testAppendHeapByteBuffer() {
+    void testAppendHeapByteBuffer() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         Assertions.assertEquals(4, buffer.capacity());
 
@@ -126,7 +126,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testAppendHeapByteBufferWithOffset() {
+    void testAppendHeapByteBufferWithOffset() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         Assertions.assertEquals(4, buffer.capacity());
 
@@ -150,7 +150,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testAppendDirectByteBuffer() {
+    void testAppendDirectByteBuffer() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         Assertions.assertEquals(4, buffer.capacity());
 
@@ -172,7 +172,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testInvalidAppend() throws Exception {
+    void testInvalidAppend() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         buffer.append((byte[])null, 0, 0);
 
@@ -185,7 +185,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testAppendOneByte() throws Exception {
+    void testAppendOneByte() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         Assertions.assertEquals(4, buffer.capacity());
 
@@ -202,21 +202,21 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testSetLength() throws Exception {
+    void testSetLength() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         buffer.setLength(2);
         Assertions.assertEquals(2, buffer.length());
     }
 
     @Test
-    public void testSetInvalidLength() throws Exception {
+    void testSetInvalidLength() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> buffer.setLength(-2));
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> buffer.setLength(200));
     }
 
     @Test
-    public void testEnsureCapacity() throws Exception {
+    void testEnsureCapacity() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         buffer.ensureCapacity(2);
         Assertions.assertEquals(4, buffer.capacity());
@@ -225,7 +225,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testIndexOf() throws Exception {
+    void testIndexOf() {
         final byte COLON = (byte) ':';
         final byte COMMA = (byte) ',';
         final byte[] bytes = "name1: value1; name2: value2".getBytes(StandardCharsets.US_ASCII);
@@ -244,7 +244,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testAppendCharArrayAsAscii() throws Exception {
+    void testAppendCharArrayAsAscii() {
         final String s1 = "stuff";
         final String s2 = " and more stuff";
         final char[] b1 = s1.toCharArray();
@@ -258,28 +258,28 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testAppendNullCharArray() throws Exception {
+    void testAppendNullCharArray() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(8);
         buffer.append((char[])null, 0, 0);
         Assertions.assertEquals(0, buffer.length());
     }
 
     @Test
-    public void testAppendEmptyCharArray() throws Exception {
+    void testAppendEmptyCharArray() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(8);
         buffer.append(new char[] {}, 0, 0);
         Assertions.assertEquals(0, buffer.length());
     }
 
     @Test
-    public void testAppendNullCharArrayBuffer() throws Exception {
+    void testAppendNullCharArrayBuffer() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(8);
         buffer.append((CharArrayBuffer)null, 0, 0);
         Assertions.assertEquals(0, buffer.length());
     }
 
     @Test
-    public void testAppendNullByteBuffer() throws Exception {
+    void testAppendNullByteBuffer() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(8);
         final ByteBuffer nullBuffer = null;
         buffer.append(nullBuffer);
@@ -287,7 +287,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testInvalidAppendCharArrayAsAscii() throws Exception {
+    void testInvalidAppendCharArrayAsAscii() {
         final ByteArrayBuffer buffer = new ByteArrayBuffer(4);
         buffer.append((char[])null, 0, 0);
 
@@ -300,7 +300,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final ByteArrayBuffer orig = new ByteArrayBuffer(32);
         orig.append(1);
         orig.append(2);
@@ -324,7 +324,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testControlCharFiltering() throws Exception {
+    void testControlCharFiltering() {
         final char[] chars = new char[256];
         for (char i = 0; i < 256; i++) {
             chars[i] = i;
@@ -346,7 +346,7 @@ public class TestByteArrayBuffer {
     }
 
     @Test
-    public void testUnicodeFiltering() throws Exception {
+    void testUnicodeFiltering() {
         // Various languages
         Assertions.assertEquals("?????", new String(asByteArray("буквы".toCharArray()), StandardCharsets.ISO_8859_1));
         Assertions.assertEquals("????", new String(asByteArray("四字熟語".toCharArray()), StandardCharsets.ISO_8859_1));

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestCharArrayBuffer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestCharArrayBuffer.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link CharArrayBuffer}.
  *
  */
-public class TestCharArrayBuffer {
+class TestCharArrayBuffer {
 
     @Test
-    public void testConstructor() throws Exception {
+    void testConstructor() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         Assertions.assertEquals(16, buffer.capacity());
         Assertions.assertEquals(0, buffer.length());
@@ -53,7 +53,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSimpleAppend() throws Exception {
+    void testSimpleAppend() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         Assertions.assertEquals(16, buffer.capacity());
         Assertions.assertEquals(0, buffer.length());
@@ -87,7 +87,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testExpandAppend() throws Exception {
+    void testExpandAppend() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         Assertions.assertEquals(4, buffer.capacity());
 
@@ -108,7 +108,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendString() throws Exception {
+    void testAppendString() {
         final CharArrayBuffer buffer = new CharArrayBuffer(8);
         buffer.append("stuff");
         buffer.append(" and more stuff");
@@ -116,14 +116,14 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendNullString() throws Exception {
+    void testAppendNullString() {
         final CharArrayBuffer buffer = new CharArrayBuffer(8);
         buffer.append((String)null);
         Assertions.assertEquals("null", buffer.toString());
     }
 
     @Test
-    public void testAppendCharArrayBuffer() throws Exception {
+    void testAppendCharArrayBuffer() {
         final CharArrayBuffer buffer1 = new CharArrayBuffer(8);
         buffer1.append(" and more stuff");
         final CharArrayBuffer buffer2 = new CharArrayBuffer(8);
@@ -133,7 +133,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendNullCharArrayBuffer() throws Exception {
+    void testAppendNullCharArrayBuffer() {
         final CharArrayBuffer buffer = new CharArrayBuffer(8);
         buffer.append((CharArrayBuffer)null);
         buffer.append((CharArrayBuffer)null, 0, 0);
@@ -141,7 +141,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendSingleChar() throws Exception {
+    void testAppendSingleChar() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         buffer.append('1');
         buffer.append('2');
@@ -153,7 +153,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testInvalidCharArrayAppend() throws Exception {
+    void testInvalidCharArrayAppend() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         buffer.append((char[])null, 0, 0);
 
@@ -166,21 +166,21 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSetLength() throws Exception {
+    void testSetLength() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         buffer.setLength(2);
         Assertions.assertEquals(2, buffer.length());
     }
 
     @Test
-    public void testSetInvalidLength() throws Exception {
+    void testSetInvalidLength() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> buffer.setLength(-2));
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> buffer.setLength(200));
     }
 
     @Test
-    public void testEnsureCapacity() throws Exception {
+    void testEnsureCapacity() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         buffer.ensureCapacity(2);
         Assertions.assertEquals(4, buffer.capacity());
@@ -189,7 +189,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testIndexOf() {
+    void testIndexOf() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append("name: value");
         Assertions.assertEquals(4, buffer.indexOf(':'));
@@ -200,7 +200,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSubstring() {
+    void testSubstring() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append(" name:  value    ");
         Assertions.assertEquals(5, buffer.indexOf(':'));
@@ -212,7 +212,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSubstringIndexOfOutBound() {
+    void testSubstringIndexOfOutBound() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append("stuff");
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> buffer.substring(-2, 10));
@@ -224,7 +224,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendAsciiByteArray() throws Exception {
+    void testAppendAsciiByteArray() {
         final String s1 = "stuff";
         final String s2 = " and more stuff";
         final byte[] b1 = s1.getBytes(StandardCharsets.US_ASCII);
@@ -238,7 +238,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendISOByteArray() throws Exception {
+    void testAppendISOByteArray() {
         final byte[] b = new byte[] {0x00, 0x20, 0x7F, -0x80, -0x01};
 
         final CharArrayBuffer buffer = new CharArrayBuffer(8);
@@ -254,21 +254,21 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testAppendNullByteArray() throws Exception {
+    void testAppendNullByteArray() {
         final CharArrayBuffer buffer = new CharArrayBuffer(8);
         buffer.append((byte[])null, 0, 0);
         Assertions.assertEquals("", buffer.toString());
     }
 
     @Test
-    public void testAppendNullByteArrayBuffer() throws Exception {
+    void testAppendNullByteArrayBuffer() {
         final CharArrayBuffer buffer = new CharArrayBuffer(8);
         buffer.append((ByteArrayBuffer)null, 0, 0);
         Assertions.assertEquals("", buffer.toString());
     }
 
     @Test
-    public void testInvalidAppendAsciiByteArray() throws Exception {
+    void testInvalidAppendAsciiByteArray() {
         final CharArrayBuffer buffer = new CharArrayBuffer(4);
         buffer.append((byte[])null, 0, 0);
 
@@ -281,7 +281,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final CharArrayBuffer orig = new CharArrayBuffer(32);
         orig.append('a');
         orig.append('b');
@@ -305,7 +305,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSubSequence() {
+    void testSubSequence() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append(" name:  value    ");
         Assertions.assertEquals(5, buffer.indexOf(':'));
@@ -315,7 +315,7 @@ public class TestCharArrayBuffer {
     }
 
     @Test
-    public void testSubSequenceIndexOfOutBound() {
+    void testSubSequenceIndexOfOutBound() {
         final CharArrayBuffer buffer = new CharArrayBuffer(16);
         buffer.append("stuff");
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> buffer.subSequence(-2, 10));

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestDeadline.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestDeadline.java
@@ -35,24 +35,24 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link Deadline}.
  */
-public class TestDeadline {
+class TestDeadline {
 
     @Test
-    public void testFormat() throws ParseException {
+    void testFormat() throws ParseException {
         final Deadline deadline = Deadline.fromUnixMilliseconds(1000);
         final Deadline deadline2 = Deadline.parse(deadline.toString());
         Assertions.assertEquals(1000, deadline2.getValue());
     }
 
     @Test
-    public void testIsBefore() {
+    void testIsBefore() {
         final long nowPlusOneMin = System.currentTimeMillis() + 60000;
         final Deadline deadline = Deadline.fromUnixMilliseconds(nowPlusOneMin);
         Assertions.assertTrue(deadline.isBefore(nowPlusOneMin + 1));
     }
 
     @Test
-    public void testIsExpired() {
+    void testIsExpired() {
         Assertions.assertTrue(Deadline.fromUnixMilliseconds(0).isExpired());
         Assertions.assertTrue(Deadline.fromUnixMilliseconds(1).isExpired());
         Assertions.assertFalse(Deadline.MAX_VALUE.isExpired());
@@ -60,7 +60,7 @@ public class TestDeadline {
     }
 
     @Test
-    public void testIsMax() {
+    void testIsMax() {
         Assertions.assertFalse(Deadline.fromUnixMilliseconds(0).isMax());
         Assertions.assertFalse(Deadline.fromUnixMilliseconds(1000).isMax());
         Assertions.assertFalse(Deadline.MIN_VALUE.isMax());
@@ -68,7 +68,7 @@ public class TestDeadline {
     }
 
     @Test
-    public void testIsMin() {
+    void testIsMin() {
         Assertions.assertTrue(Deadline.fromUnixMilliseconds(0).isMin());
         Assertions.assertFalse(Deadline.fromUnixMilliseconds(1000).isMin());
         Assertions.assertFalse(Deadline.MAX_VALUE.isMin());
@@ -76,7 +76,7 @@ public class TestDeadline {
     }
 
     @Test
-    public void testIsNotExpired() {
+    void testIsNotExpired() {
         Assertions.assertFalse(Deadline.fromUnixMilliseconds(0).isNotExpired());
         Assertions.assertFalse(Deadline.fromUnixMilliseconds(1).isNotExpired());
         Assertions.assertTrue(Deadline.MAX_VALUE.isNotExpired());
@@ -84,7 +84,7 @@ public class TestDeadline {
     }
 
     @Test
-    public void testMin() {
+    void testMin() {
         Assertions.assertEquals(Deadline.MIN_VALUE, Deadline.MIN_VALUE.min(Deadline.MAX_VALUE));
         Assertions.assertEquals(Deadline.MIN_VALUE, Deadline.MAX_VALUE.min(Deadline.MIN_VALUE));
         //
@@ -98,13 +98,13 @@ public class TestDeadline {
     }
 
     @Test
-    public void testParse() throws ParseException {
+    void testParse() throws ParseException {
         final Deadline deadline = Deadline.parse("1969-12-31T17:00:01.000-0700");
         Assertions.assertEquals(1000, deadline.getValue());
     }
 
     @Test
-    public void testRemaining() {
+    void testRemaining() {
         final int oneHourInMillis = 60_000 * 60;
         final long nowPlusOneHour = System.currentTimeMillis() + oneHourInMillis;
         final Deadline deadline = Deadline.fromUnixMilliseconds(nowPlusOneHour);
@@ -114,7 +114,7 @@ public class TestDeadline {
     }
 
     @Test
-    public void testRemainingTimeValue() {
+    void testRemainingTimeValue() {
         final int oneHourInMillis = 60_000 * 60;
         final long nowPlusOneHour = System.currentTimeMillis() + oneHourInMillis;
         final Deadline deadline = Deadline.fromUnixMilliseconds(nowPlusOneHour);
@@ -125,7 +125,7 @@ public class TestDeadline {
     }
 
     @Test
-    public void testValue() {
+    void testValue() {
         final long nowPlusOneMin = System.currentTimeMillis() + 60000;
         final Deadline deadline = Deadline.fromUnixMilliseconds(nowPlusOneMin);
         Assertions.assertEquals(nowPlusOneMin, deadline.getValue());

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestDeadlineTimeoutException.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestDeadlineTimeoutException.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.util;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestDeadlineTimeoutException {
+class TestDeadlineTimeoutException {
 
     @Test
-    public void testMessage() {
+    void testMessage() {
         final Deadline deadline = Deadline.fromUnixMilliseconds(1000).freeze();
         Assertions.assertTrue(deadline.isExpired(), deadline.toString());
         final String format = deadline.formatTarget();
@@ -43,7 +43,7 @@ public class TestDeadlineTimeoutException {
     }
 
     @Test
-    public void testInfiniteDeadlineMessage() {
+    void testInfiniteDeadlineMessage() {
         final Deadline deadline = Deadline.calculate(Timeout.ZERO_MILLISECONDS);
         Assertions.assertEquals("No deadline (infinite)",
                 DeadlineTimeoutException.from(deadline).getMessage());

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestLangUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestLangUtils.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link LangUtils}.
  *
  */
-public class TestLangUtils {
+class TestLangUtils {
 
     @Test
-    public void testBasicHash() {
+    void testBasicHash() {
         final Integer i = Integer.valueOf(1234);
         final int h1 = LangUtils.hashCode(LangUtils.HASH_SEED, i.hashCode());
         final int h2 = LangUtils.hashCode(LangUtils.HASH_SEED, i);
@@ -45,14 +45,14 @@ public class TestLangUtils {
     }
 
     @Test
-    public void testNullObjectHash() {
+    void testNullObjectHash() {
         final int h1 = LangUtils.hashCode(LangUtils.HASH_SEED, null);
         final int h2 = LangUtils.hashCode(LangUtils.HASH_SEED, 0);
         Assertions.assertEquals(h1, h2);
     }
 
     @Test
-    public void testBooleanHash() {
+    void testBooleanHash() {
         final int h1 = LangUtils.hashCode(LangUtils.HASH_SEED, true);
         final int h2 = LangUtils.hashCode(LangUtils.HASH_SEED, false);
         final int h3 = LangUtils.hashCode(LangUtils.HASH_SEED, true);

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestLangUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestLangUtils.java
@@ -57,7 +57,7 @@ class TestLangUtils {
         final int h2 = LangUtils.hashCode(LangUtils.HASH_SEED, false);
         final int h3 = LangUtils.hashCode(LangUtils.HASH_SEED, true);
         final int h4 = LangUtils.hashCode(LangUtils.HASH_SEED, false);
-        Assertions.assertTrue(h1 != h2);
+        Assertions.assertNotEquals(h1, h2);
         Assertions.assertEquals(h1, h3);
         Assertions.assertEquals(h2, h4);
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTextUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTextUtils.java
@@ -34,17 +34,17 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link TextUtils}.
  *
  */
-public class TestTextUtils {
+class TestTextUtils {
 
     @Test
-    public void testTextEmpty() {
+    void testTextEmpty() {
         Assertions.assertTrue(TextUtils.isEmpty(null));
         Assertions.assertTrue(TextUtils.isEmpty(""));
         Assertions.assertFalse(TextUtils.isEmpty("\t"));
     }
 
     @Test
-    public void testTextBlank() {
+    void testTextBlank() {
         Assertions.assertTrue(TextUtils.isBlank(null));
         Assertions.assertTrue(TextUtils.isBlank(""));
         Assertions.assertTrue(TextUtils.isBlank("   "));
@@ -52,7 +52,7 @@ public class TestTextUtils {
     }
 
     @Test
-    public void testTextContainsBlanks() {
+    void testTextContainsBlanks() {
         Assertions.assertFalse(TextUtils.containsBlanks(null));
         Assertions.assertFalse(TextUtils.containsBlanks(""));
         Assertions.assertTrue(TextUtils.containsBlanks("   "));
@@ -62,7 +62,7 @@ public class TestTextUtils {
     }
 
     @Test
-    public void testToHexString() {
+    void testToHexString() {
         Assertions.assertEquals("000c2001ff", TextUtils.toHexString(new byte[] { 0, 12, 32, 1 , -1}));
         Assertions.assertNull(TextUtils.toHexString(null));
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeValue.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeValue.java
@@ -37,7 +37,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestTimeValue {
+class TestTimeValue {
 
     private void checkToDays(final long value, final TimeUnit timeUnit) {
         Assertions.assertEquals(timeUnit.toDays(value), TimeValue.of(value, timeUnit).toDays());
@@ -80,23 +80,23 @@ public class TestTimeValue {
     }
 
     @Test
-    public void test0() {
+    void test0() {
         test(0);
     }
 
     @Test
-    public void test1() {
+    void test1() {
         test(1);
     }
 
     @Test
-    public void testConvert() {
+    void testConvert() {
         Assertions.assertEquals(0, TimeValue.ofMilliseconds(0).convert(TimeUnit.DAYS));
         Assertions.assertEquals(1000, TimeValue.ofSeconds(1).convert(TimeUnit.MILLISECONDS));
     }
 
     @Test
-    public void testDivide() {
+    void testDivide() {
         // nominator is 0, result should be 0.
         Assertions.assertEquals(0, TimeValue.ofMilliseconds(0).divide(2).toDays());
         Assertions.assertEquals(0, TimeValue.ofMilliseconds(0).divide(2).toHours());
@@ -115,7 +115,7 @@ public class TestTimeValue {
     }
 
     @Test
-    public void testDivideBy0() {
+    void testDivideBy0() {
         Assertions.assertThrows(ArithmeticException.class, () ->
                 TimeValue.ofMilliseconds(0).divide(0));
     }
@@ -128,12 +128,12 @@ public class TestTimeValue {
     }
 
     @Test
-    public void testFactoryForDays() {
+    void testFactoryForDays() {
         testFactory(TimeUnit.DAYS);
     }
 
     @Test
-    public void testFactoryForDuration() {
+    void testFactoryForDuration() {
         assertConvertion(Duration.ZERO);
         assertConvertion(Duration.ofDays(1));
         assertConvertion(Duration.ofHours(1));
@@ -148,37 +148,37 @@ public class TestTimeValue {
     }
 
     @Test
-    public void testFactoryForHours() {
+    void testFactoryForHours() {
         testFactory(TimeUnit.HOURS);
     }
 
     @Test
-    public void testFactoryForMicroseconds() {
+    void testFactoryForMicroseconds() {
         testFactory(TimeUnit.MICROSECONDS);
     }
 
     @Test
-    public void testFactoryForMilliseconds() {
+    void testFactoryForMilliseconds() {
         testFactory(TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void testFactoryForMinutes() {
+    void testFactoryForMinutes() {
         testFactory(TimeUnit.MINUTES);
     }
 
     @Test
-    public void testFactoryForNanoseconds() {
+    void testFactoryForNanoseconds() {
         testFactory(TimeUnit.NANOSECONDS);
     }
 
     @Test
-    public void testFactoryForSeconds() {
+    void testFactoryForSeconds() {
         testFactory(TimeUnit.SECONDS);
     }
 
     @Test
-    public void testMin() {
+    void testMin() {
         final TimeValue nanos1 = TimeValue.ofNanoseconds(1);
         final TimeValue micros1 = TimeValue.ofMicroseconds(1);
         final TimeValue millis1 = TimeValue.ofMilliseconds(1);
@@ -253,28 +253,28 @@ public class TestTimeValue {
     }
 
     @Test
-    public void testMaxInt() {
+    void testMaxInt() {
         test(Integer.MAX_VALUE);
     }
 
     @Test
-    public void testMaxLong() {
+    void testMaxLong() {
         test(Long.MAX_VALUE);
     }
 
     @Test
-    public void testNegative1() {
+    void testNegative1() {
         test(-1);
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         Assertions.assertEquals("9223372036854775807 SECONDS", TimeValue.ofSeconds(Long.MAX_VALUE).toString());
         Assertions.assertEquals("0 MILLISECONDS", TimeValue.ZERO_MILLISECONDS.toString());
     }
 
     @Test
-    public void testFromString() throws ParseException {
+    void testFromString() throws ParseException {
         final TimeValue maxSeconds = TimeValue.ofSeconds(Long.MAX_VALUE);
         Assertions.assertEquals(maxSeconds, TimeValue.parse("9223372036854775807 SECONDS"));
         Assertions.assertEquals(maxSeconds, TimeValue.parse("9223372036854775807 SECONDS"));
@@ -287,12 +287,12 @@ public class TestTimeValue {
     }
 
     @Test
-    public void testToDuration() throws ParseException {
+    void testToDuration() throws ParseException {
         Assertions.assertEquals(Long.MAX_VALUE, TimeValue.parse("9223372036854775807 SECONDS").toDuration().getSeconds());
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         final TimeValue tv1 = TimeValue.ofMilliseconds(1000L);
         final TimeValue tv2 = TimeValue.ofMilliseconds(1001L);
         final TimeValue tv3 = TimeValue.ofMilliseconds(1000L);
@@ -315,7 +315,7 @@ public class TestTimeValue {
     }
 
     @Test
-    public void testCompareTo() {
+    void testCompareTo() {
         final TimeValue tv1 = TimeValue.ofMilliseconds(1000L);
         final TimeValue tv2 = TimeValue.ofMilliseconds(1001L);
         final TimeValue tv3 = TimeValue.ofMilliseconds(1000L);

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeout.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeout.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestTimeout {
+class TestTimeout {
 
     private void checkToDays(final long value, final TimeUnit timeUnit) {
         Assertions.assertEquals(timeUnit.toDays(value), Timeout.of(value, timeUnit).toDays());
@@ -77,17 +77,17 @@ public class TestTimeout {
     }
 
     @Test
-    public void test0() {
+    void test0() {
         test(0);
     }
 
     @Test
-    public void test1() {
+    void test1() {
         test(1);
     }
 
     @Test
-    public void testDisabled() {
+    void testDisabled() {
         Assertions.assertTrue(Timeout.DISABLED.isDisabled());
         Assertions.assertFalse(Timeout.DISABLED.isEnabled());
     }
@@ -97,12 +97,12 @@ public class TestTimeout {
     }
 
     @Test
-    public void testFactoryForDays() {
+    void testFactoryForDays() {
         testFactory(TimeUnit.DAYS);
     }
 
     @Test
-    public void testFactoryForDuration() {
+    void testFactoryForDuration() {
         assertConvertion(Duration.ZERO);
         assertConvertion(Duration.ofDays(1));
         assertConvertion(Duration.ofHours(1));
@@ -117,59 +117,59 @@ public class TestTimeout {
     }
 
     @Test
-    public void testFactoryForHours() {
+    void testFactoryForHours() {
         testFactory(TimeUnit.HOURS);
     }
 
     @Test
-    public void testFactoryForMicroseconds() {
+    void testFactoryForMicroseconds() {
         testFactory(TimeUnit.MICROSECONDS);
     }
 
     @Test
-    public void testFactoryForMillisseconds() {
+    void testFactoryForMillisseconds() {
         testFactory(TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void testFactoryForMinutes() {
+    void testFactoryForMinutes() {
         testFactory(TimeUnit.MINUTES);
     }
 
     @Test
-    public void testFactoryForNanoseconds() {
+    void testFactoryForNanoseconds() {
         testFactory(TimeUnit.NANOSECONDS);
     }
 
     @Test
-    public void testFactoryForSeconds() {
+    void testFactoryForSeconds() {
         testFactory(TimeUnit.SECONDS);
     }
 
     @Test
-    public void testMaxInt() {
+    void testMaxInt() {
         test(Integer.MAX_VALUE);
     }
 
     @Test
-    public void testMaxLong() {
+    void testMaxLong() {
         test(Long.MAX_VALUE);
     }
 
     @Test
-    public void testNegative1() {
+    void testNegative1() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 test(-1));
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         Assertions.assertEquals("9223372036854775807 SECONDS", Timeout.ofSeconds(Long.MAX_VALUE).toString());
         Assertions.assertEquals("0 MILLISECONDS", Timeout.ZERO_MILLISECONDS.toString());
     }
 
     @Test
-    public void testFromString() throws ParseException {
+    void testFromString() throws ParseException {
         Assertions.assertEquals(Timeout.ofSeconds(Long.MAX_VALUE), Timeout.parse("9223372036854775807 SECONDS"));
         Assertions.assertEquals(Timeout.ofSeconds(Long.MAX_VALUE), Timeout.parse("9223372036854775807 Seconds"));
         Assertions.assertEquals(Timeout.ofSeconds(Long.MAX_VALUE), Timeout.parse("9223372036854775807  Seconds"));

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeoutValueException.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTimeoutValueException.java
@@ -30,10 +30,10 @@ package org.apache.hc.core5.util;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestTimeoutValueException {
+class TestTimeoutValueException {
 
     @Test
-    public void testMessage() {
+    void testMessage() {
         Assertions.assertEquals("Timeout deadline: 1000 MILLISECONDS, actual: 2000 MILLISECONDS",
                 TimeoutValueException.fromMilliseconds(1000, 2000).getMessage());
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestTokenizer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestTokenizer.java
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestTokenizer {
+class TestTokenizer {
 
     private Tokenizer parser;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() {
         parser = new Tokenizer();
     }
 
@@ -50,7 +50,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testBasicTokenParsing() throws Exception {
+    void testBasicTokenParsing() {
         final String s = "   raw: \" some stuff \"";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -88,7 +88,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingWithQuotedPairs() throws Exception {
+    void testTokenParsingWithQuotedPairs() {
         final String s = "raw: \"\\\"some\\stuff\\\\\"";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -118,7 +118,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingIncompleteQuote() throws Exception {
+    void testTokenParsingIncompleteQuote() {
         final String s = "\"stuff and more stuff  ";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -128,7 +128,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingTokensWithUnquotedBlanks() throws Exception {
+    void testTokenParsingTokensWithUnquotedBlanks() {
         final String s = "  stuff and   \tsome\tmore  stuff  ;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -137,7 +137,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingMixedValuesAndQuotedValues() throws Exception {
+    void testTokenParsingMixedValuesAndQuotedValues() {
         final String s = "  stuff and    \" some more \"   \"stuff  ;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -146,7 +146,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingMixedValuesAndQuotedValues2() throws Exception {
+    void testTokenParsingMixedValuesAndQuotedValues2() {
         final String s = "stuff\"more\"stuff;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -155,7 +155,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingEscapedQuotes() throws Exception {
+    void testTokenParsingEscapedQuotes() {
         final String s = "stuff\"\\\"more\\\"\"stuff;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -164,7 +164,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingEscapedDelimiter() throws Exception {
+    void testTokenParsingEscapedDelimiter() {
         final String s = "stuff\"\\\"more\\\";\"stuff;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -173,7 +173,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingEscapedSlash() throws Exception {
+    void testTokenParsingEscapedSlash() {
         final String s = "stuff\"\\\"more\\\";\\\\\"stuff;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());
@@ -182,7 +182,7 @@ public class TestTokenizer {
     }
 
     @Test
-    public void testTokenParsingSlashOutsideQuotes() throws Exception {
+    void testTokenParsingSlashOutsideQuotes() {
         final String s = "stuff\\; more stuff;";
         final CharArrayBuffer raw = createBuffer(s);
         final Tokenizer.Cursor cursor = new Tokenizer.Cursor(0, s.length());


### PR DESCRIPTION
This PR cleans up the test classes. The proposed changes include:

**Remove superfluous exceptions in throws clauses**
Superfluous exceptions within throws clauses have negative effects on the readability and maintainability of the code.

**Test classes and methods should have default package visibility**
It is ecommended to use the default package visibility to improve readability:
>
> Test classes, test methods, and lifecycle methods are not required to be public, but they must not be private.
It is generally recommended to omit the public modifier for test classes, test methods, and lifecycle methods unless there is a technical reason for doing so – for example, when a test class is extended by a test class in another package. Another technical reason for making classes and methods public is to simplify testing on the module path when using the Java Module System.
> — JUnit5 User Guide

**Fix assertion argument orders**
To me it seems like some assertions where not correctly upgraded when JUnit5 was introduced, where the order of arguments for some `Assertions` methods was changed.

**Remove duplicate tests**
Some test methods were implemented twice (=identical) under different names in the same class.

**Make sure tests have at least one assertion**
A test case should at least have one assertion made.
