### PR TITLE
Properly alert receivers when using non-default dynamic table sizes for HPACK

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/InboundDynamicTable.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/InboundDynamicTable.java
@@ -39,15 +39,19 @@ final class InboundDynamicTable {
     private int maxSize;
     private int currentSize;
 
-    InboundDynamicTable(final StaticTable staticTable) {
+    InboundDynamicTable(final int maxSize, final StaticTable staticTable) {
         this.staticTable = staticTable;
         this.headers = new FifoBuffer(256);
-        this.maxSize = Integer.MAX_VALUE;
+        this.maxSize = maxSize;
         this.currentSize = 0;
     }
 
+    InboundDynamicTable(final int maxSize) {
+        this(maxSize, StaticTable.INSTANCE);
+    }
+
     InboundDynamicTable() {
-        this(StaticTable.INSTANCE);
+        this(Integer.MAX_VALUE);
     }
 
     public int getMaxSize() {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/OutboundDynamicTable.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/OutboundDynamicTable.java
@@ -45,16 +45,20 @@ final class OutboundDynamicTable {
     private int maxSize;
     private int currentSize;
 
-    OutboundDynamicTable(final StaticTable staticTable) {
+    OutboundDynamicTable(final int maxSize, final StaticTable staticTable) {
         this.staticTable = staticTable;
         this.headers = new FifoLinkedList();
         this.mapByName = new HashMap<>();
-        this.maxSize = Integer.MAX_VALUE;
+        this.maxSize = maxSize;
         this.currentSize = 0;
     }
 
+    OutboundDynamicTable(final int maxSize) {
+        this(maxSize, StaticTable.INSTANCE);
+    }
+
     OutboundDynamicTable() {
-        this(StaticTable.INSTANCE);
+        this(Integer.MAX_VALUE);
     }
 
     public int getMaxSize() {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -159,8 +159,8 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         this.pingHandlers = new ConcurrentLinkedQueue<>();
         this.outputRequests = new AtomicInteger(0);
         this.lastStreamId = new AtomicInteger(0);
-        this.hPackEncoder = new HPackEncoder(CharCodingSupport.createEncoder(charCodingConfig));
-        this.hPackDecoder = new HPackDecoder(CharCodingSupport.createDecoder(charCodingConfig));
+        this.hPackEncoder = new HPackEncoder(H2Config.INIT.getHeaderTableSize(), CharCodingSupport.createEncoder(charCodingConfig));
+        this.hPackDecoder = new HPackDecoder(H2Config.INIT.getHeaderTableSize(), CharCodingSupport.createDecoder(charCodingConfig));
         this.streamMap = new ConcurrentHashMap<>();
         this.remoteConfig = H2Config.INIT;
         this.connInputWindow = new AtomicInteger(H2Config.INIT.getInitialWindowSize());
@@ -169,8 +169,6 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         this.initInputWinSize = H2Config.INIT.getInitialWindowSize();
         this.initOutputWinSize = H2Config.INIT.getInitialWindowSize();
 
-        this.hPackDecoder.setMaxTableSize(H2Config.INIT.getHeaderTableSize());
-        this.hPackEncoder.setMaxTableSize(H2Config.INIT.getHeaderTableSize());
         this.hPackDecoder.setMaxListSize(H2Config.INIT.getMaxHeaderListSize());
 
         this.lowMark = H2Config.INIT.getInitialWindowSize() / 2;


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7541#section-6.3

I discovered while using this library that common web browsers (chrome, edge, firefox) encountered HTTP2 protocol/HPACK compression errors when communicating with servers from this library. This was eventually traced to the browser and server using different values for the dynamic table size. I determined this was because this library does not send dynamic table size updates, and instead assumed both sides would immediately use the receiver's maximum table size. After adding encoder support for the dynamic table size update header signal, communication between browser and server is now error-free.