### PR TITLE
IOSessionImpl: Support CloseMode.IMMEDIATE for Unix domain sockets

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
@@ -29,7 +29,7 @@ package org.apache.hc.core5.reactor;
 
 import java.io.IOException;
 import java.net.SocketAddress;
-import java.net.SocketException;
+import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.SelectionKey;
@@ -266,8 +266,8 @@ class IOSessionImpl implements IOSession {
         if (this.status.compareAndSet(Status.ACTIVE, Status.CLOSED)) {
             if (closeMode == CloseMode.IMMEDIATE) {
                 try {
-                    this.channel.socket().setSoLinger(true, 0);
-                } catch (final SocketException e) {
+                    this.channel.setOption(StandardSocketOptions.SO_LINGER, 0);
+                } catch (final UnsupportedOperationException | IOException e) {
                     // Quietly ignore
                 }
             }


### PR DESCRIPTION
It's fine to set socket linger on a Unix-domain socket as long as it is done through the `SocketChannel` API. Calling `.socket()` always throws on a UDS-backed `SocketChannel`, however, which was silently causing issues for `TestAsyncSocketTimeout`, as connections were being left open until timeout.