### PR TITLE
Bug fix: Classic RequestListener to continue accepting incoming connections in case of an unexpected exception caused by a single connection

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/RequestListener.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/RequestListener.java
@@ -135,7 +135,7 @@ class RequestListener implements Runnable {
                     this.executorService.execute(worker);
                 } catch (final IOException | RuntimeException ex) {
                     Closer.closeQuietly(socket);
-                    throw ex;
+                    this.exceptionListener.onError(ex);
                 }
             }
         } catch (final Exception ex) {


### PR DESCRIPTION
The RequestListener thread terminates when an exception occurs during connection creation or in the worker thread. Specifically, I have noticed this issue simply when an http connection is attempted to an HttpServer with SSLContext - the server essentially terminates.

So instead of throwing the corresponding exception, it should be handled by the application's exceptionListener.

(This is also how it was implemented in httpcore4.)