### PR TITLE
Add NoConnectionReuseStrategy

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/NoConnectionReuseStrategy.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/NoConnectionReuseStrategy.java
@@ -1,0 +1,50 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http.impl;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.ConnectionReuseStrategy;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/**
+ * A strategy that never reuses a connection.
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
+public class NoConnectionReuseStrategy implements ConnectionReuseStrategy {
+
+    public static final NoConnectionReuseStrategy INSTANCE = new NoConnectionReuseStrategy();
+
+    @Override
+    public boolean keepAlive(final HttpRequest request, final HttpResponse response, final HttpContext context) {
+        return false;
+    }
+
+}


### PR DESCRIPTION
This PR adds `NoConnectionReuseStrategy` for v5 like [`NoConnectionReuseStrategy`](https://github.com/apache/httpcomponents-core/blob/4.4.x/httpcore/src/main/java/org/apache/http/impl/NoConnectionReuseStrategy.java) in v4.