### PR TITLE
Add content type support to JSON async entity producers

### DIFF
--- a/httpcore5-jackson2/src/main/java/org/apache/hc/core5/jackson2/http/AbstractJsonEntityProducer.java
+++ b/httpcore5-jackson2/src/main/java/org/apache/hc/core5/jackson2/http/AbstractJsonEntityProducer.java
@@ -37,10 +37,16 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 abstract class AbstractJsonEntityProducer implements AsyncEntityProducer {
 
     private final InternalBuffer buffer;
+    private final ContentType contentType;
     private volatile State state;
 
     AbstractJsonEntityProducer(final int initSize) {
+        this(initSize, null);
+    }
+
+    AbstractJsonEntityProducer(final int initSize, final ContentType contentType) {
         this.buffer = new InternalBuffer(initSize);
+        this.contentType = contentType != null ? contentType : ContentType.APPLICATION_JSON;
         this.state = State.ACTIVE;
     }
 
@@ -58,7 +64,7 @@ abstract class AbstractJsonEntityProducer implements AsyncEntityProducer {
 
     @Override
     public final String getContentType() {
-        return ContentType.APPLICATION_JSON.toString();
+        return contentType.toString();
     }
 
     @Override

--- a/httpcore5-jackson2/src/main/java/org/apache/hc/core5/jackson2/http/JsonObjectEntityProducer.java
+++ b/httpcore5-jackson2/src/main/java/org/apache/hc/core5/jackson2/http/JsonObjectEntityProducer.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -45,10 +46,23 @@ public class JsonObjectEntityProducer<T> extends AbstractJsonEntityProducer {
     private final T jsonObject;
     private final ObjectMapper objectMapper;
 
-    public JsonObjectEntityProducer(final T jsonObject, final ObjectMapper objectMapper) {
-        super(4096);
+    /**
+     * Creates a new instance that serializes the given object using the specified content type.
+     * If {@code contentType} is {@code null}, defaults to {@code application/json}.
+     *
+     * @param jsonObject   the object to serialize.
+     * @param objectMapper the object mapper.
+     * @param contentType  the content type, or {@code null} for {@code application/json}.
+     * @since 5.5
+     */
+    public JsonObjectEntityProducer(final T jsonObject, final ObjectMapper objectMapper, final ContentType contentType) {
+        super(4096, contentType);
         this.jsonObject = Args.notNull(jsonObject, "Json object");
         this.objectMapper = Args.notNull(objectMapper, "Object mapper");
+    }
+
+    public JsonObjectEntityProducer(final T jsonObject, final ObjectMapper objectMapper) {
+        this(jsonObject, objectMapper, null);
     }
 
     @Override


### PR DESCRIPTION
Allow AbstractJsonEntityProducer and JsonObjectEntityProducer to use an explicit ContentType for streamed JSON request bodies.