### PR TITLE
Add pooled ByteBuffer allocator with size classes

### DIFF
--- a/httpcore5-testing/pom.xml
+++ b/httpcore5-testing/pom.xml
@@ -171,6 +171,9 @@
                     <argument>-classpath</argument>
                     <classpath/>
                     <argument>org.openjdk.jmh.Main</argument>
+                    <!-- GC profiler -->
+                    <argument>-prof</argument>
+                    <argument>gc</argument>
                     <argument>-rf</argument>
                     <argument>json</argument>
                     <argument>-rff</argument>

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/ByteBufferAllocatorBenchmark.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/ByteBufferAllocatorBenchmark.java
@@ -1,0 +1,202 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.benchmark;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.core5.io.ByteBufferAllocator;
+import org.apache.hc.core5.io.PooledByteBufferAllocator;
+import org.apache.hc.core5.io.SimpleByteBufferAllocator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class ByteBufferAllocatorBenchmark {
+
+    /**
+     * Per-thread state: each thread gets its own allocators.
+     * This measures the best-case hot-path behaviour with no contention
+     * on the pooled allocator.
+     */
+    @State(Scope.Thread)
+    public static class ThreadLocalState {
+
+        @Param({"1024", "8192", "65536"})
+        public int bufferSize;
+
+        @Param({"100"})
+        public int iterations;
+
+        public ByteBufferAllocator simpleAllocator;
+        public ByteBufferAllocator pooledAllocator;
+
+        public byte[] payload;
+
+        @Setup
+        public void setUp() {
+            this.simpleAllocator = SimpleByteBufferAllocator.INSTANCE;
+            this.pooledAllocator = new PooledByteBufferAllocator(
+                    1024,        // min pooled size
+                    256 * 1024,  // max pooled size
+                    1024,        // maxGlobalPerBucket
+                    64           // maxLocalPerBucket
+            );
+            this.payload = new byte[bufferSize / 2];
+            for (int i = 0; i < this.payload.length; i++) {
+                this.payload[i] = (byte) (i & 0xFF);
+            }
+        }
+
+    }
+
+    /**
+     * Shared state: all threads share the same allocators.
+     * This measures contention on the global buckets and any shared
+     * structures inside the pooled allocator.
+     */
+    @State(Scope.Benchmark)
+    public static class SharedState {
+
+        @Param({"1024", "8192", "65536"})
+        public int bufferSize;
+
+        @Param({"100"})
+        public int iterations;
+
+        public ByteBufferAllocator simpleAllocator;
+        public ByteBufferAllocator pooledAllocator;
+
+        public byte[] payload;
+
+        @Setup
+        public void setUp() {
+            this.simpleAllocator = SimpleByteBufferAllocator.INSTANCE;
+            this.pooledAllocator = new PooledByteBufferAllocator(
+                    1024,
+                    256 * 1024,
+                    1024,
+                    64
+            );
+            this.payload = new byte[bufferSize / 2];
+            for (int i = 0; i < this.payload.length; i++) {
+                this.payload[i] = (byte) (i & 0xFF);
+            }
+        }
+
+    }
+
+    // --------- Per-thread allocators (your original semantics) ---------
+
+    @Benchmark
+    public void pooled_allocator_thread_local(final ThreadLocalState state, final Blackhole blackhole) {
+        final int bufferSize = state.bufferSize;
+        final int iterations = state.iterations;
+        final ByteBufferAllocator allocator = state.pooledAllocator;
+        final byte[] payload = state.payload;
+
+        for (int i = 0; i < iterations; i++) {
+            final ByteBuffer buf = allocator.allocate(bufferSize);
+            buf.put(payload);
+            buf.flip();
+            blackhole.consume(buf.get(0));
+            allocator.release(buf);
+        }
+    }
+
+    @Benchmark
+    public void simple_allocator_thread_local(final ThreadLocalState state, final Blackhole blackhole) {
+        final int bufferSize = state.bufferSize;
+        final int iterations = state.iterations;
+        final ByteBufferAllocator allocator = state.simpleAllocator;
+        final byte[] payload = state.payload;
+
+        for (int i = 0; i < iterations; i++) {
+            final ByteBuffer buf = allocator.allocate(bufferSize);
+            buf.put(payload);
+            buf.flip();
+            blackhole.consume(buf.get(0));
+            allocator.release(buf);
+        }
+    }
+
+    // --------- Shared allocator, multi-threaded contention ---------
+
+    /**
+     * Run this with multiple threads, e.g.:
+     * -t 4 or -t 8 on the JMH command line.
+     */
+    @Benchmark
+    @Threads(4) // Override from the command line if you want: -t 8, etc.
+    public void pooled_allocator_shared(final SharedState state, final Blackhole blackhole) {
+        final int bufferSize = state.bufferSize;
+        final int iterations = state.iterations;
+        final ByteBufferAllocator allocator = state.pooledAllocator;
+        final byte[] payload = state.payload;
+
+        for (int i = 0; i < iterations; i++) {
+            final ByteBuffer buf = allocator.allocate(bufferSize);
+            buf.put(payload);
+            buf.flip();
+            blackhole.consume(buf.get(0));
+            allocator.release(buf);
+        }
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void simple_allocator_shared(final SharedState state, final Blackhole blackhole) {
+        final int bufferSize = state.bufferSize;
+        final int iterations = state.iterations;
+        final ByteBufferAllocator allocator = state.simpleAllocator;
+        final byte[] payload = state.payload;
+
+        for (int i = 0; i < iterations; i++) {
+            final ByteBuffer buf = allocator.allocate(bufferSize);
+            buf.put(payload);
+            buf.flip();
+            blackhole.consume(buf.get(0));
+            allocator.release(buf);
+        }
+    }
+
+}

--- a/httpcore5/src/main/java/org/apache/hc/core5/io/ByteBufferAllocator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/io/ByteBufferAllocator.java
@@ -1,0 +1,71 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.io;
+
+import java.nio.ByteBuffer;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+
+/**
+ * Strategy for allocating and releasing {@link ByteBuffer} instances.
+ * <p>
+ * Implementations may allocate fresh buffers on every call or reuse
+ * buffers from a pool.
+ *
+ * @since 5.4
+ */
+@Contract(threading = ThreadingBehavior.STATELESS)
+public interface ByteBufferAllocator {
+
+    /**
+     * Allocates a new heap buffer of the given capacity.
+     *
+     * @param capacity buffer capacity in bytes; non-negative.
+     * @return a heap {@link ByteBuffer} with the given capacity.
+     */
+    ByteBuffer allocate(int capacity);
+
+    /**
+     * Allocates a new direct buffer of the given capacity.
+     *
+     * @param capacity buffer capacity in bytes; non-negative.
+     * @return a direct {@link ByteBuffer} with the given capacity.
+     */
+    ByteBuffer allocateDirect(int capacity);
+
+    /**
+     * Releases a buffer back to the allocator.
+     * <p>
+     * Implementations that do not pool buffers may choose to ignore
+     * this call.
+     *
+     * @param buffer the buffer to release; may be {@code null}.
+     */
+    void release(ByteBuffer buffer);
+
+}

--- a/httpcore5/src/main/java/org/apache/hc/core5/io/PooledByteBufferAllocator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/io/PooledByteBufferAllocator.java
@@ -1,0 +1,283 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.io;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.util.Args;
+
+/**
+ * {@link ByteBufferAllocator} implementation backed by a bucketed buffer pool
+ * with global queues and per-thread caches, inspired by Netty's pooled buffer
+ * allocator.
+ * <p>
+ * Buffer capacities are rounded up to the nearest power of two between
+ * {@code minCapacity} and {@code maxCapacity}. Released buffers are cached in
+ * a per-thread cache (up to {@code maxLocalPerBucket}) and then in a global
+ * bucket (up to {@code maxGlobalPerBucket}).
+ * <p>
+ * The returned buffers may have an underlying {@link ByteBuffer#capacity()}
+ * greater than the requested capacity; however, their {@link ByteBuffer#limit(int)}
+ * is set to the requested capacity.
+ *
+ * @since 5.7
+ */
+@Contract(threading = ThreadingBehavior.SAFE)
+public final class PooledByteBufferAllocator implements ByteBufferAllocator {
+
+    private static final class GlobalBucket {
+
+        final ConcurrentLinkedQueue<ByteBuffer> queue;
+        final AtomicInteger size;
+
+        GlobalBucket() {
+            this.queue = new ConcurrentLinkedQueue<>();
+            this.size = new AtomicInteger();
+        }
+
+    }
+
+    private static final class LocalCache {
+
+        final Deque<ByteBuffer>[] heapBuckets;
+        final Deque<ByteBuffer>[] directBuckets;
+
+        LocalCache(final int bucketCount) {
+            @SuppressWarnings("unchecked") final Deque<ByteBuffer>[] heap = new Deque[bucketCount];
+            @SuppressWarnings("unchecked") final Deque<ByteBuffer>[] direct = new Deque[bucketCount];
+            for (int i = 0; i < bucketCount; i++) {
+                heap[i] = new ArrayDeque<>();
+                direct[i] = new ArrayDeque<>();
+            }
+            this.heapBuckets = heap;
+            this.directBuckets = direct;
+        }
+
+    }
+
+    private final int minCapacity;
+    private final int maxCapacity;
+    private final int[] bucketCapacities;
+    private final GlobalBucket[] heapBuckets;
+    private final GlobalBucket[] directBuckets;
+    private final int maxGlobalPerBucket;
+    private final int maxLocalPerBucket;
+
+    private final ThreadLocal<LocalCache> localCache;
+
+    /**
+     * Creates a new pooled allocator.
+     *
+     * @param minCapacity        minimum capacity (inclusive) to pool, in bytes.
+     * @param maxCapacity        maximum capacity (inclusive) to pool, in bytes.
+     * @param maxGlobalPerBucket maximum number of buffers to keep per global
+     *                           bucket and memory type (heap/direct).
+     * @param maxLocalPerBucket  maximum number of buffers to keep per-thread
+     *                           cache bucket and memory type (heap/direct).
+     */
+    public PooledByteBufferAllocator(
+            final int minCapacity,
+            final int maxCapacity,
+            final int maxGlobalPerBucket,
+            final int maxLocalPerBucket) {
+        Args.notNegative(minCapacity, "Min capacity");
+        Args.notNegative(maxCapacity, "Max capacity");
+        Args.notNegative(maxGlobalPerBucket, "Max global per bucket");
+        Args.notNegative(maxLocalPerBucket, "Max local per bucket");
+        Args.check(maxCapacity >= minCapacity, "Max capacity must be >= min capacity");
+
+        this.minCapacity = normalizeCapacity(minCapacity);
+        this.maxCapacity = normalizeCapacity(maxCapacity);
+        this.maxGlobalPerBucket = maxGlobalPerBucket;
+        this.maxLocalPerBucket = maxLocalPerBucket;
+
+        final int bucketCount = bucketCount(this.minCapacity, this.maxCapacity);
+        this.bucketCapacities = new int[bucketCount];
+
+        this.heapBuckets = new GlobalBucket[bucketCount];
+        this.directBuckets = new GlobalBucket[bucketCount];
+
+        int capacity = this.minCapacity;
+        for (int i = 0; i < bucketCount; i++) {
+            this.bucketCapacities[i] = capacity;
+            this.heapBuckets[i] = new GlobalBucket();
+            this.directBuckets[i] = new GlobalBucket();
+            capacity <<= 1;
+        }
+
+        this.localCache = ThreadLocal.withInitial(() -> new LocalCache(bucketCount));
+    }
+
+    private static int normalizeCapacity(final int capacity) {
+        if (capacity <= 0) {
+            return 1;
+        }
+        int normalized = 1;
+        while (normalized < capacity) {
+            normalized <<= 1;
+        }
+        return normalized;
+    }
+
+    private static int bucketCount(final int minCapacity, final int maxCapacity) {
+        int count = 0;
+        int capacity = minCapacity;
+        while (capacity <= maxCapacity) {
+            count++;
+            capacity <<= 1;
+        }
+        return count;
+    }
+
+    private int bucketIndex(final int capacity) {
+        if (capacity <= minCapacity) {
+            return 0;
+        }
+        if (capacity > maxCapacity) {
+            return -1;
+        }
+        int idx = 0;
+        int current = minCapacity;
+        while (current < capacity && current < maxCapacity) {
+            current <<= 1;
+            idx++;
+        }
+        if (idx >= bucketCapacities.length) {
+            return -1;
+        }
+        return idx;
+    }
+
+    private ByteBuffer allocateInternal(final int requestedCapacity, final boolean direct) {
+        Args.notNegative(requestedCapacity, "Buffer capacity");
+        final int idx = bucketIndex(requestedCapacity);
+        if (idx < 0) {
+            // Not pooled: allocate exact requested capacity.
+            return direct
+                    ? ByteBuffer.allocateDirect(requestedCapacity)
+                    : ByteBuffer.allocate(requestedCapacity);
+        }
+
+        final int bucketCapacity = bucketCapacities[idx];
+
+        final LocalCache cache = localCache.get();
+        final Deque<ByteBuffer>[] localBuckets = direct
+                ? cache.directBuckets
+                : cache.heapBuckets;
+        final Deque<ByteBuffer> local = localBuckets[idx];
+
+        ByteBuffer buf = local.pollFirst();
+        if (buf != null) {
+            buf.clear();
+            buf.limit(requestedCapacity);
+            return buf;
+        }
+
+        final GlobalBucket[] globalArray = direct ? directBuckets : heapBuckets;
+        final GlobalBucket global = globalArray[idx];
+
+        buf = global.queue.poll();
+        if (buf != null) {
+            global.size.decrementAndGet();
+            buf.clear();
+            buf.limit(requestedCapacity);
+            return buf;
+        }
+
+        buf = direct
+                ? ByteBuffer.allocateDirect(bucketCapacity)
+                : ByteBuffer.allocate(bucketCapacity);
+        buf.limit(requestedCapacity);
+        return buf;
+    }
+
+    @Override
+    public ByteBuffer allocate(final int capacity) {
+        return allocateInternal(capacity, false);
+    }
+
+    @Override
+    public ByteBuffer allocateDirect(final int capacity) {
+        return allocateInternal(capacity, true);
+    }
+
+    @Override
+    public void release(final ByteBuffer buffer) {
+        if (buffer == null) {
+            return;
+        }
+        final int capacity = buffer.capacity();
+        final int idx = bucketIndex(capacity);
+        if (idx < 0) {
+            return;
+        }
+
+        final boolean direct = buffer.isDirect();
+        final LocalCache cache = localCache.get();
+        final Deque<ByteBuffer>[] localBuckets = direct
+                ? cache.directBuckets
+                : cache.heapBuckets;
+        final Deque<ByteBuffer> local = localBuckets[idx];
+
+        if (local.size() < maxLocalPerBucket) {
+            buffer.clear();
+            buffer.limit(bucketCapacities[idx]);
+            local.addFirst(buffer);
+            return;
+        }
+
+        final GlobalBucket[] globalArray = direct ? directBuckets : heapBuckets;
+        final GlobalBucket global = globalArray[idx];
+        final int current = global.size.get();
+        if (current >= maxGlobalPerBucket) {
+            return;
+        }
+        buffer.clear();
+        buffer.limit(bucketCapacities[idx]);
+        global.queue.offer(buffer);
+        global.size.incrementAndGet();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(128);
+        buf.append("PooledByteBufferAllocator[")
+                .append("minCapacity=").append(minCapacity)
+                .append(", maxCapacity=").append(maxCapacity)
+                .append(", maxGlobalPerBucket=").append(maxGlobalPerBucket)
+                .append(", maxLocalPerBucket=").append(maxLocalPerBucket)
+                .append(']');
+        return buf.toString();
+    }
+
+}

--- a/httpcore5/src/main/java/org/apache/hc/core5/io/SimpleByteBufferAllocator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/io/SimpleByteBufferAllocator.java
@@ -1,0 +1,66 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.io;
+
+import java.nio.ByteBuffer;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.util.Args;
+
+/**
+ * Simple {@link ByteBufferAllocator} that allocates a new buffer for
+ * every request and does not pool released buffers.
+ *
+ * @since 5.4
+ */
+@Contract(threading = ThreadingBehavior.STATELESS)
+public final class SimpleByteBufferAllocator implements ByteBufferAllocator {
+
+    public static final SimpleByteBufferAllocator INSTANCE = new SimpleByteBufferAllocator();
+
+    private SimpleByteBufferAllocator() {
+    }
+
+    @Override
+    public ByteBuffer allocate(final int capacity) {
+        Args.notNegative(capacity, "Buffer capacity");
+        return ByteBuffer.allocate(capacity);
+    }
+
+    @Override
+    public ByteBuffer allocateDirect(final int capacity) {
+        Args.notNegative(capacity, "Buffer capacity");
+        return ByteBuffer.allocateDirect(capacity);
+    }
+
+    @Override
+    public void release(final ByteBuffer buffer) {
+        // No-op: GC will reclaim the buffer.
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/io/TestPooledByteBufferAllocator.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/io/TestPooledByteBufferAllocator.java
@@ -1,0 +1,148 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+class TestPooledByteBufferAllocator {
+
+    @Test
+    void testNonPooledExactCapacity() {
+        final PooledByteBufferAllocator allocator = new PooledByteBufferAllocator(
+                64, 1024, 16, 8);
+
+        final int requested = 2048; // > maxCapacity → non-pooled
+
+        final ByteBuffer buf = allocator.allocate(requested);
+        assertNotNull(buf);
+        assertFalse(buf.isDirect());
+        assertEquals(requested, buf.capacity());
+        assertEquals(requested, buf.limit());
+
+        allocator.release(buf); // should be a no-op
+    }
+
+    @Test
+    void testPooledRoundedCapacityAndLimit() {
+        final PooledByteBufferAllocator allocator = new PooledByteBufferAllocator(
+                64, 1024, 16, 8);
+
+        final int requested = 100;
+
+        final ByteBuffer buf = allocator.allocate(requested);
+        assertNotNull(buf);
+        assertFalse(buf.isDirect());
+
+        // With min=64, max=1024, 100 should land in the 128 bucket.
+        assertEquals(128, buf.capacity());
+        assertEquals(requested, buf.limit());
+        assertEquals(0, buf.position());
+
+        allocator.release(buf);
+    }
+
+    @Test
+    void testPooledReusesLocalCache() {
+        final PooledByteBufferAllocator allocator = new PooledByteBufferAllocator(
+                64, 1024, 16, 8);
+
+        final int requested = 128;
+
+        final ByteBuffer buf1 = allocator.allocate(requested);
+        assertNotNull(buf1);
+        assertFalse(buf1.isDirect());
+        assertEquals(requested, buf1.limit());
+
+        allocator.release(buf1);
+
+        final ByteBuffer buf2 = allocator.allocate(requested);
+        assertSame(buf1, buf2);
+        assertEquals(0, buf2.position());
+        assertEquals(requested, buf2.limit());
+    }
+
+    @Test
+    void testReleaseResetsLimitForNextUse() {
+        final PooledByteBufferAllocator allocator = new PooledByteBufferAllocator(
+                64, 1024, 16, 8);
+
+        final int requested = 200;
+
+        final ByteBuffer buf1 = allocator.allocate(requested);
+        assertEquals(requested, buf1.limit());
+
+        // Mess with position/limit to ensure release() really resets them.
+        buf1.position(requested);
+        buf1.limit(requested);
+        allocator.release(buf1);
+
+        final ByteBuffer buf2 = allocator.allocate(requested);
+        assertSame(buf1, buf2);
+        assertEquals(0, buf2.position());
+        assertEquals(requested, buf2.limit());
+    }
+
+    @Test
+    void testDirectAndHeapArePooledSeparately() {
+        final PooledByteBufferAllocator allocator = new PooledByteBufferAllocator(
+                64, 1024, 16, 8);
+
+        final int requested = 128;
+
+        final ByteBuffer direct1 = allocator.allocateDirect(requested);
+        assertTrue(direct1.isDirect());
+        allocator.release(direct1);
+
+        final ByteBuffer direct2 = allocator.allocateDirect(requested);
+        assertTrue(direct2.isDirect());
+        assertSame(direct1, direct2);
+
+        final ByteBuffer heap = allocator.allocate(requested);
+        assertFalse(heap.isDirect());
+        assertNotSame(direct2, heap);
+    }
+
+    @Test
+    void testToStringDoesNotThrow() {
+        final PooledByteBufferAllocator allocator = new PooledByteBufferAllocator(
+                64, 1024, 16, 8);
+
+        final String s = allocator.toString();
+        assertNotNull(s);
+        assertTrue(s.contains("PooledByteBufferAllocator"));
+    }
+
+}


### PR DESCRIPTION
This is the first step towards a pluggable pooled ByteBuffer allocator.
The patch adds PooledByteBufferAllocator (power-of-two size buckets, global pool + per-thread caches) and switches the HTTP/2 FrameFactory and the benchmark to use ByteBufferAllocator. Behaviour is unchanged except for using pooled buffers for small control frames.
If this direction looks reasonable, I’ll follow up by threading the allocator through IOSession/SSLIOSession and the async codecs and add minimal metrics; otherwise I’ll keep it local to HTTP/2.

### ByteBuffer allocator throughput (JMH)

| Benchmark                                      | bufferSize | iterations | Mode  | Cnt | Score (ops/ms) | Error (ops/ms) |
|-----------------------------------------------|-----------:|-----------:|:------|----:|---------------:|---------------:|
| pooled_allocator_shared                       |       1024 |        100 | thrpt |  10 |       1644.982 |         14.006 |
| pooled_allocator_shared                       |       8192 |        100 | thrpt |  10 |        533.638 |         34.307 |
| pooled_allocator_shared                       |      65536 |        100 | thrpt |  10 |         59.422 |          0.937 |
| pooled_allocator_thread_local                 |       1024 |        100 | thrpt |  10 |        539.612 |          5.518 |
| pooled_allocator_thread_local                 |       8192 |        100 | thrpt |  10 |        201.345 |          4.451 |
| pooled_allocator_thread_local                 |      65536 |        100 | thrpt |  10 |         19.603 |          0.501 |
| simple_allocator_shared                       |       1024 |        100 | thrpt |  10 |        172.750 |          4.893 |
| simple_allocator_shared                       |       8192 |        100 | thrpt |  10 |         23.083 |          0.199 |
| simple_allocator_shared                       |      65536 |        100 | thrpt |  10 |          2.883 |          0.037 |
| simple_allocator_thread_local                 |       1024 |        100 | thrpt |  10 |        129.873 |          1.075 |
| simple_allocator_thread_local                 |       8192 |        100 | thrpt |  10 |         21.075 |          0.088 |
| simple_allocator_thread_local                 |      65536 |        100 | thrpt |  10 |          2.401 |          0.062 |



@ok2c WDYT?