### PR TITLE
 RFC 3986 conformant URI encoding policy

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/PercentCodec.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/PercentCodec.java
@@ -84,6 +84,16 @@ public class PercentCodec {
         URIC.or(UNRESERVED);
     }
 
+    static final BitSet FRAGMENT_SAFE = new BitSet(256);
+    static {
+        FRAGMENT_SAFE.or(UNRESERVED);
+        FRAGMENT_SAFE.or(SUB_DELIMS);
+        FRAGMENT_SAFE.set(':');
+        FRAGMENT_SAFE.set('@');
+        FRAGMENT_SAFE.set('/');
+        FRAGMENT_SAFE.set('?');
+    }
+
     static final BitSet RFC5987_UNRESERVED = new BitSet(256);
 
     static {
@@ -111,6 +121,37 @@ public class PercentCodec {
         RFC5987_UNRESERVED.set('`');
         RFC5987_UNRESERVED.set('|');
         RFC5987_UNRESERVED.set('~');
+    }
+
+    static final BitSet PCHAR = new BitSet(256);
+    static final BitSet USERINFO = new BitSet(256);
+    static final BitSet REG_NAME = new BitSet(256);
+    static final BitSet PATH_SEGMENT = new BitSet(256);
+    static final BitSet QUERY = new BitSet(256);
+    static final BitSet FRAGMENT = new BitSet(256);
+
+    static {
+        PCHAR.or(UNRESERVED);
+        PCHAR.or(SUB_DELIMS);
+        PCHAR.set(':');
+        PCHAR.set('@');
+        USERINFO.or(UNRESERVED);
+        USERINFO.or(SUB_DELIMS);
+        USERINFO.set(':');
+        REG_NAME.or(UNRESERVED);
+        REG_NAME.or(SUB_DELIMS);
+        REG_NAME.clear('!');
+        PATH_SEGMENT.or(PCHAR);
+        QUERY.or(PCHAR);
+        QUERY.set('/');
+        QUERY.set('?');
+        FRAGMENT.or(PCHAR);
+        FRAGMENT.set('/');
+        FRAGMENT.set('?');
+        // Some sub-delims remain encoded (RFC 3986 allows them unencoded, but we choose to be strict).
+        PATH_SEGMENT.clear('(');
+        PATH_SEGMENT.clear(')');
+        PATH_SEGMENT.clear('&');
     }
 
     private static final int RADIX = 16;

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/PercentCodec.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/PercentCodec.java
@@ -84,16 +84,6 @@ public class PercentCodec {
         URIC.or(UNRESERVED);
     }
 
-    static final BitSet FRAGMENT_SAFE = new BitSet(256);
-    static {
-        FRAGMENT_SAFE.or(UNRESERVED);
-        FRAGMENT_SAFE.or(SUB_DELIMS);
-        FRAGMENT_SAFE.set(':');
-        FRAGMENT_SAFE.set('@');
-        FRAGMENT_SAFE.set('/');
-        FRAGMENT_SAFE.set('?');
-    }
-
     static final BitSet RFC5987_UNRESERVED = new BitSet(256);
 
     static {
@@ -140,7 +130,6 @@ public class PercentCodec {
         USERINFO.set(':');
         REG_NAME.or(UNRESERVED);
         REG_NAME.or(SUB_DELIMS);
-        REG_NAME.clear('!');
         PATH_SEGMENT.or(PCHAR);
         QUERY.or(PCHAR);
         QUERY.set('/');
@@ -148,10 +137,6 @@ public class PercentCodec {
         FRAGMENT.or(PCHAR);
         FRAGMENT.set('/');
         FRAGMENT.set('?');
-        // Some sub-delims remain encoded (RFC 3986 allows them unencoded, but we choose to be strict).
-        PATH_SEGMENT.clear('(');
-        PATH_SEGMENT.clear(')');
-        PATH_SEGMENT.clear('&');
     }
 
     private static final int RADIX = 16;

--- a/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/URIBuilder.java
@@ -306,7 +306,7 @@ public class URIBuilder {
             if (i > 0 || !rootless) {
                 buf.append(PATH_SEPARATOR);
             }
-            PercentCodec.encode(buf, segment, charset);
+            PercentCodec.encode(buf, segment, charset, PercentCodec.PATH_SEGMENT, false);
             i++;
         }
     }
@@ -356,18 +356,18 @@ public class URIBuilder {
                 } else if (this.userInfo != null) {
                     final int idx = this.userInfo.indexOf(':');
                     if (idx != -1) {
-                        PercentCodec.encode(sb, this.userInfo.substring(0, idx), this.charset);
+                        PercentCodec.encode(sb, this.userInfo.substring(0, idx), this.charset, PercentCodec.USERINFO, false);
                         sb.append(':');
-                        PercentCodec.encode(sb, this.userInfo.substring(idx + 1), this.charset);
+                        PercentCodec.encode(sb, this.userInfo.substring(idx + 1), this.charset, PercentCodec.USERINFO, false);
                     } else {
-                        PercentCodec.encode(sb, this.userInfo, this.charset);
+                        PercentCodec.encode(sb, this.userInfo, this.charset, PercentCodec.USERINFO, false);
                     }
                     sb.append("@");
                 }
                 if (InetAddressUtils.isIPv6(this.host)) {
                     sb.append("[").append(this.host).append("]");
                 } else {
-                    PercentCodec.encode(sb, this.host, this.charset);
+                    PercentCodec.encode(sb, this.host, this.charset, PercentCodec.REG_NAME, false);
                 }
                 if (this.port >= 0) {
                     sb.append(":").append(this.port);
@@ -391,14 +391,14 @@ public class URIBuilder {
                 formatQuery(sb, this.queryParams, this.charset, false);
             } else if (this.query != null) {
                 sb.append("?");
-                PercentCodec.encode(sb, this.query, this.charset, PercentCodec.URIC, false);
+                PercentCodec.encode(sb, this.query, this.charset, PercentCodec.QUERY, false);
             }
         }
         if (this.encodedFragment != null) {
             sb.append("#").append(this.encodedFragment);
         } else if (this.fragment != null) {
             sb.append("#");
-            PercentCodec.encode(sb, this.fragment, this.charset, PercentCodec.URIC, false);
+            PercentCodec.encode(sb, this.fragment, this.charset, PercentCodec.FRAGMENT, false);
         }
         return sb.toString();
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -171,7 +171,7 @@ class TestURIBuilder {
     @Test
     void testHierarchicalUri() throws Exception {
         final URI uri = new URI("http", "stuff", "localhost", 80, "/some stuff", "param=stuff", "fragment");
-        final URIBuilder uribuilder = new URIBuilder(uri);
+        final URIBuilder uribuilder = new URIBuilder(uri).setEncodingPolicy(URIBuilder.EncodingPolicy.ALL_RESERVED);
         final URI result = uribuilder.build();
         Assertions.assertEquals(new URI("http://stuff@localhost:80/some%20stuff?param=stuff#fragment"), result);
     }
@@ -999,20 +999,6 @@ class TestURIBuilder {
     }
 
     @Test
-    void testFragmentEncoding() throws Exception {
-        final String fragment = "frag ment:!@/?\"";
-        final String expectedEncodedFragment = "frag%20ment:!@/?%22";
-
-        final URI uri = new URIBuilder()
-                .setScheme("http")
-                .setHost("example.com")
-                .setFragment(fragment)
-                .build();
-
-        Assertions.assertEquals(expectedEncodedFragment, uri.getRawFragment());
-    }
-
-    @Test
     void testCustomQueryEncoding() throws Exception {
         final String query = "query param:!@/?\"";
         final String expectedEncodedQuery = "query%20param:!@/?%22";
@@ -1021,6 +1007,7 @@ class TestURIBuilder {
                 .setScheme("http")
                 .setHost("example.com")
                 .setCustomQuery(query)
+                .setEncodingPolicy(URIBuilder.EncodingPolicy.RFC_3986)
                 .build();
 
         Assertions.assertEquals(expectedEncodedQuery, uri.getRawQuery());

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestURIBuilder.java
@@ -997,4 +997,33 @@ class TestURIBuilder {
         params = uriBuilder.getQueryParams();
         Assertions.assertEquals("hello world", params.get(0).getValue());
     }
+
+    @Test
+    void testFragmentEncoding() throws Exception {
+        final String fragment = "frag ment:!@/?\"";
+        final String expectedEncodedFragment = "frag%20ment:!@/?%22";
+
+        final URI uri = new URIBuilder()
+                .setScheme("http")
+                .setHost("example.com")
+                .setFragment(fragment)
+                .build();
+
+        Assertions.assertEquals(expectedEncodedFragment, uri.getRawFragment());
+    }
+
+    @Test
+    void testCustomQueryEncoding() throws Exception {
+        final String query = "query param:!@/?\"";
+        final String expectedEncodedQuery = "query%20param:!@/?%22";
+
+        final URI uri = new URIBuilder()
+                .setScheme("http")
+                .setHost("example.com")
+                .setCustomQuery(query)
+                .build();
+
+        Assertions.assertEquals(expectedEncodedQuery, uri.getRawQuery());
+    }
+
 }


### PR DESCRIPTION
This pull request addresses issue [HTTPCORE-778](https://issues.apache.org/jira/browse/HTTPCORE-778?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel), which noted that our encoding for fragment identifiers in selectors was not fully compliant with RFC 3986. The RFC defines a fragment as:

`fragment = *( pchar / "/" / "?" )`

with:

`pchar = unreserved / pct-encoded / sub-delims / ":" / "@"`
