### PR TITLE
HTTPCORE-775: The SSLIOSession::write does not handle SSLEngineResult#BUFFER_OVERFLOW

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/SSLTestContexts.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/SSLTestContexts.java
@@ -40,16 +40,24 @@ import javax.net.ssl.SSLContext;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 
 public final class SSLTestContexts {
-
     public static SSLContext createServerSSLContext() {
+        return createServerSSLContext(null);
+    }
+
+    public static SSLContext createServerSSLContext(final String protocol) {
         final URL keyStoreURL = SSLTestContexts.class.getResource("/test.p12");
         final String storePassword = "nopassword";
         try {
-            return SSLContextBuilder.create()
+            SSLContextBuilder sslContextBuilder = SSLContextBuilder.create()
                     .setKeyStoreType("pkcs12")
                     .loadTrustMaterial(keyStoreURL, storePassword.toCharArray())
-                    .loadKeyMaterial(keyStoreURL, storePassword.toCharArray(), storePassword.toCharArray())
-                    .build();
+                    .loadKeyMaterial(keyStoreURL, storePassword.toCharArray(), storePassword.toCharArray());
+
+            if (protocol != null) {
+                sslContextBuilder = sslContextBuilder.setProtocol(protocol);
+            }
+
+            return sslContextBuilder.build();
         } catch (final NoSuchAlgorithmException | KeyManagementException | KeyStoreException | CertificateException |
                        UnrecoverableKeyException | IOException ex) {
             throw new IllegalStateException(ex);
@@ -57,13 +65,22 @@ public final class SSLTestContexts {
     }
 
     public static SSLContext createClientSSLContext() {
+        return createClientSSLContext(null);
+    }
+
+    public static SSLContext createClientSSLContext(final String protocol) {
         final URL keyStoreURL = SSLTestContexts.class.getResource("/test.p12");
         final String storePassword = "nopassword";
         try {
-            return SSLContextBuilder.create()
+            SSLContextBuilder sslContextBuilder = SSLContextBuilder.create()
                     .setKeyStoreType("pkcs12")
-                    .loadTrustMaterial(keyStoreURL, storePassword.toCharArray())
-                    .build();
+                    .loadTrustMaterial(keyStoreURL, storePassword.toCharArray());
+
+            if (protocol != null) {
+                sslContextBuilder = sslContextBuilder.setProtocol(protocol);
+            }
+
+            return sslContextBuilder.build();
         } catch (final NoSuchAlgorithmException | KeyManagementException | KeyStoreException | CertificateException |
                        IOException ex) {
             throw new IllegalStateException(ex);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/SSLTestContexts.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/SSLTestContexts.java
@@ -48,16 +48,12 @@ public final class SSLTestContexts {
         final URL keyStoreURL = SSLTestContexts.class.getResource("/test.p12");
         final String storePassword = "nopassword";
         try {
-            SSLContextBuilder sslContextBuilder = SSLContextBuilder.create()
+            return SSLContextBuilder.create()
                     .setKeyStoreType("pkcs12")
                     .loadTrustMaterial(keyStoreURL, storePassword.toCharArray())
-                    .loadKeyMaterial(keyStoreURL, storePassword.toCharArray(), storePassword.toCharArray());
-
-            if (protocol != null) {
-                sslContextBuilder = sslContextBuilder.setProtocol(protocol);
-            }
-
-            return sslContextBuilder.build();
+                    .loadKeyMaterial(keyStoreURL, storePassword.toCharArray(), storePassword.toCharArray())
+                    .setProtocol(protocol)
+                    .build();
         } catch (final NoSuchAlgorithmException | KeyManagementException | KeyStoreException | CertificateException |
                        UnrecoverableKeyException | IOException ex) {
             throw new IllegalStateException(ex);
@@ -72,15 +68,11 @@ public final class SSLTestContexts {
         final URL keyStoreURL = SSLTestContexts.class.getResource("/test.p12");
         final String storePassword = "nopassword";
         try {
-            SSLContextBuilder sslContextBuilder = SSLContextBuilder.create()
+            return SSLContextBuilder.create()
                     .setKeyStoreType("pkcs12")
-                    .loadTrustMaterial(keyStoreURL, storePassword.toCharArray());
-
-            if (protocol != null) {
-                sslContextBuilder = sslContextBuilder.setProtocol(protocol);
-            }
-
-            return sslContextBuilder.build();
+                    .loadTrustMaterial(keyStoreURL, storePassword.toCharArray())
+                    .setProtocol(protocol)
+                    .build();
         } catch (final NoSuchAlgorithmException | KeyManagementException | KeyStoreException | CertificateException |
                        IOException ex) {
             throw new IllegalStateException(ex);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportTest.java
@@ -58,12 +58,12 @@ abstract class H2CoreTransportTest extends HttpCoreTransportTest {
         this(scheme, null);
     }
 
-    public H2CoreTransportTest(final URIScheme scheme, final String protocol) {
+    public H2CoreTransportTest(final URIScheme scheme, final String tlsProtocol) {
         super(scheme);
         this.serverResource = new H2AsyncServerResource();
         this.serverResource.configure(bootstrap -> bootstrap
                 .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
-                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext(protocol)))
+                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext(tlsProtocol)))
                 .setIOReactorConfig(
                         IOReactorConfig.custom()
                                 .setSoTimeout(TIMEOUT)
@@ -76,7 +76,7 @@ abstract class H2CoreTransportTest extends HttpCoreTransportTest {
         this.clientResource = new H2AsyncRequesterResource();
         this.clientResource.configure(bootstrap -> bootstrap
                 .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
-                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext(protocol)))
+                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext(tlsProtocol)))
                 .setIOReactorConfig(IOReactorConfig.custom()
                         .setSoTimeout(TIMEOUT)
                         .build())

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2CoreTransportTest.java
@@ -55,11 +55,15 @@ abstract class H2CoreTransportTest extends HttpCoreTransportTest {
     private final H2AsyncRequesterResource clientResource;
 
     public H2CoreTransportTest(final URIScheme scheme) {
+        this(scheme, null);
+    }
+
+    public H2CoreTransportTest(final URIScheme scheme, final String protocol) {
         super(scheme);
         this.serverResource = new H2AsyncServerResource();
         this.serverResource.configure(bootstrap -> bootstrap
                 .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
-                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext()))
+                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext(protocol)))
                 .setIOReactorConfig(
                         IOReactorConfig.custom()
                                 .setSoTimeout(TIMEOUT)
@@ -72,7 +76,7 @@ abstract class H2CoreTransportTest extends HttpCoreTransportTest {
         this.clientResource = new H2AsyncRequesterResource();
         this.clientResource.configure(bootstrap -> bootstrap
                 .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
-                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext()))
+                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext(protocol)))
                 .setIOReactorConfig(IOReactorConfig.custom()
                         .setSoTimeout(TIMEOUT)
                         .build())

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1CoreTransportTest.java
@@ -82,11 +82,11 @@ abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
         this(scheme, null);
     }
 
-    public Http1CoreTransportTest(final URIScheme scheme, final String protocol) {
+    public Http1CoreTransportTest(final URIScheme scheme, final String tlsProtocol) {
         super(scheme);
         this.serverResource = new HttpAsyncServerResource();
         this.serverResource.configure(bootstrap -> bootstrap
-                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext(protocol)))
+                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext(tlsProtocol)))
                 .setIOReactorConfig(
                         IOReactorConfig.custom()
                                 .setSoTimeout(TIMEOUT)
@@ -125,7 +125,7 @@ abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
         );
         this.clientResource = new HttpAsyncRequesterResource();
         this.clientResource.configure(bootstrap -> bootstrap
-                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext(protocol)))
+                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext(tlsProtocol)))
                 .setIOReactorConfig(IOReactorConfig.custom()
                         .setSoTimeout(TIMEOUT)
                         .build())

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1CoreTransportTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1CoreTransportTest.java
@@ -79,10 +79,14 @@ abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
     private final HttpAsyncRequesterResource clientResource;
 
     public Http1CoreTransportTest(final URIScheme scheme) {
+        this(scheme, null);
+    }
+
+    public Http1CoreTransportTest(final URIScheme scheme, final String protocol) {
         super(scheme);
         this.serverResource = new HttpAsyncServerResource();
         this.serverResource.configure(bootstrap -> bootstrap
-                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext()))
+                .setTlsStrategy(new H2ServerTlsStrategy(SSLTestContexts.createServerSSLContext(protocol)))
                 .setIOReactorConfig(
                         IOReactorConfig.custom()
                                 .setSoTimeout(TIMEOUT)
@@ -121,7 +125,7 @@ abstract class Http1CoreTransportTest extends HttpCoreTransportTest {
         );
         this.clientResource = new HttpAsyncRequesterResource();
         this.clientResource.configure(bootstrap -> bootstrap
-                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext()))
+                .setTlsStrategy(new H2ClientTlsStrategy(SSLTestContexts.createClientSSLContext(protocol)))
                 .setIOReactorConfig(IOReactorConfig.custom()
                         .setSoTimeout(TIMEOUT)
                         .build())

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpIntegrationTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/HttpIntegrationTests.java
@@ -54,6 +54,16 @@ class HttpIntegrationTests {
     }
 
     @Nested
+    @DisplayName("Core transport (HTTP/1.1, TLSv1.3)")
+    class CoreTransportTls13 extends Http1CoreTransportTest {
+
+        public CoreTransportTls13() {
+            super(URIScheme.HTTPS, "TLSv1.3");
+        }
+
+    }
+
+    @Nested
     @DisplayName("Core transport (H2)")
     class CoreTransportH2 extends H2CoreTransportTest {
 
@@ -69,6 +79,16 @@ class HttpIntegrationTests {
 
         public CoreTransportH2Tls() {
             super(URIScheme.HTTPS);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Core transport (H2, TLSv1.3)")
+    class CoreTransportH2Tls13 extends H2CoreTransportTest {
+
+        public CoreTransportH2Tls13() {
+            super(URIScheme.HTTPS, "TLSv1.3");
         }
 
     }


### PR DESCRIPTION
The SSLIOSession::write does not handle SSLEngineResult#BUFFER_OVERFLOW. The suggested fix it to make sure there is enough place in the output buffer to store `SSLSession#getPacketBufferSize()` bytes. Closes https://issues.apache.org/jira/browse/HTTPCORE-775