### PR TITLE
Avoid legacy Socket API in reactor code

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
@@ -131,12 +131,20 @@ class IOSessionImpl implements IOSession {
 
     @Override
     public SocketAddress getLocalAddress() {
-        return this.channel.socket().getLocalSocketAddress();
+        try {
+            return this.channel.getLocalAddress();
+        } catch (final IOException e) {
+            return null;
+        }
     }
 
     @Override
     public SocketAddress getRemoteAddress() {
-        return this.channel.socket().getRemoteSocketAddress();
+        try {
+            return channel.getRemoteAddress();
+        } catch (final IOException e) {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
The `Socket` API is considered tightly coupled to Internet Protocol, and `socketChannel.socket()` is effectively a kind of unchecked downcast which will throw an exception if called on a Unix domain `SocketChannel`. This change removes some trivial coupling to `Socket` in preparation for introducing support for JEP 380 Unix domain sockets.