### PR TITLE
Enable five-second TCP keep-alive by default

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/SocketConfig.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/SocketConfig.java
@@ -239,14 +239,14 @@ public class SocketConfig {
             this.soTimeout = DEFAULT_SOCKET_TIMEOUT;
             this.soReuseAddress = false;
             this.soLinger = TimeValue.NEG_ONE_SECOND;
-            this.soKeepAlive = false;
+            this.soKeepAlive = true;
             this.tcpNoDelay = true;
             this.sndBufSize = 0;
             this.rcvBufSize = 0;
             this.backlogSize = 0;
-            this.tcpKeepIdle = -1;
-            this.tcpKeepInterval = -1;
-            this.tcpKeepCount = -1;
+            this.tcpKeepIdle = 5;
+            this.tcpKeepInterval = 5;
+            this.tcpKeepCount = 3;
             this.socksProxyAddress = null;
         }
 
@@ -318,7 +318,7 @@ public class SocketConfig {
          * Determines the default value of the {@link SocketOptions#SO_KEEPALIVE} parameter
          * for newly created sockets.
          * <p>
-         * Default: {@code false}
+         * Default: {@code true}
          * </p>
          *
          * @return this instance.
@@ -395,7 +395,7 @@ public class SocketConfig {
          * Determines the time (in seconds) the connection needs to remain idle before TCP starts
          * sending keepalive probes.
          * <p>
-         * Default: {@code -1} (system default)
+         * Default: {@code 5}
          * </p>
          *
          * @return this instance.
@@ -409,7 +409,7 @@ public class SocketConfig {
         /**
          * Determines the time (in seconds) between individual keepalive probes.
          * <p>
-         * Default: {@code -1} (system default)
+         * Default: {@code 5}
          * </p>
          *
          * @return this instance.
@@ -423,7 +423,7 @@ public class SocketConfig {
         /**
          * Determines the maximum number of keepalive probes TCP should send before dropping the connection.
          * <p>
-         * Default: {@code -1} (system default)
+         * Default: {@code 3}
          * </p>
          *
          * @return this instance.

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOReactorConfig.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOReactorConfig.java
@@ -318,15 +318,15 @@ public final class IOReactorConfig {
             this.soTimeout = Timeout.ZERO_MILLISECONDS;
             this.soReuseAddress = false;
             this.soLinger = TimeValue.NEG_ONE_SECOND;
-            this.soKeepAlive = false;
+            this.soKeepAlive = true;
             this.tcpNoDelay = true;
             this.trafficClass = 0;
             this.sndBufSize = 0;
             this.rcvBufSize = 0;
             this.backlogSize = 0;
-            this.tcpKeepIdle = -1;
-            this.tcpKeepInterval = -1;
-            this.tcpKeepCount = -1;
+            this.tcpKeepIdle = 5;
+            this.tcpKeepInterval = 5;
+            this.tcpKeepCount = 3;
             this.socksProxyAddress = null;
             this.socksProxyUsername = null;
             this.socksProxyPassword = null;
@@ -436,7 +436,7 @@ public final class IOReactorConfig {
          * Sets the default value of the {@link SocketOptions#SO_KEEPALIVE} parameter
          * for newly created sockets.
          * <p>
-         * Default: {@code -1}
+         * Default: {@code true}
          * </p>
          *
          * @return this instance.
@@ -526,6 +526,9 @@ public final class IOReactorConfig {
         /**
          * Sets the time (in seconds) the connection needs to remain idle before TCP starts
          * sending keepalive probes.
+         * <p>
+         * Default: {@code 5}
+         * </p>
          *
          * @return this instance.
          * @since 5.3
@@ -537,6 +540,9 @@ public final class IOReactorConfig {
 
         /**
          * Sets the time (in seconds) between individual keepalive probes.
+         * <p>
+         * Default: {@code 5}
+         * </p>
          *
          * @return this instance.
          * @since 5.3
@@ -548,6 +554,9 @@ public final class IOReactorConfig {
 
         /**
          * Sets the maximum number of keepalive probes TCP should send before dropping the connection.
+         * <p>
+         * Default: {@code 3}
+         * </p>
          *
          * @return this instance.
          * @since 5.3


### PR DESCRIPTION
This setting prevents connections from going idle for longer than five seconds. Overriding the operating system defaults seems to be a best practice:

https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html

https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html

This prevents a failure mode where the network silently drops the connection, resulting in a stale connection in the connection pool that the client has no way of _knowing_ is stale:

https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout

Connections that are dropped in this way create a significant risk of a subsequent request failure, and the exception thrown in this case may or may not be safely retriable. Since TCP keep-alive is extremely cheap, and the failures caused by not using it are quite opaque, I think it makes sense to enable it by default. Traditionally this was not possible in a pure Java client, but the Java ecosystem now offers support for this option pretty much everywhere.