### PR TITLE
h2: add choosing framefactory impl

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamMultiplexerFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2StreamMultiplexerFactory.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.http2.frame.DefaultFrameFactory;
+import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
 
@@ -53,25 +54,38 @@ public final class ClientH2StreamMultiplexerFactory {
     private final H2Config h2Config;
     private final CharCodingConfig charCodingConfig;
     private final H2StreamListener streamListener;
+    private final FrameFactory frameFactory;
 
     public ClientH2StreamMultiplexerFactory(
             final HttpProcessor httpProcessor,
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
             final H2Config h2Config,
             final CharCodingConfig charCodingConfig,
-            final H2StreamListener streamListener) {
+            final H2StreamListener streamListener,
+            final FrameFactory frameFactory) {
         this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
         this.pushHandlerFactory = pushHandlerFactory;
         this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
         this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
         this.streamListener = streamListener;
+        this.frameFactory = frameFactory != null ? frameFactory : DefaultFrameFactory.INSTANCE;
+    }
+
+    public ClientH2StreamMultiplexerFactory(
+            final HttpProcessor httpProcessor,
+            final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
+            final H2Config h2Config,
+            final CharCodingConfig charCodingConfig,
+            final H2StreamListener streamListener
+    ) {
+        this(httpProcessor, pushHandlerFactory, h2Config, charCodingConfig, streamListener, null);
     }
 
     public ClientH2StreamMultiplexerFactory(
             final HttpProcessor httpProcessor,
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
             final H2StreamListener streamListener) {
-        this(httpProcessor, pushHandlerFactory, null, null, streamListener);
+        this(httpProcessor, pushHandlerFactory, null, null, streamListener, null);
     }
 
     public ClientH2StreamMultiplexerFactory(
@@ -81,7 +95,7 @@ public final class ClientH2StreamMultiplexerFactory {
     }
 
     public ClientH2StreamMultiplexer create(final ProtocolIOSession ioSession) {
-        return new ClientH2StreamMultiplexer(ioSession, DefaultFrameFactory.INSTANCE, httpProcessor,
+        return new ClientH2StreamMultiplexer(ioSession, frameFactory, httpProcessor,
                 pushHandlerFactory, h2Config, charCodingConfig, streamListener);
     }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexerFactory.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ServerH2StreamMultiplexerFactory.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.http2.frame.DefaultFrameFactory;
+import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.reactor.ProtocolIOSession;
 import org.apache.hc.core5.util.Args;
 
@@ -53,6 +54,22 @@ public final class ServerH2StreamMultiplexerFactory {
     private final H2Config h2Config;
     private final CharCodingConfig charCodingConfig;
     private final H2StreamListener streamListener;
+    private final FrameFactory frameFactory;
+
+    public ServerH2StreamMultiplexerFactory(
+            final HttpProcessor httpProcessor,
+            final HandlerFactory<AsyncServerExchangeHandler> exchangeHandlerFactory,
+            final H2Config h2Config,
+            final CharCodingConfig charCodingConfig,
+            final H2StreamListener streamListener,
+            final FrameFactory frameFactory) {
+        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
+        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
+        this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
+        this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
+        this.streamListener = streamListener;
+        this.frameFactory = frameFactory != null ? frameFactory : DefaultFrameFactory.INSTANCE;
+    }
 
     public ServerH2StreamMultiplexerFactory(
             final HttpProcessor httpProcessor,
@@ -60,17 +77,13 @@ public final class ServerH2StreamMultiplexerFactory {
             final H2Config h2Config,
             final CharCodingConfig charCodingConfig,
             final H2StreamListener streamListener) {
-        this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
-        this.exchangeHandlerFactory = Args.notNull(exchangeHandlerFactory, "Exchange handler factory");
-        this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
-        this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
-        this.streamListener = streamListener;
+        this(httpProcessor, exchangeHandlerFactory, h2Config, charCodingConfig, streamListener, null);
     }
 
     public ServerH2StreamMultiplexer create(final ProtocolIOSession ioSession) {
         return new ServerH2StreamMultiplexer(
                 ioSession,
-                DefaultFrameFactory.INSTANCE,
+                frameFactory,
                 httpProcessor,
                 exchangeHandlerFactory,
                 charCodingConfig,

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequesterBootstrap.java
@@ -40,6 +40,7 @@ import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.UriPatternType;
 import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.http2.impl.H2Processors;
 import org.apache.hc.core5.http2.impl.nio.ClientH2PrefaceHandler;
 import org.apache.hc.core5.http2.impl.nio.ClientH2StreamMultiplexerFactory;
@@ -71,6 +72,7 @@ public class H2MultiplexingRequesterBootstrap {
     private Callback<Exception> exceptionCallback;
     private IOSessionListener sessionListener;
     private H2StreamListener streamListener;
+    private FrameFactory frameFactory;
 
     private IOReactorMetricsListener threadPoolListener;
 
@@ -189,6 +191,17 @@ public class H2MultiplexingRequesterBootstrap {
     }
 
     /**
+     * Sets {@link FrameFactory} instance.
+     *
+     * @since 5.4
+     * @return this instance.
+     */
+    public final H2MultiplexingRequesterBootstrap setStreamListener(final FrameFactory frameFactory) {
+        this.frameFactory = frameFactory;
+        return this;
+    }
+
+    /**
      * Sets {@link UriPatternType} for handler registration.
      *
      * @return this instance.
@@ -249,7 +262,8 @@ public class H2MultiplexingRequesterBootstrap {
                 new DefaultAsyncPushConsumerFactory(requestRouter),
                 h2Config != null ? h2Config : H2Config.DEFAULT,
                 charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT,
-                streamListener);
+                streamListener,
+                frameFactory);
         return new H2MultiplexingRequester(
                 ioReactorConfig,
                 (ioSession, attachment) ->

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
@@ -305,6 +305,11 @@ public class H2RequesterBootstrap {
         return this;
     }
 
+    /**
+     * Sets {@link FrameFactory} instance.
+     *
+     * @return this instance.
+     */
     public final H2RequesterBootstrap setFrameFactory(final FrameFactory frameFactory) {
         this.frameFactory = frameFactory;
         return this;

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
@@ -308,6 +308,7 @@ public class H2RequesterBootstrap {
     /**
      * Sets {@link FrameFactory} instance.
      *
+     * @since 5.4
      * @return this instance.
      */
     public final H2RequesterBootstrap setFrameFactory(final FrameFactory frameFactory) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2RequesterBootstrap.java
@@ -50,6 +50,7 @@ import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.UriPatternType;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.http2.impl.H2Processors;
 import org.apache.hc.core5.http2.impl.nio.ClientH2StreamMultiplexerFactory;
 import org.apache.hc.core5.http2.impl.nio.ClientHttpProtocolNegotiationStarter;
@@ -101,6 +102,7 @@ public class H2RequesterBootstrap {
     private Http1StreamListener http1StreamListener;
     private ConnPoolListener<HttpHost> connPoolListener;
     private IOReactorMetricsListener threadPoolListener;
+    private FrameFactory frameFactory;
 
 
     private H2RequesterBootstrap() {
@@ -303,6 +305,11 @@ public class H2RequesterBootstrap {
         return this;
     }
 
+    public final H2RequesterBootstrap setFrameFactory(final FrameFactory frameFactory) {
+        this.frameFactory = frameFactory;
+        return this;
+    }
+
     /**
      * Registers the given {@link AsyncPushConsumer} {@link Supplier} as a default handler for URIs
      * matching the given pattern.
@@ -376,7 +383,8 @@ public class H2RequesterBootstrap {
                 new DefaultAsyncPushConsumerFactory(requestRouter),
                 h2Config != null ? h2Config : H2Config.DEFAULT,
                 charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT,
-                streamListener);
+                streamListener,
+                frameFactory);
 
         final TlsStrategy actualTlsStrategy = tlsStrategy != null ? tlsStrategy : new H2ClientTlsStrategy();
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2ServerBootstrap.java
@@ -62,6 +62,7 @@ import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.UriPatternType;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.http2.impl.H2Processors;
 import org.apache.hc.core5.http2.impl.nio.H2StreamListener;
 import org.apache.hc.core5.http2.impl.nio.ServerH2StreamMultiplexerFactory;
@@ -104,6 +105,7 @@ public class H2ServerBootstrap {
     private H2StreamListener h2StreamListener;
     private Http1StreamListener http1StreamListener;
     private IOReactorMetricsListener threadPoolListener;
+    private FrameFactory frameFactory;
 
     private H2ServerBootstrap() {
         this.routeEntries = new ArrayList<>();
@@ -249,6 +251,17 @@ public class H2ServerBootstrap {
      */
     public final H2ServerBootstrap setStreamListener(final H2StreamListener h2StreamListener) {
         this.h2StreamListener = h2StreamListener;
+        return this;
+    }
+
+    /**
+     * Sets {@link FrameFactory} instance.
+     *
+     * @since 5.4
+     * @return this instance.
+     */
+    public final H2ServerBootstrap setFrameFactory(final FrameFactory frameFactory) {
+        this.frameFactory = frameFactory;
         return this;
     }
 
@@ -511,7 +524,8 @@ public class H2ServerBootstrap {
                 handlerFactory,
                 h2Config != null ? h2Config : H2Config.DEFAULT,
                 charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT,
-                h2StreamListener);
+                h2StreamListener,
+                frameFactory);
 
         final TlsStrategy actualTlsStrategy = tlsStrategy != null ? tlsStrategy : new H2ServerTlsStrategy();
 


### PR DESCRIPTION
The FrameFactory interface is useful as, for example, it allows patching in PRIORITY support and changing frame values that are not generally configurable. It is set to the default impl in ClientH2StreamMultiplexerFactory making it hard to change. This PR adds the appropriate setter methods into ClientH2StreamMultiplexerFactory and H2RequesterBootstrap to choose a FrameFactory impl as so:
```java
H2RequesterBootstrap.bootstrap().setFrameFactory(impl).create()
```