### PR TITLE
Fix flaky Docker compatibility tests caused by EMFILE in httpd container

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/ContainerImages.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/compatibility/ContainerImages.java
@@ -28,6 +28,8 @@ package org.apache.hc.core5.testing.compatibility;
 
 import java.util.Random;
 
+import com.github.dockerjava.api.model.Ulimit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -116,7 +118,8 @@ public final class ContainerImages {
                 .withNetwork(network)
                 .withNetworkAliases(APACHE_HTTPD)
                 .withLogConsumer(new Slf4jLogConsumer(LOG))
-                .withExposedPorts(HTTP_PORT, H2C_PORT, HTTPS_PORT);
+                .withExposedPorts(HTTP_PORT, H2C_PORT, HTTPS_PORT)
+                .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withUlimits(new Ulimit[]{new Ulimit("nofile", 65536L, 65536L)}));
     }
 
     public static GenericContainer<?> nginx(final Network network) {


### PR DESCRIPTION
The httpd container was hitting the default file descriptor limit (1024) under concurrent test load. Apache misleadingly reports EMFILE as "file permissions deny server access" (AH00132) and returns 403.                                                                                                                                                  
Raise the nofile ulimit on the httpd container to 65536. 