### PR TITLE
added setAuthorityResolver() methods to AsyncServerBootstrap / ServerBootstrap

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/AsyncServerBootstrap.java
@@ -28,6 +28,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Decorator;
@@ -95,6 +96,7 @@ public class AsyncServerBootstrap {
     private IOSessionListener sessionListener;
     private Http1StreamListener streamListener;
     private IOReactorMetricsListener threadPoolListener;
+    private BiFunction<String, URIAuthority, URIAuthority> authorityResolver = RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER;
 
     private AsyncServerBootstrap() {
         this.routeEntries = new ArrayList<>();
@@ -281,6 +283,17 @@ public class AsyncServerBootstrap {
     }
 
     /**
+     * Sets authority resolver to be used when creating the {@link RequestRouter}.
+     *
+     * @return this instance.
+     * @since 5.4
+     */
+    public final AsyncServerBootstrap setAuthorityResolver(final BiFunction<String, URIAuthority, URIAuthority> authorityResolver) {
+        this.authorityResolver = authorityResolver;
+        return this;
+    }
+
+    /**
      * Registers the given {@link AsyncServerExchangeHandler} {@link Supplier} as a default handler for URIs
      * matching the given pattern.
      *
@@ -453,7 +466,7 @@ public class AsyncServerBootstrap {
                 requestRouterCopy = RequestRouter.create(
                         new URIAuthority(actualCanonicalHostName),
                         UriPatternType.URI_PATTERN, routeEntries,
-                        RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER,
+                        this.authorityResolver,
                         requestRouter);
             }
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/bootstrap/ServerBootstrap.java
@@ -29,6 +29,7 @@ package org.apache.hc.core5.http.impl.bootstrap;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
@@ -98,6 +99,7 @@ public class ServerBootstrap {
     private HttpConnectionFactory<? extends DefaultBHttpServerConnection> connectionFactory;
     private ExceptionListener exceptionListener;
     private Http1StreamListener streamListener;
+    private BiFunction<String, URIAuthority, URIAuthority> authorityResolver = RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER;
 
     private ServerBootstrap() {
         this.routeEntries = new ArrayList<>();
@@ -295,6 +297,17 @@ public class ServerBootstrap {
     }
 
     /**
+     * Sets authority resolver to be used when creating the {@link RequestRouter}.
+     *
+     * @return this instance.
+     * @since 5.4
+     */
+    public final ServerBootstrap setAuthorityResolver(final BiFunction<String, URIAuthority, URIAuthority> authorityResolver) {
+        this.authorityResolver = authorityResolver;
+        return this;
+    }
+
+    /**
      * Adds the filter before the filter with the given name.
      */
     public final ServerBootstrap addFilterBefore(final String existing, final String name, final HttpFilterHandler filterHandler) {
@@ -365,7 +378,7 @@ public class ServerBootstrap {
                         new URIAuthority(actualCanonicalHostName),
                         UriPatternType.URI_PATTERN,
                         routeEntries,
-                        RequestRouter.IGNORE_PORT_AUTHORITY_RESOLVER,
+                        this.authorityResolver,
                         requestRouter);
             }
         }


### PR DESCRIPTION
I migrated a project from httpcore4 to httpcore5 just recently and when it didn't work, I had to dive into the httpcore5 sources to understand what was going wrong and that I need to create a custom `RequestRouter` with `LOCAL_AUTHORITY_RESOLVER` scheme to get the same behavior as before with httpcore4 just using simple `ServerBootstrap` methods. It is quite a pain to build the custom `RequestRouter` in the application itself, especially because this isn't really very well documented.

With this new `setAuthorityResolver()` method, the legacy behavior can be achieved by calling `setAuthorityResolver(RequestRouter.LOCAL_AUTHORITY_RESOLVER)` in combination with `setCanonicalHostName("localhost")` on `ServerBootstrap` or `AsyncServerBootstrap` .