### PR TITLE
Implement the "len" part of contract for java.io.InputStream.read(byte[], int, int)

### DIFF
--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/io/MultiByteArrayInputStream.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/io/MultiByteArrayInputStream.java
@@ -77,6 +77,9 @@ class MultiByteArrayInputStream extends InputStream {
                ((off + len) > b.length) || ((off + len) < 0)) {
             throw new IndexOutOfBoundsException();
         }
+        if (len == 0) {
+            return 0;
+        }
         advance();
         if (this.current == null) {
             return -1;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
@@ -170,12 +170,13 @@ public class ChunkedInputStream extends InputStream {
      * @throws IOException in case of an I/O error
      */
     @Override
-    public int read (final byte[] b, final int off, final int len) throws IOException {
-
+    public int read(final byte[] b, final int off, final int len) throws IOException {
         if (closed) {
             throw new StreamClosedException();
         }
-
+        if (len == 0) {
+            return 0;
+        }
         if (eof) {
             return -1;
         }
@@ -206,7 +207,7 @@ public class ChunkedInputStream extends InputStream {
      * @throws IOException in case of an I/O error
      */
     @Override
-    public int read (final byte[] b) throws IOException {
+    public int read(final byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
@@ -161,11 +161,12 @@ public class ContentLengthInputStream extends InputStream {
         if (closed) {
             throw new StreamClosedException();
         }
-
+        if (len == 0) {
+            return 0;
+        }
         if (pos >= contentLength) {
             return -1;
         }
-
         int chunk = len;
         if (pos + len > contentLength) {
             chunk = (int) (contentLength - pos);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/EmptyInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/EmptyInputStream.java
@@ -96,6 +96,9 @@ public final class EmptyInputStream extends InputStream {
      */
     @Override
     public int read(final byte[] buf, final int off, final int len) {
+        if (len == 0) {
+            return 0;
+        }
         return -1;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/IdentityInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/IdentityInputStream.java
@@ -96,6 +96,9 @@ public class IdentityInputStream extends InputStream {
         if (this.closed) {
             throw new StreamClosedException();
         }
+        if (len == 0) {
+            return 0;
+        }
         return this.buffer.read(b, off, len, this.inputStream);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/SessionInputBufferImpl.java
@@ -180,7 +180,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
     @Override
     public int read(final byte[] b, final int off, final int len, final InputStream inputStream) throws IOException {
         Args.notNull(inputStream, "Input stream");
-        if (b == null) {
+        if (b == null || b.length == 0 || len == 0) {
             return 0;
         }
         if (hasBufferedData()) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java
@@ -128,6 +128,9 @@ public class EofSensorInputStream extends InputStream {
 
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
         int readLen = -1;
 
         if (isReadAllowed()) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/SessionInputBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/SessionInputBuffer.java
@@ -76,6 +76,7 @@ public interface SessionInputBuffer {
      * {@code off+len} is greater than the length of the array
      * {@code b}, then an {@code IndexOutOfBoundsException} is
      * thrown.
+     * <p> If {@code len} is zero, then no bytes are read and 0 is returned.
      *
      * @param      b     the buffer into which the data is read.
      * @param      off   the start offset in array {@code b}

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/ByteBufferEntity.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/ByteBufferEntity.java
@@ -109,6 +109,9 @@ public class ByteBufferEntity extends AbstractHttpEntity {
 
             @Override
             public int read(final byte[] bytes, final int off, final int len) throws IOException {
+                if (len == 0) {
+                    return 0;
+                }
                 if (!buffer.hasRemaining()) {
                     return -1;
                 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EmptyInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/entity/EmptyInputStream.java
@@ -97,6 +97,9 @@ public final class EmptyInputStream extends InputStream {
      */
     @Override
     public int read(final byte[] buf, final int off, final int len) {
+        if (len == 0) {
+            return 0;
+        }
         return -1;
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/ContentInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/ContentInputStream.java
@@ -54,6 +54,9 @@ public class ContentInputStream extends InputStream {
 
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
         return this.buffer.read(b, off, len);
     }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/SharedInputBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/classic/SharedInputBuffer.java
@@ -133,6 +133,9 @@ public final class SharedInputBuffer extends AbstractSharedBuffer implements Con
 
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
         lock.lock();
         try {
             setOutputMode();

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TimeoutByteArrayInputStream.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TimeoutByteArrayInputStream.java
@@ -73,6 +73,9 @@ class TimeoutByteArrayInputStream extends InputStream {
                ((off + len) > b.length) || ((off + len) < 0)) {
             throw new IndexOutOfBoundsException("off: "+off+" len: "+len+" b.length: "+b.length);
         }
+        if (len == 0) {
+            return 0;
+        }
         if (this.pos >= this.count) {
             return -1;
         }


### PR DESCRIPTION
Implement the "len" part of contract for `java.io.InputStream.read(byte[], int, int)`

- If `len` is zero, then no bytes are read and 0 is returned.
- Be explicit like we are for other invariants.
- Mostly do not reply on fall-through behavior.
- Tested with HTTP client git master at (current HEAD) commit 4009567af704530aa0578e34fc63dd8baa945d34
- Apply the same change to `SessionInputBuffer` and its implementation