### PR TITLE
Add generative contract tests for connection pools and async IT coverage for cancel/timeout scenarios

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/pool/TestConnPoolAsyncRequesterIT.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/pool/TestConnPoolAsyncRequesterIT.java
@@ -1,0 +1,266 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.testing.pool;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Message;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.impl.bootstrap.AsyncRequesterBootstrap;
+import org.apache.hc.core5.http.impl.bootstrap.HttpAsyncRequester;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.nio.AsyncClientEndpoint;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
+import org.apache.hc.core5.http.nio.support.BasicResponseConsumer;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.apache.hc.core5.pool.PoolStats;
+import org.apache.hc.core5.testing.classic.ClassicTestServer;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+final class TestConnPoolAsyncRequesterIT {
+
+    private static final TimeValue WAIT = TimeValue.ofSeconds(2);
+
+    private static final class ServerResources {
+
+        private final ClassicTestServer server;
+        private final HttpHost target;
+        private final CountDownLatch blockArrived;
+        private final CountDownLatch blockRelease;
+
+        private ServerResources(
+                final ClassicTestServer server,
+                final HttpHost target,
+                final CountDownLatch blockArrived,
+                final CountDownLatch blockRelease) {
+            this.server = server;
+            this.target = target;
+            this.blockArrived = blockArrived;
+            this.blockRelease = blockRelease;
+        }
+
+        private void releaseBlocked() {
+            blockRelease.countDown();
+        }
+    }
+
+    private static ServerResources startServer() throws IOException {
+        final ClassicTestServer server = new ClassicTestServer(SocketConfig.DEFAULT);
+
+        final CountDownLatch blockArrived = new CountDownLatch(1);
+        final CountDownLatch blockRelease = new CountDownLatch(1);
+
+        server.register("/ok", (request, response, context) -> {
+            response.setCode(HttpStatus.SC_OK);
+            response.setEntity(new StringEntity("OK", ContentType.TEXT_PLAIN));
+        });
+
+        server.register("/block", (request, response, context) -> {
+            blockArrived.countDown();
+            try {
+                blockRelease.await(10, TimeUnit.SECONDS);
+            } catch (final InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+            response.setCode(HttpStatus.SC_OK);
+            response.setEntity(new StringEntity("OK", ContentType.TEXT_PLAIN));
+        });
+
+        server.start();
+
+        final HttpHost target = new HttpHost(
+                "http",
+                server.getInetAddress().getHostAddress(),
+                server.getPort());
+
+        return new ServerResources(server, target, blockArrived, blockRelease);
+    }
+
+    private static HttpAsyncRequester createRequester(final PoolConcurrencyPolicy policy) {
+        final HttpAsyncRequester requester = AsyncRequesterBootstrap.bootstrap()
+                .setPoolConcurrencyPolicy(policy)
+                .setDefaultMaxPerRoute(1)
+                .setMaxTotal(1)
+                .setTimeToLive(Timeout.ofSeconds(30))
+                .create();
+        requester.start();
+        return requester;
+    }
+
+    private static boolean awaitPending(
+            final HttpAsyncRequester requester,
+            final HttpHost route,
+            final int expectedPending,
+            final TimeValue maxWait) throws InterruptedException {
+
+        final long deadline = System.currentTimeMillis() + maxWait.toMilliseconds();
+        while (System.currentTimeMillis() < deadline) {
+            final PoolStats stats = requester.getStats(route);
+            if (stats.getPending() >= expectedPending) {
+                return true;
+            }
+            Thread.sleep(10);
+        }
+        return false;
+    }
+
+    private static boolean awaitQuiescent(
+            final HttpAsyncRequester requester,
+            final HttpHost route,
+            final TimeValue maxWait) throws InterruptedException {
+
+        final long deadline = System.currentTimeMillis() + maxWait.toMilliseconds();
+        while (System.currentTimeMillis() < deadline) {
+            final PoolStats total = requester.getTotalStats();
+            final PoolStats stats = requester.getStats(route);
+            if (total.getLeased() == 0 && total.getPending() == 0
+                    && stats.getLeased() == 0 && stats.getPending() == 0) {
+                return true;
+            }
+            Thread.sleep(10);
+        }
+        return false;
+    }
+
+    @ParameterizedTest
+    @EnumSource(PoolConcurrencyPolicy.class)
+    @org.junit.jupiter.api.Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void cancelPendingConnectMustNotLeakOrBlockNextConnect(final PoolConcurrencyPolicy policy) throws Exception {
+        final ServerResources srv = startServer();
+        final HttpAsyncRequester requester = createRequester(policy);
+
+        try {
+            final Future<AsyncClientEndpoint> f1 = requester.connect(srv.target, Timeout.ofSeconds(2));
+            final AsyncClientEndpoint ep1 = f1.get(2, TimeUnit.SECONDS);
+
+            final Future<AsyncClientEndpoint> f2 = requester.connect(srv.target, Timeout.ofSeconds(30));
+            assertTrue(awaitPending(requester, srv.target, 1, WAIT), "Second connect did not become pending");
+            assertTrue(f2.cancel(true), "Cancel failed");
+
+            ep1.releaseAndReuse();
+
+            final AsyncClientEndpoint ep3 = requester.connect(srv.target, Timeout.ofSeconds(2)).get(2, TimeUnit.SECONDS);
+            ep3.releaseAndReuse();
+
+            assertTrue(awaitQuiescent(requester, srv.target, WAIT), "Pool did not quiesce");
+        } finally {
+            requester.close(CloseMode.IMMEDIATE);
+            srv.server.shutdown(CloseMode.IMMEDIATE);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(PoolConcurrencyPolicy.class)
+    @org.junit.jupiter.api.Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void connectTimeoutWhilePendingMustNotLeak(final PoolConcurrencyPolicy policy) throws Exception {
+        final ServerResources srv = startServer();
+        final HttpAsyncRequester requester = createRequester(policy);
+
+        try {
+            final AsyncClientEndpoint ep1 = requester.connect(srv.target, Timeout.ofSeconds(2)).get(2, TimeUnit.SECONDS);
+
+            final Future<AsyncClientEndpoint> f2 = requester.connect(srv.target, Timeout.ofMilliseconds(200));
+            assertTrue(awaitPending(requester, srv.target, 1, WAIT), "Second connect did not become pending");
+
+            // Ensure the pending request's deadline is definitely expired before we trigger pool servicing.
+            Thread.sleep(500);
+
+            // Trigger servicing of pending connects.
+            ep1.releaseAndReuse();
+
+            try {
+                final AsyncClientEndpoint ep2 = f2.get(2, TimeUnit.SECONDS);
+                if (ep2 != null) {
+                    ep2.releaseAndDiscard();
+                }
+                fail("Expected pending connect to fail due to request timeout");
+            } catch (final ExecutionException ignore) {
+                // expected: deadline timeout / connect request timeout
+            }
+
+            // Pool must still be usable
+            final AsyncClientEndpoint ep3 = requester.connect(srv.target, Timeout.ofSeconds(2)).get(2, TimeUnit.SECONDS);
+            ep3.releaseAndReuse();
+
+            assertTrue(awaitQuiescent(requester, srv.target, WAIT), "Pool did not quiesce");
+
+        } finally {
+            requester.close(CloseMode.IMMEDIATE);
+            srv.server.shutdown(CloseMode.IMMEDIATE);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(PoolConcurrencyPolicy.class)
+    @org.junit.jupiter.api.Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void closeImmediateMidFlightMustNotHang(final PoolConcurrencyPolicy policy) throws Exception {
+        final ServerResources srv = startServer();
+        final HttpAsyncRequester requester = createRequester(policy);
+
+        try {
+            final Future<Message<HttpResponse, String>> f = requester.execute(
+                    srv.target,
+                    new BasicRequestProducer(Method.GET, srv.target, "/block"),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
+                    Timeout.ofSeconds(30),
+                    null);
+
+            assertTrue(srv.blockArrived.await(5, TimeUnit.SECONDS), "Server did not receive /block");
+
+            requester.close(CloseMode.IMMEDIATE);
+            srv.releaseBlocked();
+
+            try {
+                f.get(5, TimeUnit.SECONDS);
+            } catch (final Exception ignore) {
+                // Close mid-flight may abort; we only assert: no hang.
+            }
+        } finally {
+            srv.releaseBlocked();
+            requester.close(CloseMode.IMMEDIATE);
+            srv.server.shutdown(CloseMode.IMMEDIATE);
+        }
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/ConnPoolContractFuzzer.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/ConnPoolContractFuzzer.java
@@ -1,0 +1,427 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.SplittableRandom;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+
+final class ConnPoolContractFuzzer {
+
+    private static final Timeout REQUEST_TIMEOUT = Timeout.ofSeconds(30);
+    private static final Timeout NO_WAIT = Timeout.ofMilliseconds(0);
+    private static final TimeValue IDLE_TIME = TimeValue.ofMilliseconds(1);
+
+    private ConnPoolContractFuzzer() {
+    }
+
+    private static final class PendingLease {
+        private final Object state;
+        private final Future<PoolEntry<String, PoolTestSupport.DummyConn>> future;
+
+        private PendingLease(
+                final Object state,
+                final Future<PoolEntry<String, PoolTestSupport.DummyConn>> future) {
+            this.state = state;
+            this.future = future;
+        }
+    }
+
+    static void run(
+            final PoolTestSupport.PoolType poolType,
+            final ManagedConnPool<String, PoolTestSupport.DummyConn> pool,
+            final long seed,
+            final int steps,
+            final int routeCount) throws Exception {
+
+        final SplittableRandom rnd = new SplittableRandom(seed);
+
+        final List<String> routes = new ArrayList<>(routeCount);
+        for (int i = 0; i < routeCount; i++) {
+            routes.add("r" + i);
+        }
+
+        final List<String> trace = new ArrayList<>(steps + 64);
+
+        final Set<PoolEntry<String, PoolTestSupport.DummyConn>> leasedSet =
+                Collections.newSetFromMap(new IdentityHashMap<>());
+
+        final List<PoolEntry<String, PoolTestSupport.DummyConn>> leased = new ArrayList<>();
+        final List<PendingLease> pending = new ArrayList<>();
+
+        pool.setDefaultMaxPerRoute(2);
+        for (final String route : routes) {
+            pool.setMaxPerRoute(route, 2);
+        }
+        if (poolType.hasHardTotalLimit()) {
+            pool.setMaxTotal(Math.max(6, routeCount * 2));
+        }
+
+        try {
+            for (int step = 0; step < steps; step++) {
+                drainDoneFutures(pending, leased, leasedSet);
+
+                if (pending.size() > 80) {
+                    final int idx = rnd.nextInt(pending.size());
+                    trace.add(step + ": cancel(pending[" + idx + "]) (backpressure)");
+                    pending.get(idx).future.cancel(true);
+                }
+
+                final int action = rnd.nextInt(12);
+                switch (action) {
+                    case 0:
+                    case 1:
+                    case 2: {
+                        final String route = routes.get(rnd.nextInt(routes.size()));
+                        final Object state = (rnd.nextInt(4) == 0) ? null : Integer.valueOf(rnd.nextInt(3));
+                        trace.add(step + ": lease(" + route + ", state=" + state + ")");
+                        final Future<PoolEntry<String, PoolTestSupport.DummyConn>> f =
+                                pool.lease(route, state, REQUEST_TIMEOUT, null);
+                        pending.add(new PendingLease(state, f));
+                        break;
+                    }
+                    case 3: {
+                        if (!pending.isEmpty()) {
+                            final int idx = rnd.nextInt(pending.size());
+                            trace.add(step + ": cancel(pending[" + idx + "])");
+                            pending.get(idx).future.cancel(true);
+                        } else {
+                            trace.add(step + ": cancel(<none>)");
+                        }
+                        break;
+                    }
+                    case 4:
+                    case 5: {
+                        if (!leased.isEmpty()) {
+                            final int idx = rnd.nextInt(leased.size());
+                            final PoolEntry<String, PoolTestSupport.DummyConn> entry = leased.remove(idx);
+                            leasedSet.remove(entry);
+
+                            final boolean reusable = rnd.nextBoolean();
+                            trace.add(step + ": release(" + entry.getRoute() + ", reusable=" + reusable + ")");
+
+                            if (!reusable) {
+                                entry.discardConnection(CloseMode.IMMEDIATE);
+                            }
+                            pool.release(entry, reusable);
+                        } else {
+                            trace.add(step + ": release(<none>)");
+                        }
+                        break;
+                    }
+                    case 6: {
+                        if (!leased.isEmpty()) {
+                            final int idx = rnd.nextInt(leased.size());
+                            final PoolEntry<String, PoolTestSupport.DummyConn> entry = leased.get(idx);
+                            trace.add(step + ": expire(" + entry.getRoute() + ")");
+                            entry.updateExpiry(TimeValue.ofMilliseconds(0));
+                        } else {
+                            trace.add(step + ": expire(<none>)");
+                        }
+                        break;
+                    }
+                    case 7: {
+                        final String route = routes.get(rnd.nextInt(routes.size()));
+                        final int current = pool.getMaxPerRoute(route);
+                        final int next = current + 1 + rnd.nextInt(3);
+                        trace.add(step + ": setMaxPerRoute(" + route + ", " + next + ")");
+                        pool.setMaxPerRoute(route, next);
+                        break;
+                    }
+                    case 8: {
+                        if (poolType.hasHardTotalLimit()) {
+                            final int current = pool.getMaxTotal();
+                            final int next = (current > 0 ? current : 6) + 1 + rnd.nextInt(5);
+                            trace.add(step + ": setMaxTotal(" + next + ")");
+                            pool.setMaxTotal(next);
+                        } else {
+                            trace.add(step + ": setMaxTotal(<ignored by LAX>)");
+                        }
+                        break;
+                    }
+                    case 9: {
+                        trace.add(step + ": closeExpired()");
+                        pool.closeExpired();
+                        break;
+                    }
+                    case 10: {
+                        trace.add(step + ": closeIdle()");
+                        pool.closeIdle(IDLE_TIME);
+                        break;
+                    }
+                    case 11: {
+                        trace.add(step + ": nudge()");
+                        nudge(pool, routes);
+                        break;
+                    }
+                    default: {
+                        trace.add(step + ": <noop>");
+                        break;
+                    }
+                }
+
+                // Drain again so invariants observe the same state we model.
+                drainDoneFutures(pending, leased, leasedSet);
+
+                assertCoreInvariants(pool);
+
+                if (poolType != PoolTestSupport.PoolType.LAX) {
+                    assertHardBounds(pool, routes);
+                }
+
+                assertRouteTotalsConsistent(pool);
+            }
+
+            cleanupAndAssertQuiescent(poolType, pool, routes, pending, leased, leasedSet);
+
+        } catch (final AssertionError ex) {
+            fail("Pool=" + poolType + " seed=" + seed
+                    + "\nAssertion: " + ex.getMessage()
+                    + "\nRepro: -Dhc.pool.fuzz.seed=" + seed
+                    + "\nTrace(last 80):\n" + tail(trace, 80), ex);
+        } finally {
+            pool.close(CloseMode.IMMEDIATE);
+        }
+    }
+
+    private static void drainDoneFutures(
+            final List<PendingLease> pending,
+            final List<PoolEntry<String, PoolTestSupport.DummyConn>> leased,
+            final Set<PoolEntry<String, PoolTestSupport.DummyConn>> leasedSet) throws Exception {
+
+        for (final Iterator<PendingLease> it = pending.iterator(); it.hasNext(); ) {
+            final PendingLease p = it.next();
+            if (!p.future.isDone()) {
+                continue;
+            }
+            try {
+                final PoolEntry<String, PoolTestSupport.DummyConn> entry = p.future.get();
+                if (entry != null) {
+                    if (!entry.hasConnection()) {
+                        entry.assignConnection(new PoolTestSupport.DummyConn());
+                    }
+                    entry.updateState(p.state);
+
+                    assertTrue(leasedSet.add(entry), "Same entry leased twice concurrently");
+                    leased.add(entry);
+                }
+            } catch (final CancellationException ignore) {
+                // expected
+            } catch (final ExecutionException ignore) {
+                // allowed
+            } finally {
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Fast, deterministic activity trigger. No waiting.
+     */
+    private static void nudge(
+            final ManagedConnPool<String, PoolTestSupport.DummyConn> pool,
+            final List<String> routes) {
+
+        if (pool instanceof StrictConnPool) {
+            ((StrictConnPool<?, ?>) pool).validatePendingRequests();
+            return;
+        }
+        if (pool instanceof LaxConnPool) {
+            ((LaxConnPool<?, ?>) pool).validatePendingRequests();
+            return;
+        }
+
+        // OFFLOCK: avoid waiting and avoid enqueuing if saturated.
+        for (final String route : routes) {
+            final PoolStats rs = pool.getStats(route);
+            final int max = pool.getMaxPerRoute(route);
+            if (max > 0 && rs.getLeased() + rs.getAvailable() >= max) {
+                continue;
+            }
+
+            final Future<PoolEntry<String, PoolTestSupport.DummyConn>> f = pool.lease(route, null, NO_WAIT, null);
+            if (!f.isDone()) {
+                f.cancel(true);
+                continue;
+            }
+            try {
+                final PoolEntry<String, PoolTestSupport.DummyConn> entry = f.get();
+                if (entry != null) {
+                    if (!entry.hasConnection()) {
+                        entry.assignConnection(new PoolTestSupport.DummyConn());
+                    }
+                    pool.release(entry, true);
+                }
+            } catch (final Exception ignore) {
+                // ignore
+            }
+        }
+    }
+
+    private static void cleanupAndAssertQuiescent(
+            final PoolTestSupport.PoolType poolType,
+            final ManagedConnPool<String, PoolTestSupport.DummyConn> pool,
+            final List<String> routes,
+            final List<PendingLease> pending,
+            final List<PoolEntry<String, PoolTestSupport.DummyConn>> leased,
+            final Set<PoolEntry<String, PoolTestSupport.DummyConn>> leasedSet) throws Exception {
+
+        for (final PendingLease p : pending) {
+            p.future.cancel(true);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            drainDoneFutures(pending, leased, leasedSet);
+
+            while (!leased.isEmpty()) {
+                final PoolEntry<String, PoolTestSupport.DummyConn> e = leased.remove(leased.size() - 1);
+                leasedSet.remove(e);
+                pool.release(e, true);
+            }
+
+            for (final Iterator<PendingLease> it = pending.iterator(); it.hasNext(); ) {
+                final PendingLease p = it.next();
+                if (!p.future.isDone()) {
+                    continue;
+                }
+                try {
+                    final PoolEntry<String, PoolTestSupport.DummyConn> entry = p.future.get();
+                    if (entry != null) {
+                        if (!entry.hasConnection()) {
+                            entry.assignConnection(new PoolTestSupport.DummyConn());
+                        }
+                        entry.updateState(p.state);
+                        pool.release(entry, true);
+                    }
+                } catch (final Exception ignore) {
+                    // cancelled / failed
+                } finally {
+                    it.remove();
+                }
+            }
+
+            nudge(pool, routes);
+            pool.closeExpired();
+            pool.closeIdle(IDLE_TIME);
+
+            final PoolStats total = pool.getTotalStats();
+            if (pending.isEmpty() && total.getLeased() == 0 && total.getPending() == 0) {
+                break;
+            }
+        }
+
+        final PoolStats total = pool.getTotalStats();
+        assertEquals(0, total.getLeased(), "Leased entry leak detected");
+        assertEquals(0, total.getPending(), "Stuck waiters detected");
+
+        assertCoreInvariants(pool);
+        assertRouteTotalsConsistent(pool);
+
+        if (poolType != PoolTestSupport.PoolType.LAX) {
+            assertHardBounds(pool, routes);
+        }
+    }
+
+    private static void assertCoreInvariants(final ManagedConnPool<String, PoolTestSupport.DummyConn> pool) {
+        assertTrue(pool.getMaxTotal() >= 0, "maxTotal negative");
+
+        final PoolStats total = pool.getTotalStats();
+        assertTrue(total.getLeased() >= 0, "total.leased");
+        assertTrue(total.getPending() >= 0, "total.pending");
+        assertTrue(total.getAvailable() >= 0, "total.available");
+
+        for (final String route : pool.getRoutes()) {
+            assertTrue(pool.getMaxPerRoute(route) >= 0, "maxPerRoute negative");
+            final PoolStats rs = pool.getStats(route);
+            assertTrue(rs.getLeased() >= 0, "route.leased");
+            assertTrue(rs.getPending() >= 0, "route.pending");
+            assertTrue(rs.getAvailable() >= 0, "route.available");
+        }
+    }
+
+    private static void assertHardBounds(
+            final ManagedConnPool<String, PoolTestSupport.DummyConn> pool,
+            final List<String> knownRoutes) {
+
+        final PoolStats total = pool.getTotalStats();
+        final int maxTotal = pool.getMaxTotal();
+        if (maxTotal > 0) {
+            assertTrue(total.getLeased() + total.getAvailable() <= maxTotal, "total allocated > maxTotal");
+        }
+
+        for (final String route : knownRoutes) {
+            final PoolStats rs = pool.getStats(route);
+            final int maxRoute = pool.getMaxPerRoute(route);
+            if (maxRoute > 0) {
+                assertTrue(rs.getLeased() + rs.getAvailable() <= maxRoute, "route allocated > maxPerRoute");
+            }
+        }
+    }
+
+    private static void assertRouteTotalsConsistent(final ManagedConnPool<String, PoolTestSupport.DummyConn> pool) {
+        int leased = 0;
+        int pending = 0;
+        int available = 0;
+
+        for (final String route : pool.getRoutes()) {
+            final PoolStats rs = pool.getStats(route);
+            leased += rs.getLeased();
+            pending += rs.getPending();
+            available += rs.getAvailable();
+        }
+
+        final PoolStats total = pool.getTotalStats();
+        assertEquals(total.getLeased(), leased, "total.leased mismatch");
+        assertEquals(total.getPending(), pending, "total.pending mismatch");
+        assertEquals(total.getAvailable(), available, "total.available mismatch");
+    }
+
+    private static String tail(final List<String> trace, final int n) {
+        final int from = Math.max(0, trace.size() - n);
+        final StringBuilder b = new StringBuilder();
+        for (int i = from; i < trace.size(); i++) {
+            b.append(trace.get(i)).append('\n');
+        }
+        return b.toString();
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/PoolTestSupport.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/PoolTestSupport.java
@@ -1,0 +1,112 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.pool;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.io.ModalCloseable;
+import org.apache.hc.core5.util.TimeValue;
+
+final class PoolTestSupport {
+
+    private PoolTestSupport() {
+    }
+
+    static final class DummyConn implements ModalCloseable {
+
+        private volatile boolean closed;
+
+        @Override
+        public void close(final CloseMode closeMode) {
+            this.closed = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            close(CloseMode.GRACEFUL);
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
+
+    }
+
+    static final DisposalCallback<DummyConn> DISPOSAL = DummyConn::close;
+
+    enum PoolType {
+        STRICT,
+        LAX,
+        OFFLOCK;
+
+        ManagedConnPool<String, DummyConn> createPool(
+                final int defaultMaxPerRoute,
+                final int maxTotal) {
+
+            final TimeValue ttl = TimeValue.NEG_ONE_MILLISECOND;
+            final PoolReusePolicy reusePolicy = PoolReusePolicy.LIFO;
+
+            switch (this) {
+                case STRICT: {
+                    return new StrictConnPool<>(
+                            defaultMaxPerRoute,
+                            maxTotal,
+                            ttl,
+                            reusePolicy,
+                            DISPOSAL,
+                            null);
+                }
+                case LAX: {
+                    return new LaxConnPool<>(
+                            defaultMaxPerRoute,
+                            ttl,
+                            reusePolicy,
+                            DISPOSAL,
+                            null);
+                }
+                case OFFLOCK: {
+                    return new RouteSegmentedConnPool<>(
+                            defaultMaxPerRoute,
+                            maxTotal,
+                            ttl,
+                            reusePolicy,
+                            DISPOSAL);
+                }
+                default: {
+                    throw new IllegalStateException("Unexpected: " + this);
+                }
+            }
+        }
+
+        boolean hasHardTotalLimit() {
+            return this != LAX;
+        }
+
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestConnPoolConcurrencyStress.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestConnPoolConcurrencyStress.java
@@ -1,0 +1,207 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+final class TestConnPoolConcurrencyStress {
+
+    private static int intProp(final String name, final int def) {
+        final String v = System.getProperty(name);
+        return v != null ? Integer.parseInt(v) : def;
+    }
+
+    private static long longProp(final String name, final long def) {
+        final String v = System.getProperty(name);
+        return v != null ? Long.parseLong(v) : def;
+    }
+
+    @ParameterizedTest
+    @EnumSource(PoolTestSupport.PoolType.class)
+    @org.junit.jupiter.api.Timeout(value = 180, unit = TimeUnit.SECONDS)
+    void stress(final PoolTestSupport.PoolType poolType) throws Exception {
+        assumeTrue(Boolean.getBoolean("hc.pool.stress"), "stress disabled (use -Dhc.pool.stress=true)");
+
+        final int threads = intProp("hc.pool.stress.threads", 8);
+        final int routeCount = intProp("hc.pool.stress.routes", 10);
+        final int seconds = intProp("hc.pool.stress.seconds", 5);
+        final long seed = longProp("hc.pool.stress.seed", 1L);
+
+        final ManagedConnPool<String, PoolTestSupport.DummyConn> pool = poolType.createPool(5, 50);
+        final List<String> routes = new ArrayList<>(routeCount);
+        for (int i = 0; i < routeCount; i++) {
+            routes.add("r" + i);
+            pool.setMaxPerRoute("r" + i, 5);
+        }
+        if (poolType.hasHardTotalLimit()) {
+            pool.setMaxTotal(50);
+        }
+
+        final ExecutorService executor = Executors.newFixedThreadPool(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+
+        final long endAt = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(seconds);
+
+        try {
+            for (int t = 0; t < threads; t++) {
+                final int tid = t;
+                executor.submit(() -> {
+                    final SplittableRandom rnd = new SplittableRandom(seed + tid);
+                    final List<Future<PoolEntry<String, PoolTestSupport.DummyConn>>> pending = new ArrayList<>();
+                    final List<PoolEntry<String, PoolTestSupport.DummyConn>> leased = new ArrayList<>();
+
+                    start.await();
+
+                    while (System.currentTimeMillis() < endAt) {
+                        for (int i = pending.size() - 1; i >= 0; i--) {
+                            final Future<PoolEntry<String, PoolTestSupport.DummyConn>> f = pending.get(i);
+                            if (!f.isDone()) {
+                                continue;
+                            }
+                            try {
+                                final PoolEntry<String, PoolTestSupport.DummyConn> e = f.get();
+                                if (e != null) {
+                                    if (!e.hasConnection()) {
+                                        e.assignConnection(new PoolTestSupport.DummyConn());
+                                    }
+                                    leased.add(e);
+                                }
+                            } catch (final Exception ignore) {
+                            } finally {
+                                pending.remove(i);
+                            }
+                        }
+
+                        final int action = rnd.nextInt(8);
+                        switch (action) {
+                            case 0:
+                            case 1:
+                            case 2: {
+                                final String route = routes.get(rnd.nextInt(routes.size()));
+                                final Object state = (rnd.nextInt(5) == 0) ? null : rnd.nextInt(3);
+                                pending.add(pool.lease(route, state, Timeout.ofMilliseconds(200), null));
+                                break;
+                            }
+                            case 3: {
+                                if (!pending.isEmpty()) {
+                                    pending.get(rnd.nextInt(pending.size())).cancel(true);
+                                }
+                                break;
+                            }
+                            case 4:
+                            case 5: {
+                                if (!leased.isEmpty()) {
+                                    final int idx = rnd.nextInt(leased.size());
+                                    final PoolEntry<String, PoolTestSupport.DummyConn> e = leased.remove(idx);
+                                    final boolean reusable = rnd.nextBoolean();
+                                    if (!reusable) {
+                                        e.discardConnection(CloseMode.IMMEDIATE);
+                                    }
+                                    pool.release(e, reusable);
+                                }
+                                break;
+                            }
+                            case 6: {
+                                pool.closeExpired();
+                                break;
+                            }
+                            case 7: {
+                                pool.closeIdle(TimeValue.ofMilliseconds(1));
+                                break;
+                            }
+                            default: {
+                                break;
+                            }
+                        }
+                    }
+
+                    for (final Future<PoolEntry<String, PoolTestSupport.DummyConn>> f : pending) {
+                        f.cancel(true);
+                    }
+                    for (final PoolEntry<String, PoolTestSupport.DummyConn> e : leased) {
+                        pool.release(e, true);
+                    }
+
+                    return null;
+                });
+            }
+
+            start.countDown();
+
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(seconds + 30L, TimeUnit.SECONDS), "Executor did not terminate");
+
+            for (int i = 0; i < 3; i++) {
+                pool.closeExpired();
+                pool.closeIdle(TimeValue.ofMilliseconds(1));
+                for (final String r : routes) {
+                    final Future<PoolEntry<String, PoolTestSupport.DummyConn>> f =
+                            pool.lease(r, null, Timeout.ofMilliseconds(200), null);
+                    try {
+                        final PoolEntry<String, PoolTestSupport.DummyConn> e = f.get(200, TimeUnit.MILLISECONDS);
+                        if (e != null) {
+                            if (!e.hasConnection()) {
+                                e.assignConnection(new PoolTestSupport.DummyConn());
+                            }
+                            pool.release(e, true);
+                        }
+                    } catch (final Exception ex) {
+                        f.cancel(true);
+                    }
+                }
+                if (pool.getTotalStats().getLeased() == 0 && pool.getTotalStats().getPending() == 0) {
+                    break;
+                }
+            }
+
+            assertEquals(0, pool.getTotalStats().getLeased(), "Leased leak");
+            assertEquals(0, pool.getTotalStats().getPending(), "Stuck pending");
+
+        } finally {
+            executor.shutdownNow();
+            pool.close(CloseMode.IMMEDIATE);
+        }
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestConnPoolDifferentialStrictOfflock.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestConnPoolDifferentialStrictOfflock.java
@@ -1,0 +1,114 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Test;
+
+final class TestConnPoolDifferentialStrictOfflock {
+
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void strictAndOfflockShouldMatchForSynchronousTrace() throws Exception {
+        assumeTrue(Boolean.getBoolean("hc.pool.diff"), "diff disabled (use -Dhc.pool.diff=true)");
+
+        final long seed = Long.parseLong(System.getProperty("hc.pool.diff.seed", "1"));
+        final int steps = Integer.parseInt(System.getProperty("hc.pool.diff.steps", "200"));
+        final int routeCount = Integer.parseInt(System.getProperty("hc.pool.diff.routes", "8"));
+
+        final ManagedConnPool<String, PoolTestSupport.DummyConn> strict =
+                PoolTestSupport.PoolType.STRICT.createPool(10, 200);
+        final ManagedConnPool<String, PoolTestSupport.DummyConn> offlock =
+                PoolTestSupport.PoolType.OFFLOCK.createPool(10, 200);
+
+        final List<String> routes = new ArrayList<>(routeCount);
+        for (int i = 0; i < routeCount; i++) {
+            routes.add("r" + i);
+            strict.setMaxPerRoute("r" + i, 10);
+            offlock.setMaxPerRoute("r" + i, 10);
+        }
+        strict.setMaxTotal(200);
+        offlock.setMaxTotal(200);
+
+        final SplittableRandom rnd = new SplittableRandom(seed);
+
+        try {
+            for (int i = 0; i < steps; i++) {
+                final String route = routes.get(rnd.nextInt(routes.size()));
+                final Object state = (rnd.nextInt(4) == 0) ? null : Integer.valueOf(rnd.nextInt(3));
+
+                final PoolEntry<String, PoolTestSupport.DummyConn> e1 =
+                        strict.lease(route, state, Timeout.ofSeconds(2), null).get(2, TimeUnit.SECONDS);
+                if (!e1.hasConnection()) {
+                    e1.assignConnection(new PoolTestSupport.DummyConn());
+                }
+                e1.updateState(state);
+
+                final PoolEntry<String, PoolTestSupport.DummyConn> e2 =
+                        offlock.lease(route, state, Timeout.ofSeconds(2), null).get(2, TimeUnit.SECONDS);
+                if (!e2.hasConnection()) {
+                    e2.assignConnection(new PoolTestSupport.DummyConn());
+                }
+                e2.updateState(state);
+
+                if (rnd.nextInt(6) == 0) {
+                    e1.updateExpiry(TimeValue.ofMilliseconds(0));
+                    e2.updateExpiry(TimeValue.ofMilliseconds(0));
+                }
+
+                if (rnd.nextInt(8) == 0) {
+                    strict.closeExpired();
+                    offlock.closeExpired();
+                }
+
+                strict.release(e1, true);
+                offlock.release(e2, true);
+
+                final PoolStats s1 = strict.getTotalStats();
+                final PoolStats s2 = offlock.getTotalStats();
+
+                assertEquals(s1.getLeased(), s2.getLeased(), "leased mismatch at step " + i);
+                assertEquals(s1.getPending(), s2.getPending(), "pending mismatch at step " + i);
+                assertEquals(s1.getAvailable(), s2.getAvailable(), "available mismatch at step " + i);
+            }
+        } finally {
+            strict.close(CloseMode.IMMEDIATE);
+            offlock.close(CloseMode.IMMEDIATE);
+        }
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestConnPoolGenerativeContracts.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestConnPoolGenerativeContracts.java
@@ -1,0 +1,71 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.pool;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+final class TestConnPoolGenerativeContracts {
+
+    private static int intProp(final String name, final int def) {
+        final String v = System.getProperty(name);
+        return v != null ? Integer.parseInt(v) : def;
+    }
+
+    private static long longProp(final String name, final long def) {
+        final String v = System.getProperty(name);
+        return v != null ? Long.parseLong(v) : def;
+    }
+
+    @ParameterizedTest
+    @EnumSource(PoolTestSupport.PoolType.class)
+    @org.junit.jupiter.api.Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void fuzzContract(final PoolTestSupport.PoolType poolType) throws Exception {
+        final int steps = intProp("hc.pool.fuzz.steps", 250);
+        final int routeCount = intProp("hc.pool.fuzz.routes", 5);
+
+        final String singleSeedProp = System.getProperty("hc.pool.fuzz.seed");
+        final int seeds = intProp("hc.pool.fuzz.seeds", 3);
+        final long baseSeed = longProp("hc.pool.fuzz.baseSeed", 1L);
+
+        if (singleSeedProp != null) {
+            final long seed = Long.parseLong(singleSeedProp);
+            final ManagedConnPool<String, PoolTestSupport.DummyConn> pool = poolType.createPool(2, 8);
+            ConnPoolContractFuzzer.run(poolType, pool, seed, steps, routeCount);
+            return;
+        }
+
+        for (int i = 0; i < seeds; i++) {
+            final long seed = baseSeed + i;
+            final ManagedConnPool<String, PoolTestSupport.DummyConn> pool = poolType.createPool(2, 8);
+            ConnPoolContractFuzzer.run(poolType, pool, seed, steps, routeCount);
+        }
+    }
+
+}

--- a/httpcore5/src/test/java/org/apache/hc/core5/pool/TestLaxConnPoolCancelDuringServiceDoesNotLeak.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/pool/TestLaxConnPoolCancelDuringServiceDoesNotLeak.java
@@ -1,0 +1,108 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.pool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Test;
+
+final class TestLaxConnPoolCancelDuringServiceDoesNotLeak {
+
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void cancelDuringServiceMustNotLeakEntry() throws Exception {
+        final CountDownLatch onLeaseReached = new CountDownLatch(1);
+        final CountDownLatch allowOnLeaseReturn = new CountDownLatch(1);
+        final AtomicBoolean blockNextOnLease = new AtomicBoolean(true);
+
+        final ConnPoolListener<String> listener = new ConnPoolListener<String>() {
+
+            @Override
+            public void onLease(final String route, final ConnPoolStats<String> stats) {
+                if (blockNextOnLease.compareAndSet(true, false)) {
+                    onLeaseReached.countDown();
+                    try {
+                        allowOnLeaseReturn.await(5, TimeUnit.SECONDS);
+                    } catch (final InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+
+            @Override
+            public void onRelease(final String route, final ConnPoolStats<String> stats) {
+            }
+
+        };
+
+        final LaxConnPool<String, PoolTestSupport.DummyConn> pool = new LaxConnPool<>(
+                1,
+                TimeValue.NEG_ONE_MILLISECOND,
+                PoolReusePolicy.LIFO,
+                PoolTestSupport.DISPOSAL,
+                listener);
+
+        final String route = "r1";
+
+        try {
+            pool.setMaxPerRoute(route, 1);
+
+            final PoolEntry<String, PoolTestSupport.DummyConn> leased1 =
+                    pool.lease(route, null, Timeout.ofSeconds(2), null).get(2, TimeUnit.SECONDS);
+            leased1.assignConnection(new PoolTestSupport.DummyConn());
+
+            final Future<PoolEntry<String, PoolTestSupport.DummyConn>> waiter =
+                    pool.lease(route, null, Timeout.ofSeconds(30), null);
+
+            final Thread releaser = new Thread(() -> pool.release(leased1, true), "releaser");
+            releaser.start();
+
+            assertTrue(onLeaseReached.await(5, TimeUnit.SECONDS), "Did not reach onLease hook");
+            assertTrue(waiter.cancel(true), "Waiter cancel failed");
+
+            allowOnLeaseReturn.countDown();
+            releaser.join(5000);
+            assertFalse(releaser.isAlive(), "Releaser thread stuck");
+
+            assertEquals(0, pool.getStats(route).getLeased(), "Entry leaked as leased");
+
+        } finally {
+            pool.close(CloseMode.IMMEDIATE);
+        }
+    }
+
+}


### PR DESCRIPTION
This change adds seeded generative contract tests for the connection pool implementations (STRICT, LAX, OFFLOCK) that run a shared operation trace and assert core invariants (no negative stats, no double-lease, no stuck pending, no leaked leased entries, and hard bounds where applicable) with seed+trace replay for reproducibility. It also adds a small httpcore5-testing integration test based on HttpAsyncRequester to validate real socket behavior for pending connect cancellation, pending connect timeout, and close-mid-flight without hangs across all three pool policies.