### PR TITLE
added useLocalAuthorityResolver() to ServerBootstrap and AsyncServerBootStrap classes

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
@@ -95,6 +95,7 @@ public class AsyncServerBootstrap {
     private IOSessionListener sessionListener;
     private Http1StreamListener streamListener;
     private IOReactorMetricsListener threadPoolListener;
+    private boolean localAuthorityResolver;
 
     private AsyncServerBootstrap() {
         this.routeEntries = new ArrayList<>();
@@ -435,6 +436,16 @@ public class AsyncServerBootstrap {
         return this;
     }
 
+    /**
+     * Create {@link RequestRouter} with LOCAL_AUTHORITY_RESOLVER (default: IGNORE_PORT_AUTHORITY_RESOLVER).
+     *
+     * @since 5.4
+     */
+    public final AsyncServerBootstrap useLocalAuthorityResolver(final boolean localAuthorityResolver) {
+        this.localAuthorityResolver = localAuthorityResolver;
+        return this;
+    }
+
     public HttpAsyncServer create() {
         final String actualCanonicalHostName = canonicalHostName != null ? canonicalHostName : InetAddressUtils.getCanonicalLocalHostName();
         final HttpRequestMapper<Supplier<AsyncServerExchangeHandler>> requestRouterCopy;
@@ -451,9 +462,9 @@ public class AsyncServerBootstrap {
                 requestRouterCopy = requestRouter;
             } else {
                 requestRouterCopy = RequestRouter.create(
-                        new URIAuthority(actualCanonicalHostName),
+                        this.localAuthorityResolver ? RequestRouter.LOCAL_AUTHORITY : new URIAuthority(actualCanonicalHostName),
                         UriPatternType.URI_PATTERN, routeEntries,
-                        RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER,
+                        this.localAuthorityResolver ? RequestRouter.LOCAL_AUTHORITY_RESOLVER : RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER,
                         requestRouter);
             }
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
@@ -98,6 +98,7 @@ public class ServerBootstrap {
     private HttpConnectionFactory<? extends DefaultBHttpServerConnection> connectionFactory;
     private ExceptionListener exceptionListener;
     private Http1StreamListener streamListener;
+    private boolean localAuthorityResolver;
 
     private ServerBootstrap() {
         this.routeEntries = new ArrayList<>();
@@ -346,6 +347,16 @@ public class ServerBootstrap {
         return this;
     }
 
+    /**
+     * Create {@link RequestRouter} with LOCAL_AUTHORITY_RESOLVER (default: IGNORE_PORT_AUTHORITY_RESOLVER).
+     *
+     * @since 5.4
+     */
+    public final ServerBootstrap useLocalAuthorityResolver(final boolean localAuthorityResolver) {
+        this.localAuthorityResolver = localAuthorityResolver;
+        return this;
+    }
+
     public HttpServer create() {
         final String actualCanonicalHostName = canonicalHostName != null ? canonicalHostName : InetAddressUtils.getCanonicalLocalHostName();
         final HttpRequestMapper<HttpRequestHandler> requestRouterCopy;
@@ -362,10 +373,10 @@ public class ServerBootstrap {
                 requestRouterCopy = requestRouter;
             } else {
                 requestRouterCopy = RequestRouter.create(
-                        new URIAuthority(actualCanonicalHostName),
+                        this.localAuthorityResolver ? RequestRouter.LOCAL_AUTHORITY : new URIAuthority(actualCanonicalHostName),
                         UriPatternType.URI_PATTERN,
                         routeEntries,
-                        RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER,
+                        this.localAuthorityResolver ? RequestRouter.LOCAL_AUTHORITY_RESOLVER : RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER,
                         requestRouter);
             }
         }


### PR DESCRIPTION
(Follow-up to pull request #555 which I messed up while trying to rebase it from 5.3.x to master.)

I have added a convenience method to the ServerBootstrap and AsyncServerBootstrap classes that configures the RequestRouter to use the LOCAL_AUTHORITY_RESOLVER scheme. While it is possible to create an HttpServer with such a custom RequestRouter within the application, this results in really messy and complicated code, which can easily be spared with this very simple convenience method.