### PR TITLE
Handle overflow in Deadline calculation to ensure correct behavior for large time values.

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Deadline.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Deadline.java
@@ -83,9 +83,8 @@ public class Deadline {
      */
     public static Deadline calculate(final long timeMillis, final TimeValue timeValue) {
         if (TimeValue.isPositive(timeValue)) {
-            // TODO handle unlikely overflow
-            final long deadline = timeMillis + timeValue.toMilliseconds();
-            return deadline < 0 ? Deadline.MAX_VALUE : Deadline.fromUnixMilliseconds(deadline);
+            return Deadline.fromUnixMilliseconds(timeMillis +
+                    Math.min(timeValue.toMilliseconds(), Long.MAX_VALUE - timeMillis));
         }
         return Deadline.MAX_VALUE;
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/util/TestDeadline.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/util/TestDeadline.java
@@ -130,4 +130,14 @@ class TestDeadline {
         final Deadline deadline = Deadline.fromUnixMilliseconds(nowPlusOneMin);
         Assertions.assertEquals(nowPlusOneMin, deadline.getValue());
     }
+
+    @Test
+    void testOverflowHandling() {
+        final long currentTime = Long.MAX_VALUE - 5000; // Simulate close to overflow
+        final TimeValue tenSeconds = TimeValue.ofMilliseconds(10000); // 10 seconds
+        final Deadline deadline = Deadline.calculate(currentTime, tenSeconds);
+
+        Assertions.assertEquals(Deadline.MAX_VALUE, deadline,
+                "Overflow should result in the maximum deadline value.");
+    }
 }


### PR DESCRIPTION
Fixes overflow handling in Deadline calculation to ensure proper behavior when adding large time values, returning Deadline.MAX_VALUE in case of overflow.