### PR TITLE
HTTPCORE-769- Add Configurable Behavior for Handling 408 Responses in DefaultConnectionReuseStrategy

### DIFF
--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultConnectionReuseStrategy.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/TestDefaultConnectionReuseStrategy.java
@@ -318,5 +318,13 @@ class TestDefaultConnectionReuseStrategy {
         Assertions.assertFalse(reuseStrategy.keepAlive(null, response, context));
     }
 
+    @Test
+    void testRequestTimeout408Response() {
+        final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_REQUEST_TIMEOUT, "Request Timeout");
+        response.addHeader("Connection", "keep-alive");
+        reuseStrategy = new DefaultConnectionReuseStrategy(true);
+        Assertions.assertFalse(reuseStrategy.keepAlive(null, response, context));
+    }
+
 }
 


### PR DESCRIPTION
This pull request introduces a change to the ´DefaultConnectionReuseStrategy´ class, allowing for more flexible handling of HTTP 408 (Request Timeout) responses. A new boolean parameter, ´forceCloseOn408´, has been added to make the connection reuse behavior configurable.