### PR TITLE
A FutureContribution should not allow a null BasicFuture

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/concurrent/FutureContribution.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/concurrent/FutureContribution.java
@@ -26,6 +26,8 @@
  */
 package org.apache.hc.core5.concurrent;
 
+import java.util.Objects;
+
 /**
  * Convenience base class for {@link FutureCallback}s that contribute a result
  * of the operation to another {@link BasicFuture}.
@@ -40,24 +42,20 @@ public abstract class FutureContribution<T> implements FutureCallback<T> {
     /**
      * Constructs a new instance to callback the given {@link BasicFuture}.
      *
-     * @param future The callback.
+     * @param future The callback, non-null.
      */
     public FutureContribution(final BasicFuture<?> future) {
-        this.future = future;
+        this.future = Objects.requireNonNull(future);
     }
 
     @Override
     public final void failed(final Exception ex) {
-        if (future != null) {
-            future.failed(ex);
-        }
+        future.failed(ex);
     }
 
     @Override
     public final void cancelled() {
-        if (future != null) {
-            future.cancel();
-        }
+        future.cancel();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
I do not think it makes sense to build a new FutureContribution with a null callback.

This does not happen in the current code base.
