### PR TITLE
Accept leading zeros in IPv4-mapped IPv6

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/net/InetAddressUtils.java
@@ -66,8 +66,13 @@ public class InetAddressUtils {
     private static final Pattern IPV4_PATTERN =
         Pattern.compile("^" + IPV4_BASIC_PATTERN_STRING + "$");
 
-    private static final Pattern IPV4_MAPPED_IPV6_PATTERN = // TODO does not allow for redundant leading zeros
-            Pattern.compile("^::[fF]{4}:" + IPV4_BASIC_PATTERN_STRING + "$");
+    // Accept IPv4-mapped IPv6, allowing redundant leading zeros in the IPv4 part.
+    // Examples: ::ffff:1.2.3.4, ::FFFF:001.002.003.004
+    // Still enforces each octet <= 255 and max 3 digits per octet.
+    private static final String IPV4_MAPPED_OCTET = "(25[0-5]|2[0-4]\\d|1\\d\\d|0?\\d?\\d)";
+    private static final Pattern IPV4_MAPPED_IPV6_PATTERN = Pattern.compile("^::[fF]{4}:((" + IPV4_MAPPED_OCTET + ")\\.){3}" + IPV4_MAPPED_OCTET + "$");
+
+
 
     private static final Pattern IPV6_STD_PATTERN =
         Pattern.compile(

--- a/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/net/TestInetAddressUtils.java
@@ -198,4 +198,22 @@ class TestInetAddressUtils {
         Assertions.assertFalse(InetAddressUtils.isIPv4MappedIPv6("::ffff:1:2:3:4"));
     }
 
+    @Test
+    void testValidIPv4MappedIPv6AddressWithLeadingZeros() {
+        Assertions.assertTrue(InetAddressUtils.isIPv4MappedIPv6("::ffff:001.002.003.004"));
+        Assertions.assertTrue(InetAddressUtils.isIPv4MappedIPv6("::FFFF:000.000.000.255"));
+        Assertions.assertTrue(InetAddressUtils.isIPv4MappedIPv6("::ffff:010.020.030.040"));
+    }
+
+    @Test
+    void testInvalidIPv4MappedIPv6AddressWithBadOctets() {
+        // >255 not allowed
+        Assertions.assertFalse(InetAddressUtils.isIPv4MappedIPv6("::ffff:256.000.000.000"));
+        // too few octets
+        Assertions.assertFalse(InetAddressUtils.isIPv4MappedIPv6("::ffff:01.02.03"));
+        // too many digits in an octet (4 digits)
+        Assertions.assertFalse(InetAddressUtils.isIPv4MappedIPv6("::ffff:0255.000.000.000"));
+    }
+
+
 }


### PR DESCRIPTION
Update IPV4_MAPPED_IPV6_PATTERN to allow redundant leading zeros in the IPv4 portion of IPv4-mapped IPv6 addresses (e.g., ::ffff:001.002.003.004) while keeping standalone IPv4 validation strict. Includes unit tests covering valid zero-padded forms and representative invalid inputs