### PR TITLE
Fix hostname verification tests

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicTLSIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/classic/ClassicTLSIntegrationTest.java
@@ -317,7 +317,7 @@ class ClassicTLSIntegrationTest {
                 .create();
 
         final HttpCoreContext context = HttpCoreContext.create();
-        final HttpHost target1 = new HttpHost("https", InetAddress.getLocalHost(), "localhost", server.getLocalPort());
+        final HttpHost target1 = new HttpHost("https", InetAddress.getLoopbackAddress(), "localhost", server.getLocalPort());
         final ClassicHttpRequest request1 = new BasicClassicHttpRequest(Method.POST, "/stuff");
         request1.setEntity(new StringEntity("some stuff", ContentType.TEXT_PLAIN));
         try (final ClassicHttpResponse response1 = requester.execute(target1, request1, TIMEOUT, context)) {
@@ -325,7 +325,7 @@ class ClassicTLSIntegrationTest {
         }
 
         Assertions.assertThrows(SSLHandshakeException.class, () -> {
-            final HttpHost target2 = new HttpHost("https", InetAddress.getLocalHost(), "some-other-host", server.getLocalPort());
+            final HttpHost target2 = new HttpHost("https", InetAddress.getLoopbackAddress(), "some-other-host", server.getLocalPort());
             final ClassicHttpRequest request2 = new BasicClassicHttpRequest(Method.POST, "/stuff");
             request2.setEntity(new StringEntity("some stuff", ContentType.TEXT_PLAIN));
             try (final ClassicHttpResponse response2 = requester.execute(target2, request2, TIMEOUT, context)) {

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TLSIntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/TLSIntegrationTest.java
@@ -370,7 +370,7 @@ class TLSIntegrationTest {
         final ListenerEndpoint listener = future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
         final InetSocketAddress address = (InetSocketAddress) listener.getAddress();
 
-        final HttpHost target1 = new HttpHost(URIScheme.HTTPS.id, InetAddress.getLocalHost(), "localhost", address.getPort());
+        final HttpHost target1 = new HttpHost(URIScheme.HTTPS.id, InetAddress.getLoopbackAddress(), "localhost", address.getPort());
         final Future<Message<HttpResponse, String>> resultFuture1 = client.execute(
                 target1,
                 new BasicRequestProducer(Method.POST, target1, "/stuff",
@@ -380,7 +380,7 @@ class TLSIntegrationTest {
         Assertions.assertNotNull(message1);
         Assertions.assertEquals(200, message1.getHead().getCode());
 
-        final HttpHost target2 = new HttpHost(URIScheme.HTTPS.id, InetAddress.getLocalHost(), "some-other-host", address.getPort());
+        final HttpHost target2 = new HttpHost(URIScheme.HTTPS.id, InetAddress.getLoopbackAddress(), "some-other-host", address.getPort());
         final Future<Message<HttpResponse, String>> resultFuture2 = client.execute(
                 target2,
                 new BasicRequestProducer(Method.POST, target2, "/stuff",


### PR DESCRIPTION
I noticed after a macOS upgrade that these tests were failing, evidently due to some sort of firewall behavior. Looking at the problem, it seems like these tests actually intend to call `getLoopbackAddress`, rather than `getLocalHost`, which returns the IP address and hostname of the local host _on the network_, rather than on the loopback.