### PR TITLE
HTTPCLIENT-2159: Invalid handling of charset content type parameter

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.message.BasicHeaderValueFormatter;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.message.ParserCursor;
@@ -67,105 +68,125 @@ public final class ContentType implements Serializable {
      */
     private static final String CHARSET = "charset";
 
+    /**
+     * Flag indicating whether the charset is implicit.
+     * <p>
+     * When {@code implicitCharset} is {@code true}, the charset will not be explicitly
+     * included in the string representation of this {@link ContentType} (i.e., in the {@code toString} method),
+     * unless it is required for the given MIME type.
+     * If {@code implicitCharset} is {@code false}, the charset will always be included in the string representation,
+     * unless the MIME type explicitly disallows charset parameters (e.g., certain binary or multipart types).
+     * </p>
+     * <p>
+     * This flag is essential for proper handling of content types where the charset is either implied by the specification
+     * (e.g., JSON is always UTF-8) or where including a charset is not meaningful (e.g., binary types like
+     * {@code application/octet-stream}).
+     * </p>
+     *
+     * @since 5.5
+     */
+    private final boolean implicitCharset;
+
+
     // constants
     public static final ContentType APPLICATION_ATOM_XML = create(
-            "application/atom+xml", StandardCharsets.UTF_8);
+            "application/atom+xml", StandardCharsets.UTF_8, false);
     public static final ContentType APPLICATION_FORM_URLENCODED = create(
-            "application/x-www-form-urlencoded", StandardCharsets.ISO_8859_1);
+            "application/x-www-form-urlencoded", StandardCharsets.ISO_8859_1, true);
     public static final ContentType APPLICATION_JSON = create(
-            "application/json", StandardCharsets.UTF_8);
+            "application/json", StandardCharsets.UTF_8, true);
 
     /**
      * Public constant media type for {@code application/x-ndjson}.
      * @since 5.1
      */
     public static final ContentType APPLICATION_NDJSON = create(
-            "application/x-ndjson", StandardCharsets.UTF_8);
+            "application/x-ndjson", StandardCharsets.UTF_8, true);
 
     public static final ContentType APPLICATION_OCTET_STREAM = create(
-            "application/octet-stream", (Charset) null);
+            "application/octet-stream", (Charset) null, true);
     /**
      * Public constant media type for {@code application/pdf}.
      * @since 5.1
      */
     public static final ContentType APPLICATION_PDF = create(
-            "application/pdf", StandardCharsets.UTF_8);
+            "application/pdf", (Charset) null, true);
 
     public static final ContentType APPLICATION_SOAP_XML = create(
-            "application/soap+xml", StandardCharsets.UTF_8);
+            "application/soap+xml", StandardCharsets.UTF_8, false);
     public static final ContentType APPLICATION_SVG_XML = create(
-            "application/svg+xml", StandardCharsets.UTF_8);
+            "application/svg+xml", StandardCharsets.UTF_8, false);
     public static final ContentType APPLICATION_XHTML_XML = create(
-            "application/xhtml+xml", StandardCharsets.UTF_8);
+            "application/xhtml+xml", StandardCharsets.UTF_8, false);
     public static final ContentType APPLICATION_XML = create(
-            "application/xml", StandardCharsets.UTF_8);
+            "application/xml", StandardCharsets.UTF_8, false);
     /**
      * Public constant media type for {@code application/problem+json}.
      * @see <a href="https://tools.ietf.org/html/rfc7807#section-6.1">Problem Details for HTTP APIs, 6.1. application/problem+json</a>
      * @since 5.1
      */
     public static final ContentType APPLICATION_PROBLEM_JSON = create(
-            "application/problem+json", StandardCharsets.UTF_8);
+            "application/problem+json", StandardCharsets.UTF_8, true);
     /**
      * Public constant media type for {@code application/problem+xml}.
      * @see <a href="https://tools.ietf.org/html/rfc7807#section-6.2">Problem Details for HTTP APIs, 6.2. application/problem+xml</a>
      * @since 5.1
      */
     public static final ContentType APPLICATION_PROBLEM_XML = create(
-            "application/problem+xml", StandardCharsets.UTF_8);
+            "application/problem+xml", StandardCharsets.UTF_8, false);
 
     /**
      * Public constant media type for {@code application/rss+xml}.
      * @since 5.1
      */
     public static final ContentType APPLICATION_RSS_XML = create(
-            "application/rss+xml", StandardCharsets.UTF_8);
+            "application/rss+xml", StandardCharsets.UTF_8, false);
 
     public static final ContentType IMAGE_BMP = create(
-            "image/bmp");
+            "image/bmp", (Charset) null, true);
     public static final ContentType IMAGE_GIF = create(
-            "image/gif");
+            "image/gif", (Charset) null, true);
     public static final ContentType IMAGE_JPEG = create(
-            "image/jpeg");
+            "image/jpeg", (Charset) null, true);
     public static final ContentType IMAGE_PNG = create(
-            "image/png");
+            "image/png", (Charset) null, true);
     public static final ContentType IMAGE_SVG = create(
-            "image/svg+xml");
+            "image/svg+xml", (Charset) null, false);
     public static final ContentType IMAGE_TIFF = create(
-            "image/tiff");
+            "image/tiff", (Charset) null, true);
     public static final ContentType IMAGE_WEBP = create(
-            "image/webp");
+            "image/webp", (Charset) null, true);
     public static final ContentType MULTIPART_FORM_DATA = create(
-            "multipart/form-data", StandardCharsets.ISO_8859_1);
+            "multipart/form-data", StandardCharsets.ISO_8859_1, true);
 
     /**
      * Public constant media type for {@code multipart/mixed}.
      * @since 5.1
      */
     public static final ContentType MULTIPART_MIXED = create(
-            "multipart/mixed", StandardCharsets.ISO_8859_1);
+            "multipart/mixed", StandardCharsets.ISO_8859_1, true);
 
     /**
      * Public constant media type for {@code multipart/related}.
      * @since 5.1
      */
     public static final ContentType MULTIPART_RELATED = create(
-            "multipart/related", StandardCharsets.ISO_8859_1);
+            "multipart/related", StandardCharsets.ISO_8859_1, true);
 
     public static final ContentType TEXT_HTML = create(
-            "text/html", StandardCharsets.UTF_8);
+            "text/html", StandardCharsets.UTF_8, true);
 
     /**
      * Public constant media type for {@code text/markdown}.
      * @since 5.1
      */
     public static final ContentType TEXT_MARKDOWN = create(
-            "text/markdown", StandardCharsets.UTF_8);
+            "text/markdown", StandardCharsets.UTF_8, false);
 
     public static final ContentType TEXT_PLAIN = create(
-            "text/plain", StandardCharsets.UTF_8);
+            "text/plain", StandardCharsets.UTF_8, false);
     public static final ContentType TEXT_XML = create(
-            "text/xml", StandardCharsets.UTF_8);
+            "text/xml", StandardCharsets.UTF_8, false);
     /**
      * Public constant media type for {@code text/event-stream}.
      * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommendation</a>
@@ -175,7 +196,7 @@ public final class ContentType implements Serializable {
             "text/event-stream", StandardCharsets.UTF_8);
 
     public static final ContentType WILDCARD = create(
-            "*/*", (Charset) null);
+            "*/*", (Charset) null, true);
 
     /**
      * An empty immutable {@code NameValuePair} array.
@@ -225,18 +246,42 @@ public final class ContentType implements Serializable {
     ContentType(
             final String mimeType,
             final Charset charset) {
-        this.mimeType = mimeType;
-        this.charset = charset;
-        this.params = null;
+        this (mimeType,charset,null, false);
     }
 
     ContentType(
             final String mimeType,
             final Charset charset,
             final NameValuePair[] params) {
+
+        this (mimeType,charset,params, false);
+    }
+
+    /**
+     * Constructs a new instance of {@link ContentType} with the given MIME type, charset, parameters,
+     * and an implicit charset flag.
+     * <p>
+     * If {@code implicitCharset} is set to {@code true}, the charset will not be explicitly
+     * included in the string representation of this content type (i.e., the {@code toString} method)
+     * unless it is required for the given MIME type.
+     * If {@code implicitCharset} is {@code false}, the charset will always be included in the
+     * string representation unless the MIME type is one of those that should not include a charset.
+     * </p>
+     *
+     * @param mimeType        the MIME type. It must not be {@code null} or empty and must not contain
+     *                        reserved characters such as {@code <">, <;>, <,>}.
+     * @param charset         the character set for this content type. This can be {@code null}.
+     * @param params          optional parameters for this content type. If {@code null}, no additional
+     *                        parameters will be included.
+     * @param implicitCharset whether the charset is implicit. If {@code true}, the charset is not
+     *                        included in the {@code toString} output unless required.
+     * @since 5.5
+     */
+    ContentType(final String mimeType, final Charset charset, final NameValuePair[] params, final boolean implicitCharset) {
         this.mimeType = mimeType;
         this.charset = charset;
-        this.params = params;
+        this.implicitCharset = implicitCharset;
+        this.params = params != null ? params.clone() : null;
     }
 
     public String getMimeType() {
@@ -288,8 +333,21 @@ public final class ContentType implements Serializable {
         buf.append(this.mimeType);
         if (this.params != null) {
             buf.append("; ");
-            MessageSupport.formatParameters(buf, this.params);
-        } else if (this.charset != null) {
+            boolean first = true;
+            for (int i = 0; i < params.length; i++) {
+                final NameValuePair param = params[i];
+                if (!first) {
+                    buf.append("; ");
+                }
+                if (param.getName().equalsIgnoreCase("charset") && implicitCharset) {
+                    continue;
+                }
+                BasicHeaderValueFormatter.INSTANCE.formatNameValuePair(buf, param, false);
+                first = false;
+            }
+
+        } else if (this.charset != null && !implicitCharset) {
+            // Append charset only if it's not one of the types that shouldn't have charset
             buf.append("; charset=");
             buf.append(this.charset.name());
         }
@@ -306,6 +364,58 @@ public final class ContentType implements Serializable {
         return true;
     }
 
+
+    /**
+     * Creates a new instance of {@link ContentType} with the given MIME type, charset,
+     * and an implicit charset flag.
+     * <p>
+     * This method allows specifying whether the charset should be implicit or explicit.
+     * If {@code implicitCharset} is set to {@code true}, the charset will not be explicitly
+     * included in the string representation of this content type (i.e., the {@code toString} method),
+     * unless it is required for the given MIME type. If {@code implicitCharset} is {@code false},
+     * the charset will always be included unless the MIME type does not allow a charset.
+     * </p>
+     *
+     * @param mimeType        the MIME type. It must not be {@code null} or empty and must not contain
+     *                        reserved characters such as {@code <">, <;>, <,>}.
+     * @param charset         the character set for this content type. This can be {@code null}.
+     * @param implicitCharset whether the charset is implicit. If {@code true}, the charset is
+     *                        not included in the {@code toString} output unless required.
+     * @return a new instance of {@link ContentType}.
+     * @throws IllegalArgumentException if the MIME type is invalid or contains reserved characters.
+     * @since 5.5
+     */
+    public static ContentType create(final String mimeType, final Charset charset, final boolean implicitCharset) {
+        final String normalizedMimeType = TextUtils.toLowerCase(Args.notBlank(mimeType, "MIME type"));
+        Args.check(valid(normalizedMimeType), "MIME type may not contain reserved characters");
+        return new ContentType(normalizedMimeType, charset, null, implicitCharset);
+    }
+
+    /**
+     * Creates a new instance of {@link ContentType} with the given MIME type, parameters,
+     * and an implicit charset flag.
+     * <p>
+     * This method allows specifying additional parameters for the content type and whether
+     * the charset should be implicit or explicit. If {@code implicitCharset} is {@code true},
+     * the charset will not be included in the string representation unless required.
+     * </p>
+     *
+     * @param mimeType        the MIME type. It must not be {@code null} or empty and must not contain
+     *                        reserved characters such as {@code <">, <;>, <,>}.
+     * @param implicitCharset whether the charset is implicit. If {@code true}, the charset is
+     *                        not included in the {@code toString} output unless required.
+     * @param params          optional parameters for the content type. Can be {@code null}.
+     * @return a new instance of {@link ContentType}.
+     * @throws IllegalArgumentException    if the MIME type is invalid or contains reserved characters.
+     * @throws UnsupportedCharsetException if the charset provided in the parameters is not supported.
+     * @since 5.5
+     */
+    public static ContentType create(final String mimeType, final boolean implicitCharset, final NameValuePair... params) throws UnsupportedCharsetException {
+        final String type = TextUtils.toLowerCase(Args.notBlank(mimeType, "MIME type"));
+        Args.check(valid(type), "MIME type may not contain reserved characters");
+        return create(mimeType, params != null ? params.clone() : null, implicitCharset);
+    }
+
     /**
      * Creates a new instance of {@link ContentType}.
      *
@@ -315,9 +425,7 @@ public final class ContentType implements Serializable {
      * @return content type
      */
     public static ContentType create(final String mimeType, final Charset charset) {
-        final String normalizedMimeType = TextUtils.toLowerCase(Args.notBlank(mimeType, "MIME type"));
-        Args.check(valid(normalizedMimeType), "MIME type may not contain reserved characters");
-        return new ContentType(normalizedMimeType, charset);
+       return create(mimeType, charset, false);
     }
 
     /**
@@ -356,6 +464,10 @@ public final class ContentType implements Serializable {
     }
 
     private static ContentType create(final String mimeType, final NameValuePair[] params, final boolean strict) {
+        return create(mimeType, params != null ? params.clone() : null, strict, false);
+    }
+
+    private static ContentType create(final String mimeType, final NameValuePair[] params, final boolean strict, final boolean implicitCharset) {
         Charset charset = null;
         if (params != null) {
             for (final NameValuePair param : params) {
@@ -374,7 +486,7 @@ public final class ContentType implements Serializable {
                 }
             }
         }
-        return new ContentType(mimeType, charset, params != null && params.length > 0 ? params : null);
+        return new ContentType(mimeType, charset, params != null && params.length > 0 ? params : null, implicitCharset);
     }
 
     /**
@@ -517,7 +629,7 @@ public final class ContentType implements Serializable {
         for (final Map.Entry<String, String> entry: paramMap.entrySet()) {
             newParams.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
-        return create(this.getMimeType(), newParams.toArray(EMPTY_NAME_VALUE_PAIR_ARRAY), true);
+        return create(this.getMimeType(), newParams.toArray(EMPTY_NAME_VALUE_PAIR_ARRAY), true, this.implicitCharset);
     }
 
     public boolean isSameMimeType(final ContentType contentType) {

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestContentType.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestContentType.java
@@ -183,4 +183,121 @@ class TestContentType {
         Assertions.assertEquals("text/blah; charset=ISO-8859-1; p=blah", contentType.toString());
     }
 
+
+    @Test
+    void testImplicitCharsetTrue() {
+        // ContentType with implicitCharset = true
+        final ContentType contentType = ContentType.create("application/json", StandardCharsets.UTF_8, true);
+
+        // Check that the charset is not added to the toString() output
+        Assertions.assertEquals("application/json", contentType.toString());
+        // Check that the charset is still stored
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+    }
+
+    @Test
+    void testImplicitCharsetFalse() {
+        // ContentType with implicitCharset = false
+        final ContentType contentType = ContentType.create("application/json", StandardCharsets.UTF_8, false);
+
+        // Check that the charset is included in the toString() output
+        Assertions.assertEquals("application/json; charset=UTF-8", contentType.toString());
+        // Check that the charset is correctly stored
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+    }
+
+    @Test
+    void testImplicitCharsetForTextPlain() {
+        // ContentType for text/plain with implicitCharset = true
+        final ContentType contentType = ContentType.create("text/plain", StandardCharsets.UTF_8, true);
+
+        // Check that the charset is not included in the toString() output
+        Assertions.assertEquals("text/plain", contentType.toString());
+        // Check that the charset is correctly stored
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+    }
+
+    @Test
+    void testWithParamsAndImplicitCharset() {
+        // ContentType with parameters and implicitCharset = true
+        ContentType contentType = ContentType.create("text/plain", StandardCharsets.UTF_8, true)
+                .withParameters(
+                        new BasicNameValuePair("p", "this"),
+                        new BasicNameValuePair("p", "that"));
+
+        // Check that the last "p" parameter overwrites the first one
+        // ImplicitCharset is true, so charset should not be included
+        Assertions.assertEquals("text/plain; p=that", contentType.toString());
+
+        // Verify that charset is still available in the object
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+
+        // Test with implicitCharset = false
+        contentType = ContentType.create("text/plain", StandardCharsets.UTF_8, false)
+                .withParameters(
+                        new BasicNameValuePair("p", "this"),
+                        new BasicNameValuePair("p", "that"));
+
+        // Check that the charset is included in the toString() output due to implicitCharset = false
+        Assertions.assertEquals("text/plain; charset=UTF-8; p=that", contentType.toString());
+    }
+
+    @Test
+    void testNoCharsetForSpecificMediaTypes() {
+        // Testing application/octet-stream should not include charset in toString
+        ContentType contentType = ContentType.create("application/octet-stream", StandardCharsets.UTF_8, true);
+        Assertions.assertEquals("application/octet-stream", contentType.toString());
+        Assertions.assertNotNull(contentType.getCharset()); // Ensure charset is set
+
+        // Testing image/jpeg should not include charset in toString
+        contentType = ContentType.create("image/jpeg", StandardCharsets.UTF_8, true);
+        Assertions.assertEquals("image/jpeg", contentType.toString());
+        Assertions.assertNotNull(contentType.getCharset());
+
+        // Testing multipart/form-data should not include charset in toString
+        contentType = ContentType.create("multipart/form-data", StandardCharsets.UTF_8, true);
+        Assertions.assertEquals("multipart/form-data", contentType.toString());
+        Assertions.assertNotNull(contentType.getCharset());
+    }
+
+
+    @Test
+    void testCharsetForOtherMediaTypes() {
+        // Testing application/json should include charset
+        ContentType contentType = ContentType.create("application/json", StandardCharsets.UTF_8, false);
+        Assertions.assertEquals("application/json; charset=UTF-8", contentType.toString());
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+
+        // Testing text/html should include charset
+        contentType = ContentType.create("text/html", StandardCharsets.UTF_8, false);
+        Assertions.assertEquals("text/html; charset=UTF-8", contentType.toString());
+        Assertions.assertEquals(StandardCharsets.UTF_8, contentType.getCharset());
+    }
+
+    @Test
+    void testNoCharsetForBinaryMediaTypes() throws Exception {
+        // Test for application/octet-stream
+        ContentType contentType = ContentType.create("application/octet-stream", null, true);
+        Assertions.assertEquals("application/octet-stream", contentType.toString());
+        Assertions.assertNull(contentType.getCharset());
+
+        // Test for image/jpeg
+        contentType = ContentType.create("image/jpeg", null, true);
+        Assertions.assertEquals("image/jpeg", contentType.toString());
+        Assertions.assertNull(contentType.getCharset());
+    }
+
+    @Test
+    void testFormUrlEncodedWithoutCharset() throws Exception {
+        // Test for application/x-www-form-urlencoded with percent-encoding
+        final ContentType contentType = ContentType.create("application/x-www-form-urlencoded", null, true);
+        Assertions.assertEquals("application/x-www-form-urlencoded", contentType.toString());
+        Assertions.assertNull(contentType.getCharset());
+
+        // Test body encoding example with percent-encoding
+        final String encodedBody = "echotext=TEST%F6TEST";
+        // Simulate HTTP redirect where charset shouldn't change
+        final String redirectedBody = "echotext=TEST%F6TEST";
+        Assertions.assertEquals(encodedBody, redirectedBody);  // Ensure body stays the same after redirect
+    }
 }


### PR DESCRIPTION
This PR is an attempt to mitigate the issues highlighted in [HTTPCLIENT-2159,](https://issues.apache.org/jira/browse/HTTPCLIENT-2159). The root problem stems from how we are incorrectly handling certain content types by attaching charset parameters when they shouldn't have one. This update adjusts the way the Content-Type header handles specific cases, ensuring compliance with relevant specifications.