### PR TITLE
Add HTTP Method QUERY support

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
@@ -39,5 +39,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.CLASS)
 public @interface Experimental {
-    String value() default ""; // Useful for documenting the reason for the experimental status
+    String value() default ""; // Useful for documenting the rationale for the experimental status
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
@@ -39,5 +39,4 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.CLASS)
 public @interface Experimental {
-    String value() default ""; // Useful for documenting the rationale for the experimental status
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
@@ -39,5 +39,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.CLASS)
 public @interface Experimental {
-    String reason() default "";
+    String value() default ""; // Useful for documenting the reason for the experimental status
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/annotation/Experimental.java
@@ -36,7 +36,8 @@ import java.lang.annotation.Target;
  * The field or method to which this annotation is applied is marked as experimental.
  */
 @Documented
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.CLASS)
 public @interface Experimental {
+    String reason() default "";
 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -91,7 +91,12 @@ public enum Method {
     /**
      * The HTTP {@code PATCH} method is unsafe and non-idempotent.
      */
-    PATCH(false, false);
+    PATCH(false, false),
+
+    /**
+     * The HTTP {@code QUERY} method is safe and idempotent.
+     */
+    QUERY(true, true);
 
     private final boolean safe;
     private final boolean idempotent;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -104,7 +104,8 @@ public enum Method {
      *
      * @since 5.4
      */
-    @Experimental("QUERY method is still in DRAFT status")
+    @Experimental
+    //("QUERY method is still in DRAFT status")
     QUERY(true, true);
 
     private final boolean safe;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -95,6 +95,11 @@ public enum Method {
 
     /**
      * The HTTP {@code QUERY} method is safe and idempotent.
+     * <p>
+     * {@code QUERY} is a method defined to represent a safe, idempotent request that carries a body.
+     * This allows clients to send a body while enjoying the {@code GET}-like properties (such as easy caching,
+     * safe CORS handling [if supported] and bookmarking), as well as the {@code POST}-like properties (such as
+     * being able to send a query in a richer format, and not being limited by URI length and escaping restrictions).
      *
      * @since 5.4
      */

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http;
 
 import java.util.Locale;
 
+import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -103,6 +104,7 @@ public enum Method {
      *
      * @since 5.4
      */
+    @Experimental(reason = "QUERY method is still in DRAFT status")
     QUERY(true, true);
 
     private final boolean safe;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -95,6 +95,8 @@ public enum Method {
 
     /**
      * The HTTP {@code QUERY} method is safe and idempotent.
+     *
+     * @since 5.4
      */
     QUERY(true, true);
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -104,7 +104,7 @@ public enum Method {
      *
      * @since 5.4
      */
-    @Experimental(reason = "QUERY method is still in DRAFT status")
+    @Experimental("QUERY method is still in DRAFT status")
     QUERY(true, true);
 
     private final boolean safe;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -121,6 +121,10 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
     }
 
     /**
+     * Initializes a new {@link ClassicRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static ClassicRequestBuilder query() {
@@ -128,6 +132,11 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
     }
 
     /**
+     * Initializes a new {@link ClassicRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @param uri the request URI.
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static ClassicRequestBuilder query(final URI uri) {
@@ -135,6 +144,11 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
     }
 
     /**
+     * Initializes a new {@link ClassicRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @param uri the request URI.
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static ClassicRequestBuilder query(final String uri) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -120,6 +120,18 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
         return new ClassicRequestBuilder(Method.HEAD, uri);
     }
 
+    public static ClassicRequestBuilder query() {
+        return new ClassicRequestBuilder(Method.QUERY);
+    }
+
+    public static ClassicRequestBuilder query(final URI uri) {
+        return new ClassicRequestBuilder(Method.QUERY, uri);
+    }
+
+    public static ClassicRequestBuilder query(final String uri) {
+        return new ClassicRequestBuilder(Method.QUERY, uri);
+    }
+
     public static ClassicRequestBuilder patch() {
         return new ClassicRequestBuilder(Method.PATCH);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
@@ -127,6 +128,7 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
      *
      * @since 5.4
      */
+    @Experimental
     public static ClassicRequestBuilder query() {
         return new ClassicRequestBuilder(Method.QUERY);
     }
@@ -139,6 +141,7 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
      *
      * @since 5.4
      */
+    @Experimental
     public static ClassicRequestBuilder query(final URI uri) {
         return new ClassicRequestBuilder(Method.QUERY, uri);
     }
@@ -151,6 +154,7 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
      *
      * @since 5.4
      */
+    @Experimental
     public static ClassicRequestBuilder query(final String uri) {
         return new ClassicRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -120,14 +120,23 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
         return new ClassicRequestBuilder(Method.HEAD, uri);
     }
 
+    /**
+     * @since 5.4
+     */
     public static ClassicRequestBuilder query() {
         return new ClassicRequestBuilder(Method.QUERY);
     }
 
+    /**
+     * @since 5.4
+     */
     public static ClassicRequestBuilder query(final URI uri) {
         return new ClassicRequestBuilder(Method.QUERY, uri);
     }
 
+    /**
+     * @since 5.4
+     */
     public static ClassicRequestBuilder query(final String uri) {
         return new ClassicRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -120,6 +120,18 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
         return new AsyncRequestBuilder(Method.HEAD, uri);
     }
 
+    public static AsyncRequestBuilder query() {
+        return new AsyncRequestBuilder(Method.QUERY);
+    }
+
+    public static AsyncRequestBuilder query(final URI uri) {
+        return new AsyncRequestBuilder(Method.QUERY, uri);
+    }
+
+    public static AsyncRequestBuilder query(final String uri) {
+        return new AsyncRequestBuilder(Method.QUERY, uri);
+    }
+
     public static AsyncRequestBuilder patch() {
         return new AsyncRequestBuilder(Method.PATCH);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -121,6 +121,10 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
     }
 
     /**
+     * Initializes a new {@link AsyncRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static AsyncRequestBuilder query() {
@@ -128,6 +132,11 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
     }
 
     /**
+     * Initializes a new {@link AsyncRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @param uri the request URI.
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static AsyncRequestBuilder query(final URI uri) {
@@ -135,6 +144,11 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
     }
 
     /**
+     * Initializes a new {@link AsyncRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @param uri the request URI.
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static AsyncRequestBuilder query(final String uri) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
@@ -127,6 +128,7 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
      *
      * @since 5.4
      */
+    @Experimental
     public static AsyncRequestBuilder query() {
         return new AsyncRequestBuilder(Method.QUERY);
     }
@@ -139,6 +141,7 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
      *
      * @since 5.4
      */
+    @Experimental
     public static AsyncRequestBuilder query(final URI uri) {
         return new AsyncRequestBuilder(Method.QUERY, uri);
     }
@@ -151,6 +154,7 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
      *
      * @since 5.4
      */
+    @Experimental
     public static AsyncRequestBuilder query(final String uri) {
         return new AsyncRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -120,14 +120,23 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
         return new AsyncRequestBuilder(Method.HEAD, uri);
     }
 
+    /**
+     * @since 5.4
+     */
     public static AsyncRequestBuilder query() {
         return new AsyncRequestBuilder(Method.QUERY);
     }
 
+    /**
+     * @since 5.4
+     */
     public static AsyncRequestBuilder query(final URI uri) {
         return new AsyncRequestBuilder(Method.QUERY, uri);
     }
 
+    /**
+     * @since 5.4
+     */
     public static AsyncRequestBuilder query(final String uri) {
         return new AsyncRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestContent.java
@@ -138,7 +138,7 @@ public class RequestContent implements HttpRequestInterceptor {
     }
 
     private boolean isContentEnclosingMethod(final String method) {
-        return Method.POST.isSame(method) || Method.PUT.isSame(method) || Method.PATCH.isSame(method);
+        return Method.POST.isSame(method) || Method.PUT.isSame(method) || Method.PATCH.isSame(method) || Method.QUERY.isSame(method);
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -104,14 +104,23 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
         return new BasicRequestBuilder(Method.HEAD, uri);
     }
 
+    /**
+     * @since 5.4
+     */
     public static BasicRequestBuilder query() {
         return new BasicRequestBuilder(Method.QUERY);
     }
 
+    /**
+     * @since 5.4
+     */
     public static BasicRequestBuilder query(final URI uri) {
         return new BasicRequestBuilder(Method.QUERY, uri);
     }
 
+    /**
+     * @since 5.4
+     */
     public static BasicRequestBuilder query(final String uri) {
         return new BasicRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
@@ -111,6 +112,7 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
      *
      * @since 5.4
      */
+    @Experimental
     public static BasicRequestBuilder query() {
         return new BasicRequestBuilder(Method.QUERY);
     }
@@ -123,6 +125,7 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
      *
      * @since 5.4
      */
+    @Experimental
     public static BasicRequestBuilder query(final URI uri) {
         return new BasicRequestBuilder(Method.QUERY, uri);
     }
@@ -135,6 +138,7 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
      *
      * @since 5.4
      */
+    @Experimental
     public static BasicRequestBuilder query(final String uri) {
         return new BasicRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -105,6 +105,10 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
     }
 
     /**
+     * Initializes a new {@link BasicRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static BasicRequestBuilder query() {
@@ -112,6 +116,11 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
     }
 
     /**
+     * Initializes a new {@link BasicRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @param uri the request URI.
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static BasicRequestBuilder query(final URI uri) {
@@ -119,6 +128,11 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
     }
 
     /**
+     * Initializes a new {@link BasicRequestBuilder} instance for the {@code QUERY} method.
+     *
+     * @param uri the request URI.
+     * @see Method#QUERY for more information regarding the properties of the {@code QUERY} method.
+     *
      * @since 5.4
      */
     public static BasicRequestBuilder query(final String uri) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -104,6 +104,18 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
         return new BasicRequestBuilder(Method.HEAD, uri);
     }
 
+    public static BasicRequestBuilder query() {
+        return new BasicRequestBuilder(Method.QUERY);
+    }
+
+    public static BasicRequestBuilder query(final URI uri) {
+        return new BasicRequestBuilder(Method.QUERY, uri);
+    }
+
+    public static BasicRequestBuilder query(final String uri) {
+        return new BasicRequestBuilder(Method.QUERY, uri);
+    }
+
     public static BasicRequestBuilder patch() {
         return new BasicRequestBuilder(Method.PATCH);
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilderTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilderTest.java
@@ -110,6 +110,19 @@ class ClassicRequestBuilderTest {
     }
 
     @Test
+    void query() throws UnknownHostException, URISyntaxException {
+        final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.query();
+        assertEquals(Method.QUERY.name(), classicRequestBuilder.getMethod());
+
+        final ClassicRequestBuilder classicRequestBuilder1 = ClassicRequestBuilder.query(URIBuilder.localhost().build());
+        assertEquals(Method.QUERY.name(), classicRequestBuilder1.getMethod());
+
+        final ClassicRequestBuilder classicRequestBuilder3 = ClassicRequestBuilder.query("/localhost");
+        assertEquals(Method.QUERY.name(), classicRequestBuilder3.getMethod());
+        assertEquals("/localhost", classicRequestBuilder3.getPath());
+    }
+
+    @Test
     void patch() throws UnknownHostException, URISyntaxException {
         final ClassicRequestBuilder classicRequestBuilder = ClassicRequestBuilder.patch();
         assertEquals(Method.PATCH.name(), classicRequestBuilder.getMethod());


### PR DESCRIPTION
This PR introduces support for the HTTP Method `QUERY`, a safe-idempotent method that has a body. Since Node added [support for the query method](https://github.com/nodejs/node/issues/51562), there is now a need for clients to support it and behave properly (like sending content length == 0 when skipping a body).