### PR TITLE
Optimize connection close logic to resolve timeout delay issue

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
@@ -56,10 +56,11 @@ public class Http1Config {
     private final int maxHeaderCount;
     private final int maxEmptyLineCount;
     private final int initialWindowSize;
+    private final boolean useRstOnTimeout;
 
     Http1Config(final HttpVersion version, final int bufferSize, final int chunkSizeHint,
                 final Timeout waitForContinueTimeout, final int maxLineLength, final int maxHeaderCount,
-                final int maxEmptyLineCount, final int initialWindowSize) {
+                final int maxEmptyLineCount, final int initialWindowSize, final boolean useRstOnTimeout) {
         super();
         this.version = version;
         this.bufferSize = bufferSize;
@@ -69,6 +70,7 @@ public class Http1Config {
         this.maxHeaderCount = maxHeaderCount;
         this.maxEmptyLineCount = maxEmptyLineCount;
         this.initialWindowSize = initialWindowSize;
+        this.useRstOnTimeout = useRstOnTimeout;
     }
 
     /**
@@ -109,6 +111,10 @@ public class Http1Config {
         return initialWindowSize;
     }
 
+    public boolean getUseRstOnTimeout() {
+        return useRstOnTimeout;
+    }
+
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
@@ -120,6 +126,7 @@ public class Http1Config {
                 .append(", maxHeaderCount=").append(maxHeaderCount)
                 .append(", maxEmptyLineCount=").append(maxEmptyLineCount)
                 .append(", initialWindowSize=").append(initialWindowSize)
+                .append(", useRstOnTimeout=").append(useRstOnTimeout)
                 .append("]");
         return builder.toString();
     }
@@ -147,6 +154,7 @@ public class Http1Config {
     private static final int INIT_MAX_HEADER_COUNT = -1;
     private static final int INIT_MAX_LINE_LENGTH = -1;
     private static final int INIT_MAX_EMPTY_LINE_COUNT = 10;
+    private static final boolean USE_RST_ON_TIMEOUT = false;
 
     public static class Builder {
 
@@ -158,6 +166,7 @@ public class Http1Config {
         private int maxHeaderCount;
         private int maxEmptyLineCount;
         private int initialWindowSize;
+        private boolean userRstOnTimeout;
 
         Builder() {
             this.version = HttpVersion.HTTP_1_1;
@@ -168,6 +177,7 @@ public class Http1Config {
             this.maxHeaderCount = INIT_MAX_HEADER_COUNT;
             this.maxEmptyLineCount = INIT_MAX_EMPTY_LINE_COUNT;
             this.initialWindowSize = INIT_WINDOW_SIZE;
+            this.userRstOnTimeout = USE_RST_ON_TIMEOUT;
         }
 
         /**
@@ -222,6 +232,11 @@ public class Http1Config {
             return this;
         }
 
+        public Builder setUserRstOnTimeout(final boolean userRstOnTimeout) {
+            this.userRstOnTimeout = userRstOnTimeout;
+            return this;
+        }
+
         public Http1Config build() {
             return new Http1Config(
                     version,
@@ -231,7 +246,8 @@ public class Http1Config {
                     maxLineLength,
                     maxHeaderCount,
                     maxEmptyLineCount,
-                    initialWindowSize);
+                    initialWindowSize,
+                    userRstOnTimeout);
         }
 
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
@@ -56,11 +56,10 @@ public class Http1Config {
     private final int maxHeaderCount;
     private final int maxEmptyLineCount;
     private final int initialWindowSize;
-    private final boolean useRstOnTimeout;
 
     Http1Config(final HttpVersion version, final int bufferSize, final int chunkSizeHint,
                 final Timeout waitForContinueTimeout, final int maxLineLength, final int maxHeaderCount,
-                final int maxEmptyLineCount, final int initialWindowSize, final boolean useRstOnTimeout) {
+                final int maxEmptyLineCount, final int initialWindowSize) {
         super();
         this.version = version;
         this.bufferSize = bufferSize;
@@ -70,7 +69,6 @@ public class Http1Config {
         this.maxHeaderCount = maxHeaderCount;
         this.maxEmptyLineCount = maxEmptyLineCount;
         this.initialWindowSize = initialWindowSize;
-        this.useRstOnTimeout = useRstOnTimeout;
     }
 
     /**
@@ -111,13 +109,6 @@ public class Http1Config {
         return initialWindowSize;
     }
 
-    /**
-     * @since 5.4
-     */
-    public boolean getUseRstOnTimeout() {
-        return useRstOnTimeout;
-    }
-
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
@@ -129,7 +120,6 @@ public class Http1Config {
                 .append(", maxHeaderCount=").append(maxHeaderCount)
                 .append(", maxEmptyLineCount=").append(maxEmptyLineCount)
                 .append(", initialWindowSize=").append(initialWindowSize)
-                .append(", useRstOnTimeout=").append(useRstOnTimeout)
                 .append("]");
         return builder.toString();
     }
@@ -157,7 +147,6 @@ public class Http1Config {
     private static final int INIT_MAX_HEADER_COUNT = -1;
     private static final int INIT_MAX_LINE_LENGTH = -1;
     private static final int INIT_MAX_EMPTY_LINE_COUNT = 10;
-    private static final boolean USE_RST_ON_TIMEOUT = false;
 
     public static class Builder {
 
@@ -169,7 +158,6 @@ public class Http1Config {
         private int maxHeaderCount;
         private int maxEmptyLineCount;
         private int initialWindowSize;
-        private boolean userRstOnTimeout;
 
         Builder() {
             this.version = HttpVersion.HTTP_1_1;
@@ -180,7 +168,6 @@ public class Http1Config {
             this.maxHeaderCount = INIT_MAX_HEADER_COUNT;
             this.maxEmptyLineCount = INIT_MAX_EMPTY_LINE_COUNT;
             this.initialWindowSize = INIT_WINDOW_SIZE;
-            this.userRstOnTimeout = USE_RST_ON_TIMEOUT;
         }
 
         /**
@@ -235,14 +222,6 @@ public class Http1Config {
             return this;
         }
 
-        /**
-         * @since 5.4
-         */
-        public Builder setUserRstOnTimeout(final boolean userRstOnTimeout) {
-            this.userRstOnTimeout = userRstOnTimeout;
-            return this;
-        }
-
         public Http1Config build() {
             return new Http1Config(
                     version,
@@ -252,8 +231,7 @@ public class Http1Config {
                     maxLineLength,
                     maxHeaderCount,
                     maxEmptyLineCount,
-                    initialWindowSize,
-                    userRstOnTimeout);
+                    initialWindowSize);
         }
 
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/config/Http1Config.java
@@ -111,6 +111,9 @@ public class Http1Config {
         return initialWindowSize;
     }
 
+    /**
+     * @since 5.4
+     */
     public boolean getUseRstOnTimeout() {
         return useRstOnTimeout;
     }
@@ -232,6 +235,9 @@ public class Http1Config {
             return this;
         }
 
+        /**
+         * @since 5.4
+         */
         public Builder setUserRstOnTimeout(final boolean userRstOnTimeout) {
             this.userRstOnTimeout = userRstOnTimeout;
             return this;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
@@ -59,6 +59,8 @@ import org.apache.hc.core5.io.Closer;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 
+import javax.net.ssl.SSLException;
+
 /**
  * {@code HttpRequestExecutor} is a client side HTTP protocol handler based
  * on the blocking (classic) I/O model.
@@ -212,8 +214,11 @@ public class HttpRequestExecutor {
             }
             return response;
 
-        } catch (final HttpException | IOException | RuntimeException ex) {
+        } catch (final IOException | RuntimeException ex) {
             Closer.close(conn, CloseMode.IMMEDIATE);
+            throw ex;
+        } catch (final HttpException ex) {
+            Closer.closeQuietly(conn);
             throw ex;
         }
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
@@ -214,11 +214,11 @@ public class HttpRequestExecutor {
             }
             return response;
 
+        } catch (final HttpException | SSLException ex) {
+            Closer.closeQuietly(conn);
+            throw ex;
         } catch (final IOException | RuntimeException ex) {
             Closer.close(conn, CloseMode.IMMEDIATE);
-            throw ex;
-        } catch (final HttpException ex) {
-            Closer.closeQuietly(conn);
             throw ex;
         }
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
@@ -54,6 +54,7 @@ import org.apache.hc.core5.http.message.StatusLine;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
+import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.Closer;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
@@ -212,7 +213,11 @@ public class HttpRequestExecutor {
             return response;
 
         } catch (final HttpException | IOException | RuntimeException ex) {
-            Closer.closeQuietly(conn);
+            if (http1Config.getUseRstOnTimeout()) {
+                Closer.close(conn, CloseMode.IMMEDIATE);
+            } else {
+                Closer.closeQuietly(conn);
+            }
             throw ex;
         }
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpRequestExecutor.java
@@ -213,11 +213,7 @@ public class HttpRequestExecutor {
             return response;
 
         } catch (final HttpException | IOException | RuntimeException ex) {
-            if (http1Config.getUseRstOnTimeout()) {
-                Closer.close(conn, CloseMode.IMMEDIATE);
-            } else {
-                Closer.closeQuietly(conn);
-            }
+            Closer.close(conn, CloseMode.IMMEDIATE);
             throw ex;
         }
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
@@ -27,12 +27,7 @@
 
 package org.apache.hc.core5.http.impl.io;
 
-import java.io.IOException;
-import java.net.SocketTimeoutException;
-import java.util.List;
-
 import org.apache.hc.core5.http.*;
-import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
@@ -46,6 +41,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.List;
 
 class TestHttpRequestExecutor {
 

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
@@ -27,7 +27,14 @@
 
 package org.apache.hc.core5.http.impl.io;
 
-import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HeaderElements;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
@@ -28,6 +28,7 @@
 package org.apache.hc.core5.http.impl.io;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.List;
 
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -37,12 +38,14 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
+import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -402,7 +405,7 @@ class TestHttpRequestExecutor {
 
         Mockito.doThrow(new IOException("Oopsie")).when(conn).sendRequestHeader(request);
         Assertions.assertThrows(IOException.class, () -> executor.execute(request, conn, context));
-        Mockito.verify(conn).close();
+        Mockito.verify(conn).close(CloseMode.IMMEDIATE);
     }
 
     @Test
@@ -415,7 +418,7 @@ class TestHttpRequestExecutor {
 
         Mockito.doThrow(new RuntimeException("Oopsie")).when(conn).receiveResponseHeader();
         Assertions.assertThrows(RuntimeException.class, () -> executor.execute(request, conn, context));
-        Mockito.verify(conn).close();
+        Mockito.verify(conn).close(CloseMode.IMMEDIATE);
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/impl/io/TestHttpRequestExecutor.java
@@ -31,13 +31,7 @@ import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.List;
 
-import org.apache.hc.core5.http.ClassicHttpRequest;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.HeaderElements;
-import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.*;
 import org.apache.hc.core5.http.config.Http1Config;
 import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
@@ -419,6 +413,19 @@ class TestHttpRequestExecutor {
         Mockito.doThrow(new RuntimeException("Oopsie")).when(conn).receiveResponseHeader();
         Assertions.assertThrows(RuntimeException.class, () -> executor.execute(request, conn, context));
         Mockito.verify(conn).close(CloseMode.IMMEDIATE);
+    }
+
+    @Test
+    void testExecutionHttpException() throws Exception {
+        final HttpClientConnection conn = Mockito.mock(HttpClientConnection.class);
+        final HttpRequestExecutor executor = new HttpRequestExecutor();
+
+        final HttpCoreContext context = HttpCoreContext.create();
+        final ClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");
+
+        Mockito.doThrow(new HttpException("Oopsie")).when(conn).receiveResponseHeader();
+        Assertions.assertThrows(HttpException.class, () -> executor.execute(request, conn, context));
+        Mockito.verify(conn).close();
     }
 
 }


### PR DESCRIPTION
## Description

- Introduced a configuration option useRstOnTimeout in Http1Config to allow connections to be closed with an RST (Reset) signal when a timeout occurs.
- Updated HttpRequestExecutor to respect this configuration and invoke the appropriate close mode (CloseMode.IMMEDIATE for RST or Closer.closeQuietly for FIN).
- Maintained backward compatibility by defaulting to FIN-based connection closure.

This change improves flexibility and allows faster resource cleanup in timeout scenarios, aligning with the HTTP/1.1 recommendations for abnormal connection termination.

## Problem Description

There is an issue where the connection close operation takes as long as the SocketTimeout value set in the SocketConfig after a Socket timeout occurs. This behavior arises because the NioSocketImpl performs an additional poll for the duration of the SocketTimeout during the close operation. Consequently, HTTP requests may experience delays of up to twice the configured SocketTimeout value.


## Proposed Solution

This Pull Request introduces the useRstOnTimeout configuration option to mitigate this issue by enabling connections to be closed using an RST signal instead of a FIN-based closure.
- Key benefits:
  - Avoids unnecessary delays during connection closure.
  - Ensures efficient resource cleanup.
  - Maintains backward compatibility by defaulting to FIN-based closure.

_The following image shows the test results with the socket timeout value set to 5 seconds_
<img width="1466" alt="img-1" src="https://github.com/user-attachments/assets/9176273c-a89c-49be-a117-29104ce2384f">

<img width="1022" alt="img-2" src="https://github.com/user-attachments/assets/0cc6eda5-d0a3-49b5-9f6b-8df956cc711c">


## Example Workflow Before Fix

1. Socket timeout occurs:
   The socket reaches the timeout value specified in the SocketTimeout configuration.
2. Connection close:
   During the close operation, the NioSocketImpl performs an additional poll for the same timeout duration.
3. Total wait time:
   HTTP requests may end up waiting for up to twice the configured SocketTimeout value.

Resolves: [HTTPCLIENT-2324](https://issues.apache.org/jira/browse/HTTPCLIENT-2324)