### PR TITLE
fix ContentType JavaDoc

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ContentType.java
@@ -423,10 +423,8 @@ public final class ContentType implements Serializable {
      *
      * @param s text
      * @return content type {@code Content-Type} value or null.
-     * @throws UnsupportedCharsetException Thrown when the named charset is not available in
-     * this instance of the Java virtual machine
      */
-    public static ContentType parseLenient(final CharSequence s) throws UnsupportedCharsetException {
+    public static ContentType parseLenient(final CharSequence s) {
         return parse(s, false);
     }
 


### PR DESCRIPTION
The whole point of `ContentType.parseLenient()` is to **not** throw `UnsupportedCharsetException`. This should be reflected in the JavaDoc and the method signature.