### PR TITLE
Safety net for infinite unproductive loop

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -73,7 +73,7 @@ import org.apache.hc.core5.util.Timeout;
 @Internal
 public class SSLIOSession implements IOSession {
 
-    public static final int UNPRODUCTIVE_CYCLE_COUNT_LIMIT = 10_000;
+    public static final int UNPRODUCTIVE_CYCLE_COUNT_LIMIT = 1000;
 
     enum TLSHandShakeState { READY, INITIALIZED, HANDSHAKING, COMPLETE }
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -609,8 +609,8 @@ public class SSLIOSession implements IOSession {
                     final ByteBuffer inPlainBuf = inPlain.acquire();
                     try {
                         final SSLEngineResult result = doUnwrap(inEncryptedBuf, inPlainBuf);
-                        if(result.getStatus() == SSLEngineResult.Status.OK && result.bytesConsumed() == 0){
-                            unproductiveDoUnwrapCycles ++;
+                        if (result.getStatus() == SSLEngineResult.Status.OK && result.bytesConsumed() == 0) {
+                            unproductiveDoUnwrapCycles++;
                         } else {
                             unproductiveDoUnwrapCycles = 0;
                         }


### PR DESCRIPTION
As a safety net for handling an infinite loop happening inside decrypt method (that has been reported here https://issues.apache.org/jira/browse/HTTPCORE-782), we propose a unproductive loop detection mechanism being added to it.
The mechanism counts the number of times the loop circles without consuming any data from the encrypted buffer while the unwrapping method reports a successful operation by returning OK status.
If we reach to 1000 unproductive loop, we throw an exception to escape the unproductive loop.

We are trying to have this feature inside production system, but have not seen the issue in weeks.