### PR TITLE
Add H2 multiplexing connection pool

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2IOEventHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2IOEventHandler.java
@@ -47,7 +47,16 @@ class AbstractH2IOEventHandler implements HttpConnectionEventHandler {
     final AbstractH2StreamMultiplexer streamMultiplexer;
 
     AbstractH2IOEventHandler(final AbstractH2StreamMultiplexer streamMultiplexer) {
+        this(streamMultiplexer, null);
+    }
+
+    AbstractH2IOEventHandler(
+            final AbstractH2StreamMultiplexer streamMultiplexer,
+            final H2PoolSessionSupport sessionSupport) {
         this.streamMultiplexer = Args.notNull(streamMultiplexer, "Stream multiplexer");
+        if (sessionSupport != null) {
+            streamMultiplexer.setPoolSessionSupport(sessionSupport);
+        }
     }
 
     @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -143,6 +143,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
 
     private EndpointDetails endpointDetails;
     private boolean goAwayReceived;
+    private volatile H2PoolSessionSupport poolSessionSupport;
 
     private volatile boolean peerNoRfc7540Priorities;
 
@@ -193,6 +194,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         this.frameFactory = Args.notNull(frameFactory, "Frame factory");
         this.httpProcessor = Args.notNull(httpProcessor, "HTTP processor");
         this.streams = new H2Streams(idGenerator);
+        this.streams.setLocalStreamChangeCallback(this::fireCapacityAvailable);
         this.localConfig = h2Config != null ? h2Config : H2Config.DEFAULT;
         this.inputMetrics = new BasicH2TransportMetrics();
         this.outputMetrics = new BasicH2TransportMetrics();
@@ -674,6 +676,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
         }
         streams.shutdownAndReleaseAll();
         CommandSupport.cancelCommands(ioSession);
+        fireSessionClosed();
     }
 
     private void executeShutdown(final ShutdownCommand shutdownCommand) throws IOException {
@@ -1099,6 +1102,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
                     streams.shutdownAndReleaseAll();
                     connState = ConnectionHandshake.SHUTDOWN;
                 }
+                fireDraining();
             }
             ioSession.setEvent(SelectionKey.OP_WRITE);
             break;
@@ -1358,6 +1362,7 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
                 }
             }
         }
+        fireCapacityAvailable();
     }
 
     private void applyLocalSettings() throws H2ConnectionException {
@@ -1436,6 +1441,61 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
     @Override
     public SocketAddress getLocalAddress() {
         return ioSession.getLocalAddress();
+    }
+
+    int getActiveLocalStreams() {
+        return streams.getLocalCount();
+    }
+
+    int getPeerMaxConcurrentStreams() {
+        return remoteConfig.getMaxConcurrentStreams();
+    }
+
+    boolean isGoAwayReceived() {
+        return goAwayReceived;
+    }
+
+    boolean isShutdown() {
+        return connState.compareTo(ConnectionHandshake.GRACEFUL_SHUTDOWN) >= 0;
+    }
+
+    void setPoolSessionSupport(final H2PoolSessionSupport poolSessionSupport) {
+        this.poolSessionSupport = poolSessionSupport;
+        if (poolSessionSupport != null) {
+            poolSessionSupport.updateActiveLocalStreams(streams.getLocalCount());
+            poolSessionSupport.updatePeerMaxConcurrentStreams(remoteConfig.getMaxConcurrentStreams());
+            poolSessionSupport.updateGoAwayReceived(goAwayReceived);
+            poolSessionSupport.updateShutdown(
+                    connState.compareTo(ConnectionHandshake.GRACEFUL_SHUTDOWN) >= 0);
+        }
+    }
+
+    void fireCapacityAvailable() {
+        final H2PoolSessionSupport support = this.poolSessionSupport;
+        if (support != null) {
+            support.updateActiveLocalStreams(streams.getLocalCount());
+            support.updatePeerMaxConcurrentStreams(remoteConfig.getMaxConcurrentStreams());
+            support.updateShutdown(connState.compareTo(ConnectionHandshake.GRACEFUL_SHUTDOWN) >= 0);
+            support.fireCapacityAvailable();
+        }
+    }
+
+    void fireDraining() {
+        final H2PoolSessionSupport support = this.poolSessionSupport;
+        if (support != null) {
+            support.updateGoAwayReceived(true);
+            support.updateShutdown(connState.compareTo(ConnectionHandshake.GRACEFUL_SHUTDOWN) >= 0);
+            support.fireDraining();
+        }
+    }
+
+    void fireSessionClosed() {
+        final H2PoolSessionSupport support = this.poolSessionSupport;
+        if (support != null) {
+            support.updateActiveLocalStreams(0);
+            support.updateShutdown(true);
+            support.fireSessionClosed();
+        }
     }
 
     void appendState(final StringBuilder buf) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2PrefaceHandler.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/ClientH2PrefaceHandler.java
@@ -61,6 +61,7 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
 
     private final ClientH2StreamMultiplexerFactory http2StreamHandlerFactory;
     private final boolean strictALPNHandshake;
+    private final H2PoolSessionSupport sessionSupport;
     private final AtomicBoolean initialized;
 
     private volatile ByteBuffer preface;
@@ -83,9 +84,23 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
             final boolean strictALPNHandshake,
             final FutureCallback<ProtocolIOSession> resultCallback,
             final Callback<Exception> exceptionCallback) {
+        this(ioSession, http2StreamHandlerFactory, strictALPNHandshake, null, resultCallback, exceptionCallback);
+    }
+
+    /**
+     * @since 5.5
+     */
+    public ClientH2PrefaceHandler(
+            final ProtocolIOSession ioSession,
+            final ClientH2StreamMultiplexerFactory http2StreamHandlerFactory,
+            final boolean strictALPNHandshake,
+            final H2PoolSessionSupport sessionSupport,
+            final FutureCallback<ProtocolIOSession> resultCallback,
+            final Callback<Exception> exceptionCallback) {
         super(ioSession, resultCallback, exceptionCallback);
         this.http2StreamHandlerFactory = Args.notNull(http2StreamHandlerFactory, "HTTP/2 stream handler factory");
         this.strictALPNHandshake = strictALPNHandshake;
+        this.sessionSupport = sessionSupport;
         this.initialized = new AtomicBoolean();
     }
 
@@ -117,7 +132,8 @@ public class ClientH2PrefaceHandler extends PrefaceHandlerBase {
         if (!preface.hasRemaining()) {
             session.clearEvent(SelectionKey.OP_WRITE);
             final ByteBuffer data = inBuf != null ? inBuf.data() : null;
-            startProtocol(new ClientH2IOEventHandler(http2StreamHandlerFactory.create(ioSession)), data);
+            startProtocol(new ClientH2IOEventHandler(
+                    http2StreamHandlerFactory.create(ioSession), sessionSupport), data);
             if (inBuf != null) {
                 inBuf.clear();
             }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/H2PoolSessionSupport.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/H2PoolSessionSupport.java
@@ -1,0 +1,163 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.impl.nio;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hc.core5.annotation.Internal;
+
+/**
+ * Attachment-based bridge between the HTTP/2 multiplexing connection
+ * pool and the stream multiplexer. The pool creates an instance and
+ * passes it as the {@code attachment} argument to the connection
+ * initiator; the I/O event handler detects it and wires it to the
+ * multiplexer. The multiplexer pushes state updates into this object
+ * and fires observer callbacks through it; the pool reads state and
+ * registers its observer here.
+ *
+ * @since 5.5
+ */
+@Internal
+public final class H2PoolSessionSupport {
+
+    /**
+     * Callback for capacity, draining and session-closure notifications.
+     * Implementations are invoked from the I/O reactor thread
+     * and must not block.
+     */
+    public interface Observer {
+
+        /** Stream capacity became available on the connection. */
+        void onCapacityAvailable();
+
+        /** Connection entered a draining state. */
+        void onDraining();
+
+        /**
+         * Underlying session has been fully disconnected. Fired exactly once
+         * after the multiplexer has finalised its disconnect bookkeeping, so
+         * the observer may treat reservations and active streams on this
+         * session as void. Default is a no-op to preserve source and binary
+         * compatibility with existing observers.
+         *
+         * @since 5.5
+         */
+        default void onSessionClosed() {
+        }
+
+    }
+
+    private final AtomicInteger activeLocalStreams;
+    private final AtomicInteger peerMaxConcurrentStreams;
+    private final AtomicReference<Observer> observerRef;
+
+    private volatile boolean goAwayReceived;
+    private volatile boolean shutdown;
+
+    public H2PoolSessionSupport() {
+        this.activeLocalStreams = new AtomicInteger();
+        this.peerMaxConcurrentStreams = new AtomicInteger(Integer.MAX_VALUE);
+        this.observerRef = new AtomicReference<>();
+    }
+
+    /** Returns the number of locally initiated streams currently open. */
+    public int getActiveLocalStreams() {
+        return activeLocalStreams.get();
+    }
+
+    /** Returns the peer's {@code MAX_CONCURRENT_STREAMS} value. */
+    public int getPeerMaxConcurrentStreams() {
+        return peerMaxConcurrentStreams.get();
+    }
+
+    /** Returns {@code true} if a {@code GOAWAY} frame has been received. */
+    public boolean isGoAwayReceived() {
+        return goAwayReceived;
+    }
+
+    /** Returns {@code true} if the session is shutting down. */
+    public boolean isShutdown() {
+        return shutdown;
+    }
+
+    /** Registers the observer for capacity change notifications. */
+    public void setObserver(final Observer observer) {
+        observerRef.set(observer);
+    }
+
+    /** Pushes the current active local stream count. */
+    public void updateActiveLocalStreams(final int count) {
+        activeLocalStreams.set(count);
+    }
+
+    /** Pushes the peer's {@code MAX_CONCURRENT_STREAMS} value. */
+    public void updatePeerMaxConcurrentStreams(final int max) {
+        peerMaxConcurrentStreams.set(max);
+    }
+
+    /** Pushes the GOAWAY-received flag. */
+    public void updateGoAwayReceived(final boolean value) {
+        goAwayReceived = value;
+    }
+
+    /** Pushes the shutdown flag. */
+    public void updateShutdown(final boolean value) {
+        shutdown = value;
+    }
+
+    /** Fires the capacity-available notification. */
+    public void fireCapacityAvailable() {
+        final Observer observer = observerRef.get();
+        if (observer != null) {
+            observer.onCapacityAvailable();
+        }
+    }
+
+    /** Fires the draining notification. */
+    public void fireDraining() {
+        final Observer observer = observerRef.get();
+        if (observer != null) {
+            observer.onDraining();
+        }
+    }
+
+    /**
+     * Fires the session-closed notification. Intended to be invoked exactly
+     * once per session after the multiplexer has reset its local stream
+     * state, so the pool sees a coherent final picture.
+     *
+     * @since 5.5
+     */
+    public void fireSessionClosed() {
+        final Observer observer = observerRef.get();
+        if (observer != null) {
+            observer.onSessionClosed();
+        }
+    }
+
+}

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/H2Streams.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/H2Streams.java
@@ -51,6 +51,7 @@ class H2Streams {
     private final AtomicInteger lastRemoteId;
     private final AtomicInteger localCount;
     private final AtomicInteger remoteCount;
+    private volatile Runnable localStreamChangeCallback;
 
     public H2Streams(final StreamIdGenerator idGenerator) {
         this.idGenerator = Args.notNull(idGenerator, "Stream id generator");
@@ -60,6 +61,10 @@ class H2Streams {
         this.lastRemoteId = new AtomicInteger(0);
         this.localCount = new AtomicInteger(0);
         this.remoteCount = new AtomicInteger(0);
+    }
+
+    void setLocalStreamChangeCallback(final Runnable callback) {
+        this.localStreamChangeCallback = callback;
     }
 
     public boolean isEmpty() {
@@ -94,9 +99,21 @@ class H2Streams {
             switch (state) {
                 case OPEN:
                     count.incrementAndGet();
+                    if (!remoteStream) {
+                        final Runnable cb = localStreamChangeCallback;
+                        if (cb != null) {
+                            cb.run();
+                        }
+                    }
                     break;
                 case CLOSED:
                     count.decrementAndGet();
+                    if (!remoteStream) {
+                        final Runnable cb = localStreamChangeCallback;
+                        if (cb != null) {
+                            cb.run();
+                        }
+                    }
             }
         });
         if (remoteStream) {

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequester.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequester.java
@@ -32,9 +32,9 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.concurrent.Cancellable;
@@ -50,6 +50,7 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.impl.DefaultAddressResolver;
 import org.apache.hc.core5.http.impl.bootstrap.AsyncRequester;
@@ -67,7 +68,9 @@ import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http.nio.support.BasicClientExchangeHandler;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
-import org.apache.hc.core5.http2.nio.pool.H2ConnPool;
+import org.apache.hc.core5.http2.nio.pool.H2PoolPolicy;
+import org.apache.hc.core5.http2.nio.pool.H2RequesterConnPool;
+import org.apache.hc.core5.http2.nio.pool.H2StreamLease;
 import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
@@ -87,7 +90,7 @@ import org.apache.hc.core5.util.Timeout;
  */
 public class H2MultiplexingRequester extends AsyncRequester {
 
-    private final H2ConnPool connPool;
+    private final H2RequesterConnPool connPool;
     private final AtomicReference<TimeValue> validateAfterInactivityRef;
 
     /**
@@ -112,14 +115,40 @@ public class H2MultiplexingRequester extends AsyncRequester {
             final IOWorkerSelector workerSelector,
             final AtomicReference<TimeValue> validateAfterInactivityRef,
             final int maxCommandsPerConnection) {
+        this(ioReactorConfig, eventHandlerFactory, ioSessionDecorator, exceptionCallback, sessionListener,
+                addressResolver, tlsStrategy, threadPoolListener, workerSelector,
+                validateAfterInactivityRef, maxCommandsPerConnection, null, 0, 0, null);
+    }
+
+    /**
+     * Use {@link H2MultiplexingRequesterBootstrap} to create instances of this class.
+     *
+     * @since 5.5
+     */
+    @Internal
+    public H2MultiplexingRequester(
+            final IOReactorConfig ioReactorConfig,
+            final IOEventHandlerFactory eventHandlerFactory,
+            final Decorator<IOSession> ioSessionDecorator,
+            final Callback<Exception> exceptionCallback,
+            final IOSessionListener sessionListener,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy,
+            final IOReactorMetricsListener threadPoolListener,
+            final IOWorkerSelector workerSelector,
+            final AtomicReference<TimeValue> validateAfterInactivityRef,
+            final int maxCommandsPerConnection,
+            final H2PoolPolicy poolPolicy,
+            final int defaultMaxPerRoute,
+            final int maxTotal,
+            final TimeValue validateAfterInactivity) {
         super(eventHandlerFactory, ioReactorConfig, ioSessionDecorator, exceptionCallback, sessionListener,
                 ShutdownCommand.GRACEFUL_IMMEDIATE_CALLBACK, DefaultAddressResolver.INSTANCE,
                 threadPoolListener, workerSelector);
-        this.connPool = new H2ConnPool(this, addressResolver, tlsStrategy);
+        this.connPool = H2RequesterConnPool.create(
+                this, addressResolver, tlsStrategy, poolPolicy,
+                defaultMaxPerRoute, maxTotal, validateAfterInactivity);
         this.validateAfterInactivityRef = validateAfterInactivityRef;
-        if (this.validateAfterInactivityRef != null) {
-            this.validateAfterInactivityRef.set(this.connPool.getValidateAfterInactivity());
-        }
         this.maxCommandsPerConnection = maxCommandsPerConnection;
     }
 
@@ -132,14 +161,15 @@ public class H2MultiplexingRequester extends AsyncRequester {
     }
 
     public TimeValue getValidateAfterInactivity() {
-        return connPool.getValidateAfterInactivity();
+        return validateAfterInactivityRef != null
+                ? validateAfterInactivityRef.get() : TimeValue.NEG_ONE_MILLISECOND;
     }
 
     public void setValidateAfterInactivity(final TimeValue timeValue) {
-        connPool.setValidateAfterInactivity(timeValue);
         if (validateAfterInactivityRef != null) {
             validateAfterInactivityRef.set(timeValue);
         }
+        connPool.setValidateAfterInactivity(timeValue);
     }
 
     /**
@@ -201,97 +231,12 @@ public class H2MultiplexingRequester extends AsyncRequester {
                 if (request.getAuthority() == null) {
                     request.setAuthority(new URIAuthority(host));
                 }
-                connPool.getSession(host, timeout, new FutureCallback<IOSession>() {
+                connPool.leaseSession(host, timeout, new FutureCallback<H2StreamLease>() {
 
                     @Override
-                    public void completed(final IOSession ioSession) {
-                        final AsyncClientExchangeHandler handlerProxy = new AsyncClientExchangeHandler() {
-
-                            @Override
-                            public void releaseResources() {
-                                exchangeHandler.releaseResources();
-                            }
-
-                            @Override
-                            public void produceRequest(final RequestChannel channel, final HttpContext httpContext) throws HttpException, IOException {
-                                channel.sendRequest(request, entityDetails, httpContext);
-                            }
-
-                            @Override
-                            public int available() {
-                                return exchangeHandler.available();
-                            }
-
-                            @Override
-                            public void produce(final DataStreamChannel channel) throws IOException {
-                                exchangeHandler.produce(channel);
-                            }
-
-                            @Override
-                            public void consumeInformation(final HttpResponse response, final HttpContext httpContext) throws HttpException, IOException {
-                                exchangeHandler.consumeInformation(response, httpContext);
-                            }
-
-                            @Override
-                            public void consumeResponse(
-                                    final HttpResponse response, final EntityDetails entityDetails, final HttpContext httpContext) throws HttpException, IOException {
-                                exchangeHandler.consumeResponse(response, entityDetails, httpContext);
-                            }
-
-                            @Override
-                            public void updateCapacity(final CapacityChannel capacityChannel) throws IOException {
-                                exchangeHandler.updateCapacity(capacityChannel);
-                            }
-
-                            @Override
-                            public void consume(final ByteBuffer src) throws IOException {
-                                exchangeHandler.consume(src);
-                            }
-
-                            @Override
-                            public void streamEnd(final List<? extends Header> trailers) throws HttpException, IOException {
-                                exchangeHandler.streamEnd(trailers);
-                            }
-
-                            @Override
-                            public void cancel() {
-                                exchangeHandler.cancel();
-                            }
-
-                            @Override
-                            public void failed(final Exception cause) {
-                                exchangeHandler.failed(cause);
-                            }
-
-                        };
-                        final int max = maxCommandsPerConnection;
-                        if (max > 0) {
-                            final int pending = ioSession.getPendingCommandCount();
-                            if (pending >= 0 && pending >= max) {
-                                try {
-                                    exchangeHandler.failed(new RejectedExecutionException(
-                                            "Maximum number of pending commands per connection reached (max=" + max + ")"));
-                                } finally {
-                                    exchangeHandler.releaseResources();
-                                }
-                                return;
-                            }
-                        }
-                        final Timeout socketTimeout = ioSession.getSocketTimeout();
-                        ioSession.enqueue(new RequestExecutionCommand(
-                                        handlerProxy,
-                                        pushHandlerFactory,
-                                        context,
-                                        streamControl -> {
-                                            cancellableDependency.setDependency(streamControl);
-                                            if (socketTimeout != null) {
-                                                streamControl.setTimeout(socketTimeout);
-                                            }
-                                        }),
-                                Command.Priority.NORMAL);
-                        if (!ioSession.isOpen()) {
-                            exchangeHandler.failed(new ConnectionClosedException());
-                        }
+                    public void completed(final H2StreamLease lease) {
+                        dispatchLease(lease, exchangeHandler, request, entityDetails,
+                                pushHandlerFactory, cancellableDependency, context);
                     }
 
                     @Override
@@ -309,6 +254,142 @@ public class H2MultiplexingRequester extends AsyncRequester {
             }, context);
         } catch (final IOException | HttpException ex) {
             exchangeHandler.failed(ex);
+        }
+    }
+
+    /**
+     * Dispatches a leased stream reservation to the underlying {@link IOSession}.
+     * Wraps the caller-supplied exchange handler so that the lease is released
+     * through all terminal paths: the stream-control callback invoked when the
+     * multiplexer allocates a stream, {@link AsyncClientExchangeHandler#releaseResources()
+     * releaseResources}, the per-connection command cap, an {@code enqueue}
+     * failure, and a race where the session closes after the command has been
+     * accepted.
+     *
+     * @since 5.5
+     */
+    void dispatchLease(
+            final H2StreamLease lease,
+            final AsyncClientExchangeHandler exchangeHandler,
+            final HttpRequest request,
+            final EntityDetails entityDetails,
+            final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
+            final CancellableDependency cancellableDependency,
+            final HttpContext context) {
+        final IOSession ioSession = lease.getSession();
+
+        final AsyncClientExchangeHandler handlerProxy = new AsyncClientExchangeHandler() {
+
+            @Override
+            public void releaseResources() {
+                try {
+                    lease.releaseReservation();
+                } finally {
+                    exchangeHandler.releaseResources();
+                }
+            }
+
+            @Override
+            public void produceRequest(final RequestChannel channel, final HttpContext httpContext)
+                    throws HttpException, IOException {
+                channel.sendRequest(request, entityDetails, httpContext);
+            }
+
+            @Override
+            public int available() {
+                return exchangeHandler.available();
+            }
+
+            @Override
+            public void produce(final DataStreamChannel channel) throws IOException {
+                exchangeHandler.produce(channel);
+            }
+
+            @Override
+            public void consumeInformation(final HttpResponse response, final HttpContext httpContext)
+                    throws HttpException, IOException {
+                exchangeHandler.consumeInformation(response, httpContext);
+            }
+
+            @Override
+            public void consumeResponse(
+                    final HttpResponse response,
+                    final EntityDetails entityDetails,
+                    final HttpContext httpContext) throws HttpException, IOException {
+                exchangeHandler.consumeResponse(response, entityDetails, httpContext);
+            }
+
+            @Override
+            public void updateCapacity(final CapacityChannel capacityChannel) throws IOException {
+                exchangeHandler.updateCapacity(capacityChannel);
+            }
+
+            @Override
+            public void consume(final ByteBuffer src) throws IOException {
+                exchangeHandler.consume(src);
+            }
+
+            @Override
+            public void streamEnd(final List<? extends Header> trailers)
+                    throws HttpException, IOException {
+                exchangeHandler.streamEnd(trailers);
+            }
+
+            @Override
+            public void cancel() {
+                exchangeHandler.cancel();
+            }
+
+            @Override
+            public void failed(final Exception cause) {
+                exchangeHandler.failed(cause);
+            }
+
+        };
+
+        final int max = maxCommandsPerConnection;
+        if (max > 0) {
+            final int pending = ioSession.getPendingCommandCount();
+            if (pending >= 0 && pending >= max) {
+                try {
+                    exchangeHandler.failed(new RejectedExecutionException(
+                            "Maximum number of pending commands per connection reached (max=" + max + ")"));
+                } finally {
+                    lease.releaseReservation();
+                    exchangeHandler.releaseResources();
+                }
+                return;
+            }
+        }
+
+        final Timeout socketTimeout = ioSession.getSocketTimeout();
+        final RequestExecutionCommand command = new RequestExecutionCommand(
+                handlerProxy,
+                pushHandlerFactory,
+                context,
+                streamControl -> {
+                    lease.releaseReservation();
+                    cancellableDependency.setDependency(streamControl);
+                    if (socketTimeout != null) {
+                        streamControl.setTimeout(socketTimeout);
+                    }
+                });
+
+        try {
+            ioSession.enqueue(command, Command.Priority.NORMAL);
+        } catch (final RuntimeException ex) {
+            try {
+                exchangeHandler.failed(ex);
+            } finally {
+                lease.releaseReservation();
+                exchangeHandler.releaseResources();
+            }
+            return;
+        }
+
+        if (!ioSession.isOpen()) {
+            lease.releaseReservation();
+            exchangeHandler.failed(new ConnectionClosedException());
         }
     }
 
@@ -332,7 +413,8 @@ public class H2MultiplexingRequester extends AsyncRequester {
                 requestProducer,
                 responseConsumer,
                 new CompletingFutureContribution<T, T>(future));
-        execute(target, exchangeHandler, pushHandlerFactory, future, timeout, context != null ? context : HttpCoreContext.create());
+        execute(target, exchangeHandler, pushHandlerFactory, future, timeout,
+                context != null ? context : HttpCoreContext.create());
         return future;
     }
 
@@ -377,8 +459,14 @@ public class H2MultiplexingRequester extends AsyncRequester {
         return execute(null, requestProducer, responseConsumer, null, timeout, null, callback);
     }
 
+    /**
+     * Returns the connection pool used by this requester.
+     *
+     * @return the connection pool
+     * @since 5.5
+     */
     @Internal
-    public H2ConnPool getConnPool() {
+    public H2RequesterConnPool getConnectionPool() {
         return connPool;
     }
 }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequesterBootstrap.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/bootstrap/H2MultiplexingRequesterBootstrap.java
@@ -45,8 +45,10 @@ import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.http2.frame.FrameFactory;
 import org.apache.hc.core5.http2.impl.H2Processors;
 import org.apache.hc.core5.http2.impl.nio.ClientH2PrefaceHandler;
+import org.apache.hc.core5.http2.impl.nio.H2PoolSessionSupport;
 import org.apache.hc.core5.http2.impl.nio.ClientH2StreamMultiplexerFactory;
 import org.apache.hc.core5.http2.impl.nio.H2StreamListener;
+import org.apache.hc.core5.http2.nio.pool.H2PoolPolicy;
 import org.apache.hc.core5.http2.nio.support.DefaultAsyncPushConsumerFactory;
 import org.apache.hc.core5.http2.ssl.H2ClientTlsStrategy;
 import org.apache.hc.core5.reactor.IOReactorConfig;
@@ -81,6 +83,9 @@ public class H2MultiplexingRequesterBootstrap {
     private IOReactorMetricsListener threadPoolListener;
 
     private int maxCommandsPerConnection;
+    private H2PoolPolicy poolPolicy = H2PoolPolicy.BASIC;
+    private int defaultMaxPerRoute;
+    private int maxTotal;
 
     private Timeout pingAckTimeout;
 
@@ -206,6 +211,56 @@ public class H2MultiplexingRequesterBootstrap {
     }
 
     /**
+     * Sets the HTTP/2 connection pool policy. {@link H2PoolPolicy#BASIC}
+     * uses a simple one-session-per-endpoint pool where the multiplexer
+     * handles all stream management. {@link H2PoolPolicy#MULTIPLEXING}
+     * enables a stream-capacity-aware pool that manages multiple
+     * connections per endpoint and tracks individual stream slots.
+     * The default is {@link H2PoolPolicy#BASIC}.
+     *
+     * @param poolPolicy pool policy
+     * @return this instance.
+     * @since 5.5
+     */
+    @Experimental
+    public final H2MultiplexingRequesterBootstrap setH2PoolPolicy(final H2PoolPolicy poolPolicy) {
+        this.poolPolicy = Args.notNull(poolPolicy, "Pool policy");
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of connections per route for the
+     * multiplexing connection pool. A value {@code <= 0} uses the
+     * default ({@code 3}). Only applies when pool policy is
+     * {@link H2PoolPolicy#MULTIPLEXING}.
+     *
+     * @param max maximum connections per route
+     * @return this instance.
+     * @since 5.5
+     */
+    @Experimental
+    public final H2MultiplexingRequesterBootstrap setDefaultMaxPerRoute(final int max) {
+        this.defaultMaxPerRoute = max;
+        return this;
+    }
+
+    /**
+     * Sets the maximum total number of connections for the
+     * multiplexing connection pool. A value {@code <= 0} uses the
+     * default ({@code 25}). Only applies when pool policy is
+     * {@link H2PoolPolicy#MULTIPLEXING}.
+     *
+     * @param max maximum total connections
+     * @return this instance.
+     * @since 5.5
+     */
+    @Experimental
+    public final H2MultiplexingRequesterBootstrap setMaxTotal(final int max) {
+        this.maxTotal = max;
+        return this;
+    }
+
+    /**
      * Sets the timeout applied while waiting for the HTTP/2 PING ACK emitted during
      * pre-flight connection validation. When unset, the default of 5 seconds is used.
      *
@@ -306,8 +361,15 @@ public class H2MultiplexingRequesterBootstrap {
                 pingAckTimeout);
         return new H2MultiplexingRequester(
                 ioReactorConfig,
-                (ioSession, attachment) ->
-                        new ClientH2PrefaceHandler(ioSession, http2StreamHandlerFactory, strictALPNHandshake, exceptionCallback),
+                (ioSession, attachment) -> {
+                    final H2PoolSessionSupport sessionSupport =
+                            attachment instanceof H2PoolSessionSupport
+                                    ? (H2PoolSessionSupport) attachment : null;
+                    return new ClientH2PrefaceHandler(
+                            ioSession, http2StreamHandlerFactory,
+                            strictALPNHandshake, sessionSupport,
+                            null, exceptionCallback);
+                },
                 ioSessionDecorator,
                 exceptionCallback,
                 sessionListener,
@@ -316,7 +378,11 @@ public class H2MultiplexingRequesterBootstrap {
                 threadPoolListener,
                 null,
                 validateAfterInactivityRef,
-                maxCommandsPerConnection);
+                maxCommandsPerConnection,
+                poolPolicy,
+                defaultMaxPerRoute,
+                maxTotal,
+                null);
     }
 
 }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2ConnPool.java
@@ -57,30 +57,76 @@ import org.apache.hc.core5.util.Timeout;
  * @since 5.0
  */
 @Contract(threading = ThreadingBehavior.SAFE)
-public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> {
+public final class H2ConnPool extends AbstractIOSessionPool<HttpHost> implements H2RequesterConnPool {
 
     private final ConnectionInitiator connectionInitiator;
     private final Resolver<HttpHost, InetSocketAddress> addressResolver;
     private final TlsStrategy tlsStrategy;
 
-    private volatile TimeValue validateAfterInactivity = TimeValue.NEG_ONE_MILLISECOND;
+    private volatile TimeValue validateAfterInactivity;
 
     public H2ConnPool(
             final ConnectionInitiator connectionInitiator,
             final Resolver<HttpHost, InetSocketAddress> addressResolver,
             final TlsStrategy tlsStrategy) {
+        this(connectionInitiator, addressResolver, tlsStrategy, null);
+    }
+
+    H2ConnPool(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy,
+            final TimeValue validateAfterInactivity) {
         super();
         this.connectionInitiator = Args.notNull(connectionInitiator, "Connection initiator");
         this.addressResolver = addressResolver != null ? addressResolver : DefaultAddressResolver.INSTANCE;
         this.tlsStrategy = tlsStrategy;
+        this.validateAfterInactivity = validateAfterInactivity != null
+                ? validateAfterInactivity : TimeValue.NEG_ONE_MILLISECOND;
     }
 
+    /**
+     * Returns the current validate-after-inactivity interval. A non-negative
+     * value enables stale-checking of pooled sessions that have been idle
+     * for longer than the interval before they are handed out again.
+     *
+     * @since 5.0
+     */
     public TimeValue getValidateAfterInactivity() {
         return validateAfterInactivity;
     }
 
+    @Override
+    public Future<H2StreamLease> leaseSession(
+            final HttpHost endpoint,
+            final Timeout connectTimeout,
+            final FutureCallback<H2StreamLease> callback) {
+        final org.apache.hc.core5.concurrent.BasicFuture<H2StreamLease> future =
+                new org.apache.hc.core5.concurrent.BasicFuture<>(callback);
+        getSession(endpoint, connectTimeout, new FutureCallback<IOSession>() {
+
+            @Override
+            public void completed(final IOSession ioSession) {
+                future.completed(new H2StreamLease(ioSession, () -> {
+                }));
+            }
+
+            @Override
+            public void failed(final Exception ex) {
+                future.failed(ex);
+            }
+
+            @Override
+            public void cancelled() {
+                future.cancel();
+            }
+        });
+        return future;
+    }
+
+    @Override
     public void setValidateAfterInactivity(final TimeValue timeValue) {
-        this.validateAfterInactivity = timeValue;
+        this.validateAfterInactivity = timeValue != null ? timeValue : TimeValue.NEG_ONE_MILLISECOND;
     }
 
     @Override

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2MultiplexingConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2MultiplexingConnPool.java
@@ -1,0 +1,1188 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.nio.pool;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.concurrent.BasicFuture;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.function.Resolver;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.impl.DefaultAddressResolver;
+import org.apache.hc.core5.http.nio.command.ShutdownCommand;
+import org.apache.hc.core5.http.nio.command.StaleCheckCommand;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http2.impl.nio.H2PoolSessionSupport;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.ConnectionInitiator;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * HTTP/2 stream-capacity-aware connection pool. Tracks active and
+ * reserved streams per connection, honours the peer's
+ * {@code MAX_CONCURRENT_STREAMS}, opens additional connections when
+ * existing ones are saturated, and drains connections on
+ * {@code GOAWAY}. Routes blocked by {@code maxTotal} are queued in
+ * a global FIFO to avoid scanning all routes on every release.
+ *
+ * @since 5.5
+ */
+@Contract(threading = ThreadingBehavior.SAFE)
+class H2MultiplexingConnPool implements H2RequesterConnPool {
+
+    private final ConnectionInitiator connectionInitiator;
+    private final Resolver<HttpHost, InetSocketAddress> addressResolver;
+    private final TlsStrategy tlsStrategy;
+
+    private final ConcurrentHashMap<HttpHost, RoutePool> routePools;
+    private final ConcurrentLinkedQueue<QueuedRoute> globallyBlockedRoutes;
+
+    private final AtomicBoolean closed;
+    private final AtomicInteger totalConnectionCount;
+    private final ReentrantReadWriteLock lifecycleLock;
+
+    private final int defaultMaxPerRoute;
+    private final int maxTotal;
+    private volatile TimeValue validateAfterInactivity;
+
+    private static final int DEFAULT_MAX_PER_ROUTE = 3;
+    private static final int DEFAULT_MAX_TOTAL = 25;
+
+    H2MultiplexingConnPool(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy) {
+        this(connectionInitiator, addressResolver, tlsStrategy, DEFAULT_MAX_PER_ROUTE, DEFAULT_MAX_TOTAL, null);
+    }
+
+    H2MultiplexingConnPool(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy,
+            final int defaultMaxPerRoute,
+            final int maxTotal) {
+        this(connectionInitiator, addressResolver, tlsStrategy, defaultMaxPerRoute, maxTotal, null);
+    }
+
+    H2MultiplexingConnPool(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy,
+            final int defaultMaxPerRoute,
+            final int maxTotal,
+            final TimeValue validateAfterInactivity) {
+        this.connectionInitiator = Args.notNull(connectionInitiator, "Connection initiator");
+        this.addressResolver = addressResolver != null ? addressResolver : DefaultAddressResolver.INSTANCE;
+        this.tlsStrategy = tlsStrategy;
+        this.routePools = new ConcurrentHashMap<>();
+        this.globallyBlockedRoutes = new ConcurrentLinkedQueue<>();
+        this.closed = new AtomicBoolean();
+        this.totalConnectionCount = new AtomicInteger(0);
+        this.lifecycleLock = new ReentrantReadWriteLock(true);
+        this.defaultMaxPerRoute = defaultMaxPerRoute > 0 ? defaultMaxPerRoute : DEFAULT_MAX_PER_ROUTE;
+        this.maxTotal = maxTotal > 0 ? maxTotal : DEFAULT_MAX_TOTAL;
+        this.validateAfterInactivity = validateAfterInactivity != null ? validateAfterInactivity : TimeValue.NEG_ONE_MILLISECOND;
+    }
+
+    @Override
+    public Set<HttpHost> getRoutes() {
+        return new HashSet<>(routePools.keySet());
+    }
+
+    @Override
+    public void setValidateAfterInactivity(final TimeValue timeValue) {
+        this.validateAfterInactivity = timeValue != null ? timeValue : TimeValue.NEG_ONE_MILLISECOND;
+    }
+
+    RoutePool getRoutePool(final HttpHost endpoint) {
+        return routePools.computeIfAbsent(endpoint, key -> new RoutePool());
+    }
+
+    private boolean tryReserveGlobalSlot() {
+        for (;;) {
+            if (closed.get()) {
+                return false;
+            }
+            final int current = totalConnectionCount.get();
+            if (current >= maxTotal) {
+                return false;
+            }
+            if (totalConnectionCount.compareAndSet(current, current + 1)) {
+                if (closed.get()) {
+                    totalConnectionCount.decrementAndGet();
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+
+    private void releaseGlobalSlot() {
+        if (!closed.get()) {
+            totalConnectionCount.decrementAndGet();
+        }
+    }
+
+    private boolean routeHasRoom(final RoutePool routePool) {
+        int count = routePool.connectInFlight ? 1 : 0;
+        for (final ConnectionEntry entry : routePool.entries) {
+            if (entry.countsTowardRouteLimit()) {
+                count++;
+            }
+        }
+        return count < defaultMaxPerRoute;
+    }
+
+    /**
+     * Removes {@code routePool} from the route map when it holds no state that
+     * would require further servicing. Must be called while holding
+     * {@code routePool.lock}.
+     */
+    private void pruneRoutePoolIfUnused(final HttpHost endpoint, final RoutePool routePool) {
+        if (routePool.entries.isEmpty()
+                && routePool.pendingRequests.isEmpty()
+                && !routePool.connectInFlight
+                && !routePool.globallyQueued) {
+            routePools.remove(endpoint, routePool);
+        }
+    }
+
+    /**
+     * Acquires the per-endpoint route pool with its lock held. Re-fetches if a
+     * concurrent prune has removed the candidate from the route map, so no
+     * caller operates on a detached pool.
+     */
+    private RoutePool acquireRoutePool(final HttpHost endpoint) {
+        for (;;) {
+            final RoutePool candidate = getRoutePool(endpoint);
+            candidate.lock.lock();
+            if (routePools.get(endpoint) == candidate) {
+                return candidate;
+            }
+            candidate.lock.unlock();
+        }
+    }
+
+    private boolean markConnectInFlightIfPossible(final RoutePool routePool) {
+        if (!routePool.connectInFlight && routeHasRoom(routePool) && tryReserveGlobalSlot()) {
+            routePool.connectInFlight = true;
+            return true;
+        }
+        return false;
+    }
+
+    Future<H2StreamLease> lease(
+            final HttpHost endpoint,
+            final Timeout connectTimeout,
+            final FutureCallback<H2StreamLease> callback) {
+        Args.notNull(endpoint, "Endpoint");
+        final BasicFuture<H2StreamLease> future = new BasicFuture<>(callback);
+
+        final ReentrantReadWriteLock.ReadLock readLock = lifecycleLock.readLock();
+        readLock.lock();
+        try {
+            if (closed.get()) {
+                future.failed(new IllegalStateException("Connection pool shut down"));
+                return future;
+            }
+
+            final RoutePool routePool = acquireRoutePool(endpoint);
+            ConnectionEntry reserved = null;
+            boolean startDial = false;
+            int purged = 0;
+
+            try {
+                if (closed.get()) {
+                    future.failed(new IllegalStateException("Connection pool shut down"));
+                    return future;
+                }
+
+                reserved = tryFastReserve(routePool);
+                if (reserved == null) {
+                    purged = purgeDeadEntries(routePool);
+
+                    reserved = tryFastReserve(routePool);
+                    if (reserved == null) {
+                        final PendingLease pending = new PendingLease(future, connectTimeout);
+
+                        if (routePool.connectInFlight) {
+                            routePool.pendingRequests.add(pending);
+                            return future;
+                        }
+
+                        reserved = routePool.reserveAvailable();
+                        if (reserved == null) {
+                            if (markConnectInFlightIfPossible(routePool)) {
+                                routePool.pendingRequests.add(pending);
+                                startDial = true;
+                            } else {
+                                routePool.pendingRequests.add(pending);
+                                if (routeHasRoom(routePool) && totalConnectionCount.get() >= maxTotal) {
+                                    enqueueGloballyBlockedRoute(endpoint, routePool);
+                                }
+                            }
+                        }
+                    }
+                }
+            } finally {
+                routePool.lock.unlock();
+            }
+
+            if (startDial) {
+                startConnect(endpoint, connectTimeout, routePool);
+            } else if (reserved != null) {
+                completeLeaseWithValidation(endpoint, routePool, reserved, future, connectTimeout);
+            }
+
+            if (purged > 0) {
+                processGlobalPending();
+            }
+
+            return future;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    private ConnectionEntry tryFastReserve(final RoutePool routePool) {
+        if (routePool.connectInFlight || !routePool.pendingRequests.isEmpty() || routePool.entries.size() != 1) {
+            return null;
+        }
+        final ConnectionEntry entry = routePool.entries.get(0);
+        final int capacity = entry.availableCapacity();
+        if (capacity > 0) {
+            entry.reserved.incrementAndGet();
+            entry.lastUsed = System.currentTimeMillis();
+            return entry;
+        }
+        return null;
+    }
+
+    private void completeLeaseWithValidation(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final ConnectionEntry entry,
+            final BasicFuture<H2StreamLease> future,
+            final Timeout connectTimeout) {
+        final IOSession session = entry.session;
+        final TimeValue timeValue = validateAfterInactivity;
+        if (TimeValue.isNonNegative(timeValue) && session.isOpen()) {
+            final long lastIo = Math.max(session.getLastReadTime(), session.getLastWriteTime());
+            final long deadline = lastIo + timeValue.toMilliseconds();
+            if (deadline <= System.currentTimeMillis()) {
+                session.enqueue(new StaleCheckCommand(valid -> {
+                    if (valid) {
+                        finalizeLease(endpoint, routePool, entry, future, connectTimeout);
+                    } else {
+                        retryAfterValidationFailure(endpoint, routePool, entry, future, connectTimeout);
+                    }
+                }), Command.Priority.NORMAL);
+                return;
+            }
+        }
+        finalizeLease(endpoint, routePool, entry, future, connectTimeout);
+    }
+
+    private void finalizeLease(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final ConnectionEntry entry,
+            final BasicFuture<H2StreamLease> future,
+            final Timeout connectTimeout) {
+        final ReentrantReadWriteLock.ReadLock readLock = lifecycleLock.readLock();
+        readLock.lock();
+        try {
+            H2StreamLease lease = null;
+            Exception failure = null;
+            boolean retry = false;
+
+            routePool.lock.lock();
+            try {
+                if (closed.get()) {
+                    if (entry.reserved.get() > 0) {
+                        entry.reserved.decrementAndGet();
+                    }
+                    failure = new IllegalStateException("Connection pool shut down");
+                } else if (future.isDone()) {
+                    if (entry.reserved.get() > 0) {
+                        entry.reserved.decrementAndGet();
+                    }
+                    return;
+                } else if (!routePool.entries.contains(entry)
+                        || !entry.session.isOpen()
+                        || entry.draining) {
+                    retry = true;
+                } else {
+                    lease = createLease(endpoint, routePool, entry);
+                }
+            } finally {
+                routePool.lock.unlock();
+            }
+
+            if (failure != null) {
+                future.failed(failure);
+                return;
+            }
+
+            if (retry) {
+                retryAfterValidationFailure(endpoint, routePool, entry, future, connectTimeout);
+                return;
+            }
+
+            if (!future.completed(lease)) {
+                releaseReservation(endpoint, routePool, entry);
+            }
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    private void retryAfterValidationFailure(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final ConnectionEntry entry,
+            final BasicFuture<H2StreamLease> future,
+            final Timeout connectTimeout) {
+        boolean startDial = false;
+        final boolean evicted;
+        ConnectionEntry retryEntry;
+
+        routePool.lock.lock();
+        try {
+            if (entry.reserved.get() > 0) {
+                entry.reserved.decrementAndGet();
+            }
+            entry.draining = true;
+            evicted = evictIfDead(routePool, entry);
+
+            if (closed.get() || future.isDone()) {
+                return;
+            }
+
+            retryEntry = tryFastReserve(routePool);
+            if (retryEntry == null) {
+                retryEntry = routePool.reserveAvailable();
+            }
+            if (retryEntry == null) {
+                final PendingLease pending = new PendingLease(future, connectTimeout);
+                if (markConnectInFlightIfPossible(routePool)) {
+                    routePool.pendingRequests.addFirst(pending);
+                    startDial = true;
+                } else {
+                    routePool.pendingRequests.addFirst(pending);
+                    if (routeHasRoom(routePool) && totalConnectionCount.get() >= maxTotal) {
+                        enqueueGloballyBlockedRoute(endpoint, routePool);
+                    }
+                }
+            }
+        } finally {
+            routePool.lock.unlock();
+        }
+
+        if (startDial) {
+            startConnect(endpoint, connectTimeout, routePool);
+        } else if (retryEntry != null) {
+            completeLeaseWithValidation(endpoint, routePool, retryEntry, future, connectTimeout);
+        }
+
+        if (evicted) {
+            processGlobalPending();
+        }
+    }
+
+    private H2StreamLease createLease(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final ConnectionEntry entry) {
+        return new H2StreamLease(entry.session, () -> releaseReservation(endpoint, routePool, entry));
+    }
+
+    private void releaseReservation(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final ConnectionEntry entry) {
+        final List<Runnable> completions;
+        routePool.lock.lock();
+        try {
+            if (entry.reserved.get() > 0) {
+                entry.reserved.decrementAndGet();
+            }
+            entry.lastUsed = System.currentTimeMillis();
+            if (!entry.observerRegistered.get()) {
+                registerObserver(endpoint, routePool, entry);
+            }
+            completions = routePool.pendingRequests.isEmpty() ?
+                    Collections.emptyList() :
+                    drainPending(endpoint, routePool, true);
+        } finally {
+            routePool.lock.unlock();
+        }
+        fireCompletions(completions);
+    }
+
+    private static void purgeCancelledWaiters(final RoutePool routePool) {
+        while (!routePool.pendingRequests.isEmpty() && routePool.pendingRequests.peek().future.isDone()) {
+            routePool.pendingRequests.poll();
+        }
+    }
+
+    private List<Runnable> drainPending(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final boolean startNewConnect) {
+        final List<Runnable> completions = new ArrayList<>();
+        purgeCancelledWaiters(routePool);
+
+        while (!routePool.pendingRequests.isEmpty()) {
+            ConnectionEntry entry = tryFastReserve(routePool);
+            if (entry == null) {
+                entry = routePool.reserveAvailable();
+            }
+            if (entry == null) {
+                break;
+            }
+
+            final PendingLease pending = routePool.pendingRequests.poll();
+            if (pending != null && !pending.future.isDone()) {
+                final ConnectionEntry captured = entry;
+                final Timeout timeout = pending.connectTimeout;
+                completions.add(() -> completeLeaseWithValidation(
+                        endpoint, routePool, captured, pending.future, timeout));
+            } else {
+                if (entry.reserved.get() > 0) {
+                    entry.reserved.decrementAndGet();
+                }
+            }
+        }
+
+        if (startNewConnect) {
+            purgeCancelledWaiters(routePool);
+            if (!routePool.pendingRequests.isEmpty() && markConnectInFlightIfPossible(routePool)) {
+                final Timeout timeout = routePool.pendingRequests.peek().connectTimeout;
+                completions.add(() -> startConnect(endpoint, timeout, routePool));
+            } else if (!routePool.pendingRequests.isEmpty()
+                    && routeHasRoom(routePool) && totalConnectionCount.get() >= maxTotal) {
+                enqueueGloballyBlockedRoute(endpoint, routePool);
+            }
+        }
+
+        return completions;
+    }
+
+    private int purgeDeadEntries(final RoutePool routePool) {
+        int purged = 0;
+        final Iterator<ConnectionEntry> it = routePool.entries.iterator();
+        while (it.hasNext()) {
+            final ConnectionEntry entry = it.next();
+            if (!entry.session.isOpen() && entry.reserved.get() <= 0) {
+                it.remove();
+                entry.support.setObserver(null);
+                releaseGlobalSlot();
+                purged++;
+            }
+        }
+        return purged;
+    }
+
+    private void enqueueGloballyBlockedRoute(
+            final HttpHost endpoint,
+            final RoutePool routePool) {
+        if (!routePool.globallyQueued
+                && !routePool.pendingRequests.isEmpty()
+                && !routePool.connectInFlight
+                && routeHasRoom(routePool)) {
+            routePool.globallyQueued = true;
+            globallyBlockedRoutes.add(new QueuedRoute(endpoint, routePool));
+        }
+    }
+
+    /**
+     * Wake routes blocked by maxTotal without scanning every route.
+     */
+    private void processGlobalPending() {
+        if (closed.get()) {
+            return;
+        }
+
+        final List<Runnable> starts = new ArrayList<>();
+
+        while (!closed.get() && totalConnectionCount.get() < maxTotal) {
+            final QueuedRoute queuedRoute = globallyBlockedRoutes.poll();
+            if (queuedRoute == null) {
+                break;
+            }
+
+            final HttpHost endpoint = queuedRoute.endpoint;
+            final RoutePool routePool = queuedRoute.routePool;
+            Timeout connectTimeout = null;
+
+            routePool.lock.lock();
+            try {
+                routePool.globallyQueued = false;
+                purgeCancelledWaiters(routePool);
+
+                if (closed.get()) {
+                    continue;
+                }
+                if (routePools.get(endpoint) != routePool) {
+                    continue;
+                }
+                if (routePool.pendingRequests.isEmpty()) {
+                    continue;
+                }
+
+                if (markConnectInFlightIfPossible(routePool)) {
+                    connectTimeout = routePool.pendingRequests.peek().connectTimeout;
+                } else if (totalConnectionCount.get() >= maxTotal) {
+                    enqueueGloballyBlockedRoute(endpoint, routePool);
+                    break;
+                }
+            } finally {
+                routePool.lock.unlock();
+            }
+
+            if (connectTimeout != null) {
+                final Timeout capturedTimeout = connectTimeout;
+                starts.add(() -> startConnect(endpoint, capturedTimeout, routePool));
+            } else {
+                break;
+            }
+        }
+
+        fireCompletions(starts);
+    }
+
+    private void startConnect(
+            final HttpHost endpoint,
+            final Timeout connectTimeout,
+            final RoutePool routePool) {
+        final ReentrantReadWriteLock.ReadLock readLock = lifecycleLock.readLock();
+        readLock.lock();
+        try {
+            if (closed.get()) {
+                return;
+            }
+
+            final H2PoolSessionSupport support = new H2PoolSessionSupport();
+            final InetSocketAddress remoteAddress = addressResolver.resolve(endpoint);
+            connectionInitiator.connect(
+                    endpoint,
+                    remoteAddress,
+                    null,
+                    connectTimeout,
+                    support,
+                    new FutureCallback<IOSession>() {
+
+                        @Override
+                        public void completed(final IOSession ioSession) {
+                            if (tlsStrategy != null
+                                    && URIScheme.HTTPS.same(endpoint.getSchemeName())
+                                    && ioSession instanceof TransportSecurityLayer) {
+                                try {
+                                    tlsStrategy.upgrade(
+                                            (TransportSecurityLayer) ioSession,
+                                            endpoint,
+                                            null,
+                                            connectTimeout,
+                                            new FutureCallback<TransportSecurityLayer>() {
+
+                                                @Override
+                                                public void completed(final TransportSecurityLayer transportSecurityLayer) {
+                                                    onSessionReady(endpoint, ioSession, routePool, support);
+                                                }
+
+                                                @Override
+                                                public void failed(final Exception ex) {
+                                                    ioSession.close(CloseMode.IMMEDIATE);
+                                                    onConnectFailed(endpoint, routePool, ex);
+                                                }
+
+                                                @Override
+                                                public void cancelled() {
+                                                    ioSession.close(CloseMode.IMMEDIATE);
+                                                    onConnectFailed(endpoint, routePool, new InterruptedException());
+                                                }
+                                            });
+                                    ioSession.setSocketTimeout(connectTimeout);
+                                } catch (final RuntimeException ex) {
+                                    ioSession.close(CloseMode.IMMEDIATE);
+                                    onConnectFailed(endpoint, routePool, ex);
+                                }
+                            } else {
+                                onSessionReady(endpoint, ioSession, routePool, support);
+                            }
+                        }
+
+                        @Override
+                        public void failed(final Exception ex) {
+                            onConnectFailed(endpoint, routePool, ex);
+                        }
+
+                        @Override
+                        public void cancelled() {
+                            onConnectFailed(endpoint, routePool, new InterruptedException());
+                        }
+                    });
+        } catch (final RuntimeException ex) {
+            onConnectFailed(endpoint, routePool, ex);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    void onSessionReady(
+            final HttpHost endpoint,
+            final IOSession ioSession,
+            final RoutePool routePool,
+            final H2PoolSessionSupport support) {
+        boolean closeSession = false;
+        List<Runnable> completions = null;
+
+        routePool.lock.lock();
+        try {
+            routePool.connectInFlight = false;
+            routePool.globallyQueued = false;
+
+            if (closed.get()) {
+                closeSession = true;
+            } else {
+                final ConnectionEntry entry = new ConnectionEntry(ioSession, support);
+                routePool.entries.add(entry);
+                registerObserver(endpoint, routePool, entry);
+                completions = drainPending(endpoint, routePool, true);
+            }
+        } finally {
+            routePool.lock.unlock();
+        }
+
+        if (closeSession) {
+            ioSession.close(CloseMode.GRACEFUL);
+            return;
+        }
+        fireCompletions(completions);
+    }
+
+    void onConnectFailed(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final Exception ex) {
+        final List<Runnable> completions;
+        final List<PendingLease> failed;
+        boolean startDial = false;
+        Timeout retryTimeout = null;
+
+        routePool.lock.lock();
+        try {
+            routePool.connectInFlight = false;
+
+            if (closed.get()) {
+                return;
+            }
+
+            releaseGlobalSlot();
+            completions = drainPending(endpoint, routePool, false);
+
+            if (!completions.isEmpty()) {
+                failed = null;
+            } else if (!routePool.pendingRequests.isEmpty() && routePool.entries.isEmpty()) {
+                failed = new ArrayList<>();
+                PendingLease pending;
+                while ((pending = routePool.pendingRequests.poll()) != null) {
+                    failed.add(pending);
+                }
+            } else {
+                failed = null;
+                if (!routePool.pendingRequests.isEmpty()) {
+                    if (markConnectInFlightIfPossible(routePool)) {
+                        retryTimeout = routePool.pendingRequests.peek().connectTimeout;
+                        startDial = true;
+                    } else if (routeHasRoom(routePool) && totalConnectionCount.get() >= maxTotal) {
+                        enqueueGloballyBlockedRoute(endpoint, routePool);
+                    }
+                }
+            }
+            pruneRoutePoolIfUnused(endpoint, routePool);
+        } finally {
+            routePool.lock.unlock();
+        }
+
+        fireCompletions(completions);
+
+        if (failed != null) {
+            for (final PendingLease pending : failed) {
+                pending.future.failed(ex);
+            }
+        }
+
+        if (startDial) {
+            startConnect(endpoint, retryTimeout, routePool);
+        }
+
+        processGlobalPending();
+    }
+
+    private void registerObserver(
+            final HttpHost endpoint,
+            final RoutePool routePool,
+            final ConnectionEntry entry) {
+        if (!entry.observerRegistered.compareAndSet(false, true)) {
+            return;
+        }
+
+        entry.support.setObserver(new H2PoolSessionSupport.Observer() {
+
+            @Override
+            public void onCapacityAvailable() {
+                if (closed.get()) {
+                    return;
+                }
+                final List<Runnable> completions;
+                routePool.lock.lock();
+                try {
+                    if (entry.reserved.get() > 0) {
+                        reconcileReserved(entry);
+                    }
+                    entry.lastUsed = System.currentTimeMillis();
+                    completions = routePool.pendingRequests.isEmpty() ?
+                            Collections.emptyList() :
+                            drainPending(endpoint, routePool, true);
+                } finally {
+                    routePool.lock.unlock();
+                }
+                fireCompletions(completions);
+            }
+
+            @Override
+            public void onDraining() {
+                if (closed.get()) {
+                    return;
+                }
+
+                final List<Runnable> completions;
+                final boolean evicted;
+
+                routePool.lock.lock();
+                try {
+                    entry.draining = true;
+                    evicted = evictIfDead(routePool, entry);
+                    completions = routePool.pendingRequests.isEmpty() ?
+                            Collections.emptyList() :
+                            drainPending(endpoint, routePool, true);
+                    if (evicted) {
+                        pruneRoutePoolIfUnused(endpoint, routePool);
+                    }
+                } finally {
+                    routePool.lock.unlock();
+                }
+
+                fireCompletions(completions);
+
+                if (evicted) {
+                    processGlobalPending();
+                }
+            }
+
+            @Override
+            public void onSessionClosed() {
+                if (closed.get()) {
+                    return;
+                }
+
+                final List<Runnable> completions;
+                final boolean evicted;
+
+                routePool.lock.lock();
+                try {
+                    entry.draining = true;
+                    entry.support.setObserver(null);
+                    // Session is dead. Reservations and active streams on it
+                    // are void, so evict unconditionally. Any caller still
+                    // holding a reservation will see the entry invalidated in
+                    // finalizeLease and retry.
+                    if (routePool.entries.remove(entry)) {
+                        releaseGlobalSlot();
+                        evicted = true;
+                    } else {
+                        evicted = false;
+                    }
+                    completions = routePool.pendingRequests.isEmpty() ?
+                            Collections.emptyList() :
+                            drainPending(endpoint, routePool, true);
+                    if (evicted) {
+                        pruneRoutePoolIfUnused(endpoint, routePool);
+                    }
+                } finally {
+                    routePool.lock.unlock();
+                }
+
+                fireCompletions(completions);
+
+                if (evicted) {
+                    processGlobalPending();
+                }
+            }
+        });
+    }
+
+    /**
+     * Reconciles the entry's {@code reserved} counter against the current
+     * active-local-stream count reported by the multiplexer. Each new active
+     * stream observed since the last sample consumes one reservation, which
+     * atomically transitions a slot from reserved to active without a
+     * separate handshake from the caller. Always invoked while holding
+     * {@code routePool.lock}.
+     */
+    private static void reconcileReserved(final ConnectionEntry entry) {
+        final int currentActive = entry.support.getActiveLocalStreams();
+        final int previous = entry.lastSeenActive.getAndSet(currentActive);
+        final int delta = currentActive - previous;
+        if (delta <= 0) {
+            return;
+        }
+        for (;;) {
+            final int current = entry.reserved.get();
+            if (current <= 0) {
+                return;
+            }
+            final int consume = Math.min(current, delta);
+            if (entry.reserved.compareAndSet(current, current - consume)) {
+                return;
+            }
+        }
+    }
+
+    private boolean evictIfDead(
+            final RoutePool routePool,
+            final ConnectionEntry entry) {
+        if (closed.get()) {
+            return false;
+        }
+        if (!entry.draining) {
+            return false;
+        }
+        if (entry.reserved.get() > 0) {
+            return false;
+        }
+
+        if (entry.support.getActiveLocalStreams() > 0) {
+            return false;
+        }
+
+        if (routePool.entries.remove(entry)) {
+            entry.support.setObserver(null);
+            releaseGlobalSlot();
+            closeSession(entry.session, CloseMode.GRACEFUL);
+            return true;
+        }
+        return false;
+    }
+
+    private void closeSession(
+            final IOSession ioSession,
+            final CloseMode closeMode) {
+        if (closeMode == CloseMode.GRACEFUL) {
+            ioSession.enqueue(ShutdownCommand.GRACEFUL, Command.Priority.NORMAL);
+        } else {
+            ioSession.close(closeMode);
+        }
+    }
+
+    public void closeIdle(final TimeValue idleTime) {
+        final long deadline = System.currentTimeMillis()
+                - (TimeValue.isPositive(idleTime) ? idleTime.toMilliseconds() : 0);
+        boolean freedCapacity = false;
+
+        for (final Map.Entry<HttpHost, RoutePool> mapEntry : routePools.entrySet()) {
+            final HttpHost endpoint = mapEntry.getKey();
+            final RoutePool routePool = mapEntry.getValue();
+            routePool.lock.lock();
+            try {
+                final Iterator<ConnectionEntry> it = routePool.entries.iterator();
+                while (it.hasNext()) {
+                    final ConnectionEntry entry = it.next();
+                    if (entry.reserved.get() <= 0 && entry.lastUsed <= deadline) {
+                        if (entry.support.getActiveLocalStreams() == 0) {
+                            it.remove();
+                            entry.support.setObserver(null);
+                            releaseGlobalSlot();
+                            freedCapacity = true;
+                            closeSession(entry.session, CloseMode.GRACEFUL);
+                        }
+                    }
+                }
+                pruneRoutePoolIfUnused(endpoint, routePool);
+            } finally {
+                routePool.lock.unlock();
+            }
+        }
+
+        if (freedCapacity) {
+            processGlobalPending();
+        }
+    }
+
+    void closeExpired() {
+        boolean freedCapacity = false;
+
+        for (final Map.Entry<HttpHost, RoutePool> mapEntry : routePools.entrySet()) {
+            final HttpHost endpoint = mapEntry.getKey();
+            final RoutePool routePool = mapEntry.getValue();
+            routePool.lock.lock();
+            try {
+                final Iterator<ConnectionEntry> it = routePool.entries.iterator();
+                while (it.hasNext()) {
+                    final ConnectionEntry entry = it.next();
+                    if (entry.reserved.get() <= 0 && (entry.draining || !entry.session.isOpen())) {
+                        if (entry.support.getActiveLocalStreams() == 0) {
+                            it.remove();
+                            entry.support.setObserver(null);
+                            releaseGlobalSlot();
+                            freedCapacity = true;
+                            closeSession(entry.session, CloseMode.GRACEFUL);
+                        }
+                    }
+                }
+                pruneRoutePoolIfUnused(endpoint, routePool);
+            } finally {
+                routePool.lock.unlock();
+            }
+        }
+
+        if (freedCapacity) {
+            processGlobalPending();
+        }
+    }
+
+    @Override
+    public void close(final CloseMode closeMode) {
+        final ReentrantReadWriteLock.WriteLock writeLock = lifecycleLock.writeLock();
+        writeLock.lock();
+        try {
+            if (closed.compareAndSet(false, true)) {
+                final List<PendingLease> allCancelled = new ArrayList<>();
+                for (final Map.Entry<HttpHost, RoutePool> mapEntry : routePools.entrySet()) {
+                    final RoutePool routePool = mapEntry.getValue();
+                    routePool.lock.lock();
+                    try {
+                        for (final ConnectionEntry entry : routePool.entries) {
+                            entry.support.setObserver(null);
+                            closeSession(entry.session, closeMode);
+                        }
+                        routePool.entries.clear();
+
+                        PendingLease pending;
+                        while ((pending = routePool.pendingRequests.poll()) != null) {
+                            allCancelled.add(pending);
+                        }
+                    } finally {
+                        routePool.lock.unlock();
+                    }
+                }
+                for (final PendingLease pending : allCancelled) {
+                    pending.future.cancel();
+                }
+                globallyBlockedRoutes.clear();
+                routePools.clear();
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        close(CloseMode.GRACEFUL);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("H2MultiplexingConnPool [routes: ");
+        buf.append(routePools.size());
+        buf.append(", total connections: ");
+        buf.append(totalConnectionCount.get());
+        buf.append(", globally blocked routes: ");
+        buf.append(globallyBlockedRoutes.size());
+        buf.append("]");
+        return buf.toString();
+    }
+
+    private static void fireCompletions(final List<Runnable> completions) {
+        if (completions == null || completions.isEmpty()) {
+            return;
+        }
+        for (final Runnable runnable : completions) {
+            runnable.run();
+        }
+    }
+
+    static final class PendingLease {
+
+        final BasicFuture<H2StreamLease> future;
+        final Timeout connectTimeout;
+
+        PendingLease(
+                final BasicFuture<H2StreamLease> future,
+                final Timeout connectTimeout) {
+            this.future = future;
+            this.connectTimeout = connectTimeout;
+        }
+    }
+
+    static final class QueuedRoute {
+
+        final HttpHost endpoint;
+        final RoutePool routePool;
+
+        QueuedRoute(
+                final HttpHost endpoint,
+                final RoutePool routePool) {
+            this.endpoint = endpoint;
+            this.routePool = routePool;
+        }
+    }
+
+    static class ConnectionEntry {
+
+        final IOSession session;
+        final H2PoolSessionSupport support;
+        final AtomicInteger reserved;
+        final AtomicInteger lastSeenActive;
+        final AtomicBoolean observerRegistered;
+
+        volatile long lastUsed;
+        volatile boolean draining;
+
+        ConnectionEntry(final IOSession session, final H2PoolSessionSupport support) {
+            this.session = session;
+            this.support = support;
+            this.reserved = new AtomicInteger(0);
+            this.lastSeenActive = new AtomicInteger(support.getActiveLocalStreams());
+            this.observerRegistered = new AtomicBoolean(false);
+            this.lastUsed = System.currentTimeMillis();
+            this.draining = false;
+        }
+
+        int availableCapacity() {
+            if (draining || !session.isOpen()) {
+                return 0;
+            }
+            if (support.isGoAwayReceived() || support.isShutdown()) {
+                return 0;
+            }
+            final int peerMax = support.getPeerMaxConcurrentStreams();
+            final int active = support.getActiveLocalStreams();
+            final int res = reserved.get();
+            return Math.max(0, peerMax - active - res);
+        }
+
+        /**
+         * Whether this entry still occupies a per-route slot that must block
+         * the pool from opening a replacement connection. A draining, closed,
+         * {@code GOAWAY}-received or shut-down entry can serve no new leases
+         * and therefore must not count.
+         */
+        boolean countsTowardRouteLimit() {
+            if (draining || !session.isOpen()) {
+                return false;
+            }
+            if (support.isGoAwayReceived() || support.isShutdown()) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    static class RoutePool {
+
+        final List<ConnectionEntry> entries;
+        final Deque<PendingLease> pendingRequests;
+        final ReentrantLock lock;
+
+        boolean connectInFlight;
+        boolean globallyQueued;
+
+        RoutePool() {
+            this.entries = new ArrayList<>();
+            this.pendingRequests = new ArrayDeque<>();
+            this.lock = new ReentrantLock();
+            this.connectInFlight = false;
+            this.globallyQueued = false;
+        }
+
+        ConnectionEntry reserveAvailable() {
+            ConnectionEntry best = null;
+            int bestCapacity = 0;
+            for (final ConnectionEntry entry : entries) {
+                final int capacity = entry.availableCapacity();
+                if (capacity > bestCapacity) {
+                    best = entry;
+                    bestCapacity = capacity;
+                }
+            }
+            if (best != null) {
+                best.reserved.incrementAndGet();
+                best.lastUsed = System.currentTimeMillis();
+                return best;
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public Future<H2StreamLease> leaseSession(
+            final HttpHost endpoint,
+            final Timeout connectTimeout,
+            final FutureCallback<H2StreamLease> callback) {
+        return lease(endpoint, connectTimeout, callback);
+    }
+
+}

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2PoolPolicy.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2PoolPolicy.java
@@ -24,40 +24,34 @@
  * <http://www.apache.org/>.
  *
  */
+package org.apache.hc.core5.http2.nio.pool;
 
-package org.apache.hc.core5.http2.impl.nio;
-
-import org.apache.hc.core5.net.InetAddressUtils;
+import org.apache.hc.core5.annotation.Experimental;
 
 /**
- * {@link org.apache.hc.core5.reactor.IOEventHandler} that implements
- * client side HTTP/2 messaging protocol with full support for
- * multiplexed message transmission.
+ * Enumeration of HTTP/2 connection pool policies.
  *
- * @since 5.0
+ * @since 5.5
  */
-public class ClientH2IOEventHandler extends AbstractH2IOEventHandler {
+@Experimental
+public enum H2PoolPolicy {
 
-    public ClientH2IOEventHandler(final ClientH2StreamMultiplexer streamMultiplexer) {
-        super(streamMultiplexer);
-    }
+    /**
+     * Simple session pool with one logical session per endpoint.
+     * Multiplexing is handled entirely by the HTTP/2 multiplexer;
+     * the pool itself has no awareness of individual streams or
+     * peer {@code MAX_CONCURRENT_STREAMS} limits. This is the
+     * default policy.
+     */
+    BASIC,
 
-    ClientH2IOEventHandler(
-            final ClientH2StreamMultiplexer streamMultiplexer,
-            final H2PoolSessionSupport sessionSupport) {
-        super(streamMultiplexer, sessionSupport);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        InetAddressUtils.formatAddress(buf, getLocalAddress());
-        buf.append("->");
-        InetAddressUtils.formatAddress(buf, getRemoteAddress());
-        buf.append(" [");
-        streamMultiplexer.appendState(buf);
-        buf.append("]");
-        return buf.toString();
-    }
+    /**
+     * Stream-capacity-aware pool that manages multiple connections
+     * per endpoint. The pool tracks active and reserved streams,
+     * honours the peer's {@code MAX_CONCURRENT_STREAMS}, opens
+     * additional connections when existing ones are saturated,
+     * and drains connections gracefully on {@code GOAWAY}.
+     */
+    MULTIPLEXING
 
 }

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2RequesterConnPool.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2RequesterConnPool.java
@@ -1,0 +1,79 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.nio.pool;
+
+import java.net.InetSocketAddress;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.function.Resolver;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.io.ModalCloseable;
+import org.apache.hc.core5.reactor.ConnectionInitiator;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * Common abstraction for HTTP/2 connection pools that hand out
+ * {@link H2StreamLease} reservations to the requester layer.
+ *
+ * @since 5.5
+ */
+@Internal
+public interface H2RequesterConnPool extends ModalCloseable {
+
+    Future<H2StreamLease> leaseSession(HttpHost endpoint, Timeout connectTimeout, FutureCallback<H2StreamLease> callback);
+
+    void closeIdle(TimeValue idleTime);
+
+    Set<HttpHost> getRoutes();
+
+    void setValidateAfterInactivity(TimeValue timeValue);
+
+    static H2RequesterConnPool create(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy,
+            final H2PoolPolicy poolPolicy,
+            final int defaultMaxPerRoute,
+            final int maxTotal,
+            final TimeValue validateAfterInactivity) {
+        if (poolPolicy == H2PoolPolicy.MULTIPLEXING) {
+            return new H2MultiplexingConnPool(
+                    connectionInitiator,
+                    addressResolver,
+                    tlsStrategy,
+                    defaultMaxPerRoute,
+                    maxTotal,
+                    validateAfterInactivity);
+        }
+        return new H2ConnPool(connectionInitiator, addressResolver, tlsStrategy, validateAfterInactivity);
+    }
+}

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2StreamLease.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/nio/pool/H2StreamLease.java
@@ -1,0 +1,85 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.nio.pool;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.Args;
+
+/**
+ * Reservation handle returned by {@link H2RequesterConnPool#leaseSession}.
+ * Holds the leased {@link IOSession} together with a release action that the
+ * requester must invoke exactly once when the corresponding stream slot is no
+ * longer needed.
+ *
+ * @since 5.5
+ */
+@Internal
+public final class H2StreamLease {
+
+    private final IOSession session;
+    private final Runnable releaseAction;
+    private final AtomicBoolean released;
+
+    H2StreamLease(final IOSession session, final Runnable releaseAction) {
+        this.session = Args.notNull(session, "IO session");
+        this.releaseAction = Args.notNull(releaseAction, "Release action");
+        this.released = new AtomicBoolean(false);
+    }
+
+    public IOSession getSession() {
+        return session;
+    }
+
+    public void releaseReservation() {
+        if (released.compareAndSet(false, true)) {
+            releaseAction.run();
+        }
+    }
+
+    /**
+     * Returns {@code true} once {@link #releaseReservation()} has been invoked
+     * on this lease. Intended for diagnostics and for verifying lifecycle
+     * invariants in tests.
+     *
+     * @since 5.5
+     */
+    public boolean isReleased() {
+        return released.get();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("[session: ").append(session.getId());
+        buf.append(", released: ").append(released.get());
+        buf.append("]");
+        return buf.toString();
+    }
+}

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2MultiplexingPoolExample.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/examples/H2MultiplexingPoolExample.java
@@ -1,0 +1,182 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.examples;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.apache.hc.core5.function.Supplier;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Message;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.impl.bootstrap.HttpAsyncServer;
+import org.apache.hc.core5.http.impl.routing.RequestRouter;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.nio.AsyncServerExchangeHandler;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityProducer;
+import org.apache.hc.core5.http.nio.support.AsyncServerPipeline;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
+import org.apache.hc.core5.http.nio.support.BasicResponseConsumer;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2MultiplexingRequester;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2MultiplexingRequesterBootstrap;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2ServerBootstrap;
+import org.apache.hc.core5.http2.nio.pool.H2PoolPolicy;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.reactor.IOReactorConfig;
+import org.apache.hc.core5.reactor.ListenerEndpoint;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * Self-contained example of HTTP/2 request execution using the
+ * stream-capacity-aware multiplexing pool. Starts an embedded H2
+ * server with {@code MAX_CONCURRENT_STREAMS = 10}, then fires 50
+ * concurrent requests through a single requester configured with
+ * {@link H2PoolPolicy#MULTIPLEXING}. The pool tracks the peer's
+ * stream limit and opens additional connections when existing ones
+ * are saturated.
+ */
+public class H2MultiplexingPoolExample {
+
+    public static void main(final String[] args) throws Exception {
+
+        final Timeout timeout = Timeout.ofSeconds(30);
+        final int totalRequests = 50;
+
+
+        final H2Config serverH2Config = H2Config.custom()
+                .setPushEnabled(false)
+                .setMaxConcurrentStreams(10)
+                .build();
+
+        final HttpAsyncServer server = H2ServerBootstrap.bootstrap()
+                .setIOReactorConfig(IOReactorConfig.custom()
+                        .setSoTimeout(timeout)
+                        .build())
+                .setH2Config(serverH2Config)
+                .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_2)
+                .setRequestRouter(RequestRouter.<Supplier<AsyncServerExchangeHandler>>builder()
+                        .addRoute(RequestRouter.LOCAL_AUTHORITY, "*",
+                                AsyncServerPipeline.assemble()
+                                        .request()
+                                        .consumeContent(ct -> StringAsyncEntityConsumer::new)
+                                        .response()
+                                        .asString(ContentType.TEXT_PLAIN)
+                                        .handle((request, context) -> {
+                                            final String body = request.body() != null
+                                                    ? request.body() : "";
+                                            return Message.of(
+                                                    new BasicHttpResponse(HttpStatus.SC_OK),
+                                                    "echo: " + body);
+                                        })
+                                        .supplier())
+                        .resolveAuthority(RequestRouter.LOCAL_AUTHORITY_RESOLVER)
+                        .build())
+                .create();
+
+        server.start();
+        final Future<ListenerEndpoint> listenerFuture = server.listen(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
+                URIScheme.HTTP);
+        final ListenerEndpoint listener = listenerFuture.get();
+        final InetSocketAddress address = (InetSocketAddress) listener.getAddress();
+        final HttpHost target = new HttpHost(
+                URIScheme.HTTP.id, "localhost", address.getPort());
+
+        System.out.println("Server listening on " + address);
+
+
+        final H2MultiplexingRequester requester =
+                H2MultiplexingRequesterBootstrap.bootstrap()
+                        .setIOReactorConfig(IOReactorConfig.custom()
+                                .setSoTimeout(timeout)
+                                .build())
+                        .setH2Config(H2Config.custom()
+                                .setPushEnabled(false)
+                                .build())
+                        .setH2PoolPolicy(H2PoolPolicy.MULTIPLEXING)
+                        .create();
+        requester.start();
+
+        // ------ fire requests ------
+
+        final List<Future<Message<HttpResponse, String>>> futures =
+                new ArrayList<>(totalRequests);
+        for (int i = 0; i < totalRequests; i++) {
+            futures.add(requester.execute(
+                    new BasicRequestProducer("POST", target, "/echo",
+                            new StringAsyncEntityProducer(
+                                    "msg-" + i, ContentType.TEXT_PLAIN)),
+                    new BasicResponseConsumer<>(
+                            new StringAsyncEntityConsumer()),
+                    timeout, null));
+        }
+
+        System.out.println("Fired " + totalRequests + " concurrent requests");
+
+
+        int ok = 0;
+        int fail = 0;
+        for (int i = 0; i < totalRequests; i++) {
+            try {
+                final Message<HttpResponse, String> result =
+                        futures.get(i).get(
+                                timeout.getDuration(),
+                                timeout.getTimeUnit());
+                System.out.println("[" + i + "] "
+                        + result.head().getCode() + " "
+                        + result.body());
+                ok++;
+            } catch (final Exception ex) {
+                System.err.println("[" + i + "] " + ex);
+                fail++;
+            }
+        }
+
+        System.out.println();
+        System.out.println("Done: " + ok + " ok, " + fail + " failed");
+
+
+        requester.initiateShutdown();
+        requester.awaitShutdown(TimeValue.ofSeconds(5));
+        requester.close(CloseMode.IMMEDIATE);
+
+        server.initiateShutdown();
+        server.awaitShutdown(TimeValue.ofSeconds(5));
+        server.close(CloseMode.IMMEDIATE);
+    }
+
+}

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/bootstrap/TestH2MultiplexingRequesterLease.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/impl/nio/bootstrap/TestH2MultiplexingRequesterLease.java
@@ -1,0 +1,311 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.impl.nio.bootstrap;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hc.core5.concurrent.Cancellable;
+import org.apache.hc.core5.concurrent.CancellableDependency;
+import org.apache.hc.core5.http.ConnectionClosedException;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.StreamControl;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.nio.AsyncClientExchangeHandler;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.http.nio.RequestChannel;
+import org.apache.hc.core5.http.nio.command.RequestExecutionCommand;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
+import org.apache.hc.core5.http2.nio.pool.H2StreamLease;
+import org.apache.hc.core5.http2.nio.pool.H2StreamLeaseTestFactory;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.IOEventHandlerFactory;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.TimeValue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for the requester-side lease lifecycle. These tests exercise
+ * {@link H2MultiplexingRequester#dispatchLease} directly so that every
+ * terminal path that returns a stream reservation to the pool can be covered
+ * without spinning up a real I/O reactor.
+ */
+class TestH2MultiplexingRequesterLease {
+
+    private static H2MultiplexingRequester newRequester(final int maxCommandsPerConnection) {
+        final IOEventHandlerFactory factory = Mockito.mock(IOEventHandlerFactory.class);
+        return new H2MultiplexingRequester(
+                null, factory, null, null, null, null, null, null, null,
+                new AtomicReference<>(TimeValue.NEG_ONE_MILLISECOND),
+                maxCommandsPerConnection);
+    }
+
+    private static IOSession openSession() {
+        final IOSession session = Mockito.mock(IOSession.class);
+        Mockito.when(session.isOpen()).thenReturn(true);
+        return session;
+    }
+
+    private static H2StreamLease leaseFor(final IOSession session, final AtomicInteger releaseCounter) {
+        return H2StreamLeaseTestFactory.newLease(session, releaseCounter::incrementAndGet);
+    }
+
+    private static RequestExecutionCommand capturedCommand(final IOSession session) {
+        final ArgumentCaptor<Command> captor = ArgumentCaptor.forClass(Command.class);
+        Mockito.verify(session).enqueue(captor.capture(), Mockito.eq(Command.Priority.NORMAL));
+        return (RequestExecutionCommand) captor.getValue();
+    }
+
+    private static final class TrackingDependency implements CancellableDependency {
+
+        private final AtomicReference<Cancellable> dependency = new AtomicReference<>();
+
+        @Override
+        public void setDependency(final Cancellable cancellable) {
+            dependency.set(cancellable);
+        }
+
+        @Override
+        public boolean cancel() {
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        Cancellable getDependency() {
+            return dependency.get();
+        }
+    }
+
+    private static final class TrackingExchangeHandler implements AsyncClientExchangeHandler {
+
+        private final AtomicReference<Exception> failedWith = new AtomicReference<>();
+        private final AtomicInteger releaseCount = new AtomicInteger();
+
+        @Override
+        public void produceRequest(final RequestChannel channel, final HttpContext context) {
+        }
+
+        @Override
+        public int available() {
+            return 0;
+        }
+
+        @Override
+        public void produce(final DataStreamChannel channel) {
+        }
+
+        @Override
+        public void consumeInformation(final HttpResponse response, final HttpContext context) {
+        }
+
+        @Override
+        public void consumeResponse(final HttpResponse response, final EntityDetails entityDetails,
+                                    final HttpContext context) {
+        }
+
+        @Override
+        public void updateCapacity(final CapacityChannel capacityChannel) {
+        }
+
+        @Override
+        public void consume(final ByteBuffer src) {
+        }
+
+        @Override
+        public void streamEnd(final List<? extends Header> trailers) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+
+        @Override
+        public void failed(final Exception cause) {
+            failedWith.set(cause);
+        }
+
+        @Override
+        public void releaseResources() {
+            releaseCount.incrementAndGet();
+        }
+    }
+
+    @Test
+    void testStreamControlCallbackReleasesLease() throws IOException {
+        try (H2MultiplexingRequester requester = newRequester(0)) {
+            final IOSession session = openSession();
+            final AtomicInteger released = new AtomicInteger();
+            final H2StreamLease lease = leaseFor(session, released);
+
+            final TrackingExchangeHandler handler = new TrackingExchangeHandler();
+            final TrackingDependency dependency = new TrackingDependency();
+
+            requester.dispatchLease(lease, handler, new BasicHttpRequest("GET", "/"), null, null,
+                    dependency, HttpCoreContext.create());
+
+            final RequestExecutionCommand command = capturedCommand(session);
+            Assertions.assertFalse(lease.isReleased(), "lease must not be released before stream initiation");
+            Assertions.assertEquals(0, released.get());
+
+            final StreamControl streamControl = Mockito.mock(StreamControl.class);
+            command.initiated(streamControl);
+
+            Assertions.assertTrue(lease.isReleased(), "stream-control callback must release the lease");
+            Assertions.assertEquals(1, released.get());
+            Assertions.assertSame(streamControl, dependency.getDependency());
+            Assertions.assertNull(handler.failedWith.get());
+        }
+    }
+
+    @Test
+    void testHandlerReleaseResourcesReleasesLease() throws IOException {
+        try (H2MultiplexingRequester requester = newRequester(0)) {
+            final IOSession session = openSession();
+            final AtomicInteger released = new AtomicInteger();
+            final H2StreamLease lease = leaseFor(session, released);
+
+            final TrackingExchangeHandler handler = new TrackingExchangeHandler();
+
+            requester.dispatchLease(lease, handler, new BasicHttpRequest("GET", "/"), null, null,
+                    new TrackingDependency(), HttpCoreContext.create());
+
+            // Stream is never initiated; the multiplexer drops the command and only
+            // calls releaseResources on the proxied handler. The lease must still
+            // be released so the pool slot is returned.
+            capturedCommand(session).getExchangeHandler().releaseResources();
+
+            Assertions.assertTrue(lease.isReleased(), "releaseResources must release the lease");
+            Assertions.assertEquals(1, released.get());
+            Assertions.assertEquals(1, handler.releaseCount.get());
+        }
+    }
+
+    @Test
+    void testMaxCommandsRejectionReleasesLease() throws IOException {
+        try (H2MultiplexingRequester requester = newRequester(1)) {
+            final IOSession session = openSession();
+            Mockito.when(session.getPendingCommandCount()).thenReturn(2);
+
+            final AtomicInteger released = new AtomicInteger();
+            final H2StreamLease lease = leaseFor(session, released);
+
+            final TrackingExchangeHandler handler = new TrackingExchangeHandler();
+            requester.dispatchLease(lease, handler, new BasicHttpRequest("GET", "/"), null, null,
+                    new TrackingDependency(), HttpCoreContext.create());
+
+            Assertions.assertTrue(lease.isReleased(), "rejection path must release the lease");
+            Assertions.assertEquals(1, released.get());
+            Assertions.assertEquals(1, handler.releaseCount.get());
+            Assertions.assertTrue(handler.failedWith.get() instanceof RejectedExecutionException);
+            Mockito.verify(session, Mockito.never()).enqueue(Mockito.any(Command.class), Mockito.any(Command.Priority.class));
+        }
+    }
+
+    @Test
+    void testEnqueueRuntimeExceptionReleasesLease() throws IOException {
+        try (H2MultiplexingRequester requester = newRequester(0)) {
+            final IOSession session = openSession();
+            final RuntimeException boom = new IllegalStateException("enqueue rejected");
+            Mockito.doThrow(boom).when(session).enqueue(Mockito.any(Command.class), Mockito.any(Command.Priority.class));
+
+            final AtomicInteger released = new AtomicInteger();
+            final H2StreamLease lease = leaseFor(session, released);
+
+            final TrackingExchangeHandler handler = new TrackingExchangeHandler();
+            requester.dispatchLease(lease, handler, new BasicHttpRequest("GET", "/"), null, null,
+                    new TrackingDependency(), HttpCoreContext.create());
+
+            Assertions.assertTrue(lease.isReleased(), "enqueue failure must release the lease");
+            Assertions.assertEquals(1, released.get());
+            Assertions.assertSame(boom, handler.failedWith.get());
+            Assertions.assertEquals(1, handler.releaseCount.get());
+        }
+    }
+
+    @Test
+    void testSessionClosedAfterEnqueueReleasesLease() throws IOException {
+        try (H2MultiplexingRequester requester = newRequester(0)) {
+            final IOSession session = Mockito.mock(IOSession.class);
+            final AtomicBoolean open = new AtomicBoolean(true);
+            Mockito.when(session.isOpen()).thenAnswer(invocation -> open.get());
+            Mockito.doAnswer(invocation -> {
+                open.set(false);
+                return null;
+            }).when(session).enqueue(Mockito.any(Command.class), Mockito.any(Command.Priority.class));
+
+            final AtomicInteger released = new AtomicInteger();
+            final H2StreamLease lease = leaseFor(session, released);
+
+            final TrackingExchangeHandler handler = new TrackingExchangeHandler();
+            requester.dispatchLease(lease, handler, new BasicHttpRequest("GET", "/"), null, null,
+                    new TrackingDependency(), HttpCoreContext.create());
+
+            Assertions.assertTrue(lease.isReleased(), "post-enqueue close must release the lease");
+            Assertions.assertEquals(1, released.get());
+            Assertions.assertTrue(handler.failedWith.get() instanceof ConnectionClosedException);
+        }
+    }
+
+    @Test
+    void testHandlerProxyForwardsProduceRequest() throws HttpException, IOException {
+        try (H2MultiplexingRequester requester = newRequester(0)) {
+            final IOSession session = openSession();
+            final H2StreamLease lease = H2StreamLeaseTestFactory.newLease(session, () -> {
+            });
+
+            final BasicHttpRequest request = new BasicHttpRequest("GET", "/");
+            final EntityDetails entityDetails = Mockito.mock(EntityDetails.class);
+            final TrackingExchangeHandler handler = new TrackingExchangeHandler();
+
+            requester.dispatchLease(lease, handler, request, entityDetails, null,
+                    new TrackingDependency(), HttpCoreContext.create());
+
+            final RequestChannel channel = Mockito.mock(RequestChannel.class);
+            final HttpContext context = HttpCoreContext.create();
+            capturedCommand(session).getExchangeHandler().produceRequest(channel, context);
+
+            Mockito.verify(channel).sendRequest(Mockito.same(request), Mockito.same(entityDetails), Mockito.same(context));
+        }
+    }
+}

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/H2StreamLeaseTestFactory.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/H2StreamLeaseTestFactory.java
@@ -24,40 +24,22 @@
  * <http://www.apache.org/>.
  *
  */
+package org.apache.hc.core5.http2.nio.pool;
 
-package org.apache.hc.core5.http2.impl.nio;
-
-import org.apache.hc.core5.net.InetAddressUtils;
+import org.apache.hc.core5.reactor.IOSession;
 
 /**
- * {@link org.apache.hc.core5.reactor.IOEventHandler} that implements
- * client side HTTP/2 messaging protocol with full support for
- * multiplexed message transmission.
- *
- * @since 5.0
+ * Test-only factory that exposes the package-private {@link H2StreamLease}
+ * constructor to tests living outside the {@code nio.pool} package, without
+ * widening production visibility or resorting to reflection.
  */
-public class ClientH2IOEventHandler extends AbstractH2IOEventHandler {
+public final class H2StreamLeaseTestFactory {
 
-    public ClientH2IOEventHandler(final ClientH2StreamMultiplexer streamMultiplexer) {
-        super(streamMultiplexer);
+    private H2StreamLeaseTestFactory() {
     }
 
-    ClientH2IOEventHandler(
-            final ClientH2StreamMultiplexer streamMultiplexer,
-            final H2PoolSessionSupport sessionSupport) {
-        super(streamMultiplexer, sessionSupport);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        InetAddressUtils.formatAddress(buf, getLocalAddress());
-        buf.append("->");
-        InetAddressUtils.formatAddress(buf, getRemoteAddress());
-        buf.append(" [");
-        streamMultiplexer.appendState(buf);
-        buf.append("]");
-        return buf.toString();
+    public static H2StreamLease newLease(final IOSession session, final Runnable releaseAction) {
+        return new H2StreamLease(session, releaseAction);
     }
 
 }

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/TestH2ConnPool.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/TestH2ConnPool.java
@@ -93,8 +93,7 @@ class TestH2ConnPool {
     @Test
     void testValidateSessionEnqueuesStaleCheck() {
         final ConnectionInitiator connectionInitiator = Mockito.mock(ConnectionInitiator.class);
-        try (H2ConnPool pool = new H2ConnPool(connectionInitiator, null, null)) {
-            pool.setValidateAfterInactivity(TimeValue.ZERO_MILLISECONDS);
+        try (H2ConnPool pool = new H2ConnPool(connectionInitiator, null, null, TimeValue.ZERO_MILLISECONDS)) {
 
             final IOSession session = Mockito.mock(IOSession.class);
             Mockito.when(session.isOpen()).thenReturn(true);

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/TestH2MultiplexingConnPool.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/TestH2MultiplexingConnPool.java
@@ -1,0 +1,825 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.nio.pool;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.nio.command.StaleCheckCommand;
+import org.apache.hc.core5.http2.impl.nio.H2PoolSessionSupport;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.ConnectionInitiator;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TestH2MultiplexingConnPool {
+
+    private static final HttpHost HOST_A = new HttpHost(URIScheme.HTTP.id, "host-a.example.com", 80);
+    private static final HttpHost HOST_B = new HttpHost(URIScheme.HTTP.id, "host-b.example.com", 80);
+    private static final Timeout CONNECT_TIMEOUT = Timeout.ofSeconds(5);
+
+    static class MockSessionState {
+
+        final AtomicInteger peerMaxStreams;
+        final AtomicInteger activeLocalStreams;
+        final AtomicBoolean goAwayReceived;
+        final AtomicBoolean shutdown;
+        volatile H2PoolSessionSupport support;
+
+        MockSessionState(final int peerMaxStreams) {
+            this.peerMaxStreams = new AtomicInteger(peerMaxStreams);
+            this.activeLocalStreams = new AtomicInteger(0);
+            this.goAwayReceived = new AtomicBoolean(false);
+            this.shutdown = new AtomicBoolean(false);
+        }
+
+        void bind(final H2PoolSessionSupport support) {
+            support.updatePeerMaxConcurrentStreams(peerMaxStreams.get());
+            support.updateActiveLocalStreams(activeLocalStreams.get());
+            support.updateGoAwayReceived(goAwayReceived.get());
+            support.updateShutdown(shutdown.get());
+            this.support = support;
+        }
+
+        void syncToSupport() {
+            if (support != null) {
+                support.updatePeerMaxConcurrentStreams(peerMaxStreams.get());
+                support.updateActiveLocalStreams(activeLocalStreams.get());
+                support.updateGoAwayReceived(goAwayReceived.get());
+                support.updateShutdown(shutdown.get());
+            }
+        }
+    }
+
+    private IOSession createMockSession() {
+        final IOSession session = Mockito.mock(IOSession.class);
+        Mockito.when(session.isOpen()).thenReturn(true);
+        Mockito.when(session.getLastReadTime()).thenReturn(System.currentTimeMillis());
+        Mockito.when(session.getLastWriteTime()).thenReturn(System.currentTimeMillis());
+        return session;
+    }
+
+    private void setupDeferredConnect(
+            final ConnectionInitiator initiator,
+            final HttpHost host,
+            final AtomicReference<FutureCallback<IOSession>> callbackRef,
+            final AtomicReference<H2PoolSessionSupport> supportRef) {
+        Mockito.when(initiator.connect(
+                        Mockito.eq(host),
+                        Mockito.any(InetSocketAddress.class),
+                        Mockito.isNull(),
+                        Mockito.any(Timeout.class),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenAnswer(invocation -> {
+                    if (supportRef != null) {
+                        supportRef.set(invocation.getArgument(4));
+                    }
+                    final FutureCallback<IOSession> cb = invocation.getArgument(5);
+                    callbackRef.set(cb);
+                    return new CompletableFuture<>();
+                });
+    }
+
+    private void setupDeferredConnect(
+            final ConnectionInitiator initiator,
+            final HttpHost host,
+            final AtomicReference<FutureCallback<IOSession>> callbackRef) {
+        setupDeferredConnect(initiator, host, callbackRef, null);
+    }
+
+    private void setupImmediateConnect(
+            final ConnectionInitiator initiator,
+            final HttpHost host,
+            final IOSession session,
+            final MockSessionState state) {
+        Mockito.when(initiator.connect(
+                        Mockito.eq(host),
+                        Mockito.any(InetSocketAddress.class),
+                        Mockito.isNull(),
+                        Mockito.any(Timeout.class),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenAnswer(invocation -> {
+                    final H2PoolSessionSupport support = invocation.getArgument(4);
+                    state.bind(support);
+                    final FutureCallback<IOSession> cb = invocation.getArgument(5);
+                    cb.completed(session);
+                    return CompletableFuture.completedFuture(session);
+                });
+    }
+
+    @Test
+    void testBasicLeaseAndRelease() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, session, state);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final Future<H2StreamLease> future = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertTrue(future.isDone());
+
+        final H2StreamLease lease = future.get();
+        Assertions.assertSame(session, lease.getSession());
+
+        lease.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testMultipleStreamsOnOneConnection() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, session, state);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        final H2StreamLease lease2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        final H2StreamLease lease3 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+
+        Assertions.assertSame(session, lease1.getSession());
+        Assertions.assertSame(session, lease2.getSession());
+        Assertions.assertSame(session, lease3.getSession());
+
+        Mockito.verify(initiator, Mockito.times(1)).connect(
+                Mockito.eq(HOST_A),
+                Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any());
+
+        lease1.releaseReservation();
+        lease2.releaseReservation();
+        lease3.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testSingleFlightDialing() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicReference<FutureCallback<IOSession>> connectCb = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRef = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb, supportRef);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 3, 0);
+
+        final Future<H2StreamLease> f1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f1.isDone());
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+
+        Mockito.verify(initiator, Mockito.times(1)).connect(
+                Mockito.eq(HOST_A),
+                Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any());
+
+        final MockSessionState state = new MockSessionState(100);
+        state.bind(supportRef.get());
+        final IOSession session = createMockSession();
+        connectCb.get().completed(session);
+
+        Assertions.assertTrue(f1.isDone());
+        Assertions.assertTrue(f2.isDone());
+        Assertions.assertSame(session, f1.get().getSession());
+        Assertions.assertSame(session, f2.get().getSession());
+
+        f1.get().releaseReservation();
+        f2.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testGlobalLimitBlocksAndCrossRouteWakeup() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+
+        final AtomicReference<FutureCallback<IOSession>> connectCbA = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRefA = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCbA, supportRefA);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 1, 1);
+
+        final Future<H2StreamLease> fA = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+
+        final MockSessionState stateA = new MockSessionState(100);
+        stateA.bind(supportRefA.get());
+        final IOSession sessionA = createMockSession();
+        connectCbA.get().completed(sessionA);
+        Assertions.assertTrue(fA.isDone());
+
+        final AtomicReference<FutureCallback<IOSession>> connectCbB = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRefB = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_B, connectCbB, supportRefB);
+
+        final Future<H2StreamLease> fB = pool.lease(HOST_B, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(fB.isDone());
+
+        fA.get().releaseReservation();
+
+        Mockito.when(sessionA.isOpen()).thenReturn(false);
+        pool.closeExpired();
+
+        Assertions.assertNotNull(connectCbB.get());
+
+        final IOSession sessionB = createMockSession();
+        final MockSessionState stateB = new MockSessionState(100);
+        stateB.bind(supportRefB.get());
+        connectCbB.get().completed(sessionB);
+
+        Assertions.assertTrue(fB.isDone());
+        Assertions.assertSame(sessionB, fB.get().getSession());
+
+        fB.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testConnectFailureFailsPendingWhenNoLiveEntries() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicReference<FutureCallback<IOSession>> connectCb = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final Future<H2StreamLease> f1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f1.isDone());
+
+        connectCb.get().failed(new java.io.IOException("Connection refused"));
+
+        Assertions.assertTrue(f1.isDone());
+        Assertions.assertThrows(ExecutionException.class, f1::get);
+
+        pool.close();
+    }
+
+    @Test
+    void testConnectFailureRetriesWhenLiveEntriesExist() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session1 = createMockSession();
+        final MockSessionState state1 = new MockSessionState(1);
+        setupImmediateConnect(initiator, HOST_A, session1, state1);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 2, 0);
+
+        final H2StreamLease l1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertSame(session1, l1.getSession());
+
+        final AtomicReference<FutureCallback<IOSession>> connectCb2 = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb2);
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+        Assertions.assertNotNull(connectCb2.get());
+
+        final AtomicReference<FutureCallback<IOSession>> connectCb3 = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRef3 = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb3, supportRef3);
+
+        connectCb2.get().failed(new java.io.IOException("Temporary failure"));
+
+        Assertions.assertFalse(f2.isDone());
+        Assertions.assertNotNull(connectCb3.get());
+
+        final IOSession session2 = createMockSession();
+        final MockSessionState state2 = new MockSessionState(100);
+        state2.bind(supportRef3.get());
+        connectCb3.get().completed(session2);
+
+        Assertions.assertTrue(f2.isDone());
+        final H2StreamLease l2 = f2.get();
+        Assertions.assertSame(session2, l2.getSession());
+
+        l1.releaseReservation();
+        l2.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testConnectFailureFreesGlobalSlotForOtherRoutes() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 1, 1);
+
+        final AtomicReference<FutureCallback<IOSession>> connectCbA = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCbA);
+
+        final Future<H2StreamLease> fA = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+
+        final AtomicReference<FutureCallback<IOSession>> connectCbB = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRefB = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_B, connectCbB, supportRefB);
+
+        final Future<H2StreamLease> fB = pool.lease(HOST_B, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(fB.isDone());
+
+        connectCbA.get().failed(new java.io.IOException("Connection refused"));
+
+        Assertions.assertTrue(fA.isDone());
+        Assertions.assertThrows(ExecutionException.class, fA::get);
+
+        Assertions.assertNotNull(connectCbB.get());
+
+        final IOSession sessionB = createMockSession();
+        final MockSessionState stateB = new MockSessionState(100);
+        stateB.bind(supportRefB.get());
+        connectCbB.get().completed(sessionB);
+
+        Assertions.assertTrue(fB.isDone());
+        Assertions.assertSame(sessionB, fB.get().getSession());
+
+        fB.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testCloseWhileConnectInFlight() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicReference<FutureCallback<IOSession>> connectCb = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final Future<H2StreamLease> f1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+
+        pool.close();
+
+        Assertions.assertTrue(f1.isDone());
+
+        final IOSession lateSession = createMockSession();
+        connectCb.get().completed(lateSession);
+
+        Mockito.verify(lateSession).close(Mockito.any(org.apache.hc.core5.io.CloseMode.class));
+    }
+
+    @Test
+    void testCloseWhileConnectInFlightFailure() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicReference<FutureCallback<IOSession>> connectCb = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        pool.close();
+
+        connectCb.get().failed(new java.io.IOException("Connection refused"));
+    }
+
+    @Test
+    void testCancelledWaitersAreSkipped() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicReference<FutureCallback<IOSession>> connectCb = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRef = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb, supportRef);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final Future<H2StreamLease> f1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        final Future<H2StreamLease> f3 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+
+        f1.cancel(false);
+        f2.cancel(false);
+
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(100);
+        state.bind(supportRef.get());
+        connectCb.get().completed(session);
+
+        Assertions.assertTrue(f3.isDone());
+        Assertions.assertSame(session, f3.get().getSession());
+
+        f3.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testObserverWakeupDrivesPendingRequests() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(1);
+        setupImmediateConnect(initiator, HOST_A, session, state);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertNotNull(lease1);
+
+        state.activeLocalStreams.set(1);
+        state.syncToSupport();
+        lease1.releaseReservation();
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+
+        state.activeLocalStreams.set(0);
+        state.syncToSupport();
+        Assertions.assertNotNull(state.support);
+        state.support.fireCapacityAvailable();
+
+        Assertions.assertTrue(f2.isDone());
+        f2.get().releaseReservation();
+
+        pool.close();
+    }
+
+    @Test
+    void testGoAwayDraining() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session1 = createMockSession();
+        final MockSessionState state1 = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, session1, state1);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 2, 0);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertSame(session1, lease1.getSession());
+        lease1.releaseReservation();
+
+        state1.goAwayReceived.set(true);
+        state1.activeLocalStreams.set(0);
+        state1.syncToSupport();
+
+        final AtomicReference<FutureCallback<IOSession>> connectCb2 = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRef2 = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb2, supportRef2);
+
+        Assertions.assertNotNull(state1.support);
+        state1.support.fireDraining();
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+        Assertions.assertNotNull(connectCb2.get());
+
+        final IOSession session2 = createMockSession();
+        final MockSessionState state2 = new MockSessionState(100);
+        state2.bind(supportRef2.get());
+        connectCb2.get().completed(session2);
+
+        Assertions.assertTrue(f2.isDone());
+        final H2StreamLease lease2 = f2.get();
+        Assertions.assertSame(session2, lease2.getSession());
+        Assertions.assertNotSame(session1, lease2.getSession());
+
+        lease2.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testPerRouteLimitRespected() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicInteger connectCount = new AtomicInteger();
+
+        Mockito.when(initiator.connect(
+                        Mockito.eq(HOST_A),
+                        Mockito.any(InetSocketAddress.class),
+                        Mockito.isNull(),
+                        Mockito.any(Timeout.class),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenAnswer(invocation -> {
+                    connectCount.incrementAndGet();
+                    final H2PoolSessionSupport support = invocation.getArgument(4);
+                    final MockSessionState state = new MockSessionState(1);
+                    state.bind(support);
+                    final FutureCallback<IOSession> cb = invocation.getArgument(5);
+                    final IOSession s = createMockSession();
+                    cb.completed(s);
+                    return CompletableFuture.completedFuture(s);
+                });
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 2, 10);
+
+        final H2StreamLease l1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        final H2StreamLease l2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+
+        Assertions.assertEquals(2, connectCount.get());
+
+        final Future<H2StreamLease> f3 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f3.isDone());
+        Assertions.assertEquals(2, connectCount.get());
+
+        l1.releaseReservation();
+        Assertions.assertTrue(f3.isDone());
+
+        final H2StreamLease l3 = f3.get();
+        Assertions.assertNotNull(l3);
+        l2.releaseReservation();
+        l3.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testLeaseRetainsReservationUntilReleasedAndStreamCloses() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(1);
+        setupImmediateConnect(initiator, HOST_A, session, state);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 1, 1);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertSame(session, lease1.getSession());
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+
+        state.activeLocalStreams.set(1);
+        state.syncToSupport();
+        lease1.releaseReservation();
+        Assertions.assertNotNull(state.support);
+        state.support.fireCapacityAvailable();
+        Assertions.assertFalse(f2.isDone());
+
+        state.activeLocalStreams.set(0);
+        state.syncToSupport();
+        state.support.fireCapacityAvailable();
+
+        Assertions.assertTrue(f2.isDone());
+        final H2StreamLease lease2 = f2.get();
+        Assertions.assertSame(session, lease2.getSession());
+
+        lease2.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testCapacityReturnedOnStreamCloseAfterLeaseRelease() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(2);
+        setupImmediateConnect(initiator, HOST_A, session, state);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 1, 1);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        final H2StreamLease lease2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        final Future<H2StreamLease> f3 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+
+        Assertions.assertFalse(f3.isDone());
+
+        state.activeLocalStreams.set(2);
+        state.syncToSupport();
+        lease1.releaseReservation();
+        lease2.releaseReservation();
+        Assertions.assertNotNull(state.support);
+        state.support.fireCapacityAvailable();
+        Assertions.assertFalse(f3.isDone());
+
+        state.activeLocalStreams.set(1);
+        state.syncToSupport();
+        state.support.fireCapacityAvailable();
+
+        Assertions.assertTrue(f3.isDone());
+        final H2StreamLease lease3 = f3.get();
+        Assertions.assertSame(session, lease3.getSession());
+
+        lease3.releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testReplacementDialUnblockedByDrainingEntryAtPerRouteLimitOne() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session1 = createMockSession();
+        final MockSessionState state1 = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, session1, state1);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 1, 10);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertSame(session1, lease1.getSession());
+        lease1.releaseReservation();
+
+        state1.goAwayReceived.set(true);
+        state1.activeLocalStreams.set(1);
+        state1.syncToSupport();
+
+        final AtomicReference<FutureCallback<IOSession>> connectCb2 = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRef2 = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb2, supportRef2);
+
+        Assertions.assertNotNull(state1.support);
+        state1.support.fireDraining();
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+        Assertions.assertNotNull(connectCb2.get(),
+                "Replacement dial must start immediately despite the draining entry at per-route limit 1");
+
+        final IOSession session2 = createMockSession();
+        final MockSessionState state2 = new MockSessionState(100);
+        state2.bind(supportRef2.get());
+        connectCb2.get().completed(session2);
+
+        Assertions.assertTrue(f2.isDone());
+        Assertions.assertNotSame(session1, f2.get().getSession());
+        Assertions.assertSame(session2, f2.get().getSession());
+
+        f2.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testDisconnectFreesGlobalSlotWithoutMaintenance() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession sessionA = createMockSession();
+        final MockSessionState stateA = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, sessionA, stateA);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 1, 1);
+
+        final H2StreamLease leaseA = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertSame(sessionA, leaseA.getSession());
+
+        final AtomicReference<FutureCallback<IOSession>> connectCbB = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRefB = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_B, connectCbB, supportRefB);
+
+        final Future<H2StreamLease> fB = pool.lease(HOST_B, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(fB.isDone());
+        Assertions.assertNull(connectCbB.get(),
+                "Route B dial must remain blocked while route A holds the only global slot");
+
+        leaseA.releaseReservation();
+        Mockito.when(sessionA.isOpen()).thenReturn(false);
+        Assertions.assertNotNull(stateA.support);
+        stateA.support.fireSessionClosed();
+
+        Assertions.assertNotNull(connectCbB.get(),
+                "Route B dial must start after session A disconnects, without closeExpired()");
+
+        final IOSession sessionB = createMockSession();
+        final MockSessionState stateB = new MockSessionState(100);
+        stateB.bind(supportRefB.get());
+        connectCbB.get().completed(sessionB);
+
+        Assertions.assertTrue(fB.isDone());
+        Assertions.assertSame(sessionB, fB.get().getSession());
+
+        fB.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testInvalidatedReservedEntryRetriesInsteadOfFailing() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session1 = createMockSession();
+        final MockSessionState state1 = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, session1, state1);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(
+                initiator, null, null, 2, 10);
+
+        final H2StreamLease lease1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        lease1.releaseReservation();
+
+        pool.setValidateAfterInactivity(TimeValue.ofMilliseconds(100));
+
+        Mockito.when(session1.getLastReadTime()).thenReturn(System.currentTimeMillis() - 10_000);
+        Mockito.when(session1.getLastWriteTime()).thenReturn(System.currentTimeMillis() - 10_000);
+
+        final AtomicReference<Consumer<Boolean>> staleCallback = new AtomicReference<>();
+        Mockito.doAnswer(invocation -> {
+            final Object cmd = invocation.getArgument(0);
+            if (cmd instanceof StaleCheckCommand) {
+                staleCallback.set(((StaleCheckCommand) cmd).getCallback());
+            }
+            return null;
+        }).when(session1).enqueue(Mockito.any(Command.class), Mockito.any(Command.Priority.class));
+
+        final AtomicReference<FutureCallback<IOSession>> connectCb2 = new AtomicReference<>();
+        final AtomicReference<H2PoolSessionSupport> supportRef2 = new AtomicReference<>();
+        setupDeferredConnect(initiator, HOST_A, connectCb2, supportRef2);
+
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        Assertions.assertFalse(f2.isDone());
+        Assertions.assertNotNull(staleCallback.get(),
+                "StaleCheckCommand must be issued before finalizeLease");
+
+        state1.goAwayReceived.set(true);
+        state1.syncToSupport();
+        Assertions.assertNotNull(state1.support);
+        state1.support.fireDraining();
+
+        staleCallback.get().accept(Boolean.TRUE);
+
+        Assertions.assertFalse(f2.isDone(),
+                "Invalidated reserved entry must not fail the future; pool must retry");
+        Assertions.assertNotNull(connectCb2.get(),
+                "Retry must trigger a replacement dial");
+
+        final IOSession session2 = createMockSession();
+        final MockSessionState state2 = new MockSessionState(100);
+        state2.bind(supportRef2.get());
+        connectCb2.get().completed(session2);
+
+        Assertions.assertTrue(f2.isDone());
+        Assertions.assertSame(session2, f2.get().getSession());
+
+        f2.get().releaseReservation();
+        pool.close();
+    }
+
+    @Test
+    void testEmptyRoutePoolIsPruned() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final IOSession session = createMockSession();
+        final MockSessionState state = new MockSessionState(100);
+        setupImmediateConnect(initiator, HOST_A, session, state);
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null);
+
+        final H2StreamLease lease = pool.lease(HOST_A, CONNECT_TIMEOUT, null).get();
+        Assertions.assertTrue(pool.getRoutes().contains(HOST_A));
+
+        lease.releaseReservation();
+        Mockito.when(session.isOpen()).thenReturn(false);
+        pool.closeExpired();
+
+        Assertions.assertFalse(pool.getRoutes().contains(HOST_A),
+                "Empty route pool must be pruned from getRoutes()");
+
+        pool.close();
+    }
+
+    @Test
+    void testRouteLimitOpensExtraConnectionsWhenLeasesSaturateExistingConnections() throws Exception {
+        final ConnectionInitiator initiator = Mockito.mock(ConnectionInitiator.class);
+        final AtomicInteger connectCount = new AtomicInteger();
+
+        Mockito.when(initiator.connect(
+                        Mockito.eq(HOST_A),
+                        Mockito.any(InetSocketAddress.class),
+                        Mockito.isNull(),
+                        Mockito.any(Timeout.class),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenAnswer(invocation -> {
+                    connectCount.incrementAndGet();
+                    final H2PoolSessionSupport support = invocation.getArgument(4);
+                    final MockSessionState state = new MockSessionState(1);
+                    state.bind(support);
+                    final FutureCallback<IOSession> cb = invocation.getArgument(5);
+                    final IOSession s = createMockSession();
+                    cb.completed(s);
+                    return CompletableFuture.completedFuture(s);
+                });
+
+        final H2MultiplexingConnPool pool = new H2MultiplexingConnPool(initiator, null, null, 2, 10);
+
+        final Future<H2StreamLease> f1 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        final Future<H2StreamLease> f2 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+        final Future<H2StreamLease> f3 = pool.lease(HOST_A, CONNECT_TIMEOUT, null);
+
+        Assertions.assertTrue(f1.isDone());
+        Assertions.assertTrue(f2.isDone());
+        Assertions.assertFalse(f3.isDone());
+        Assertions.assertEquals(2, connectCount.get());
+        Assertions.assertNotSame(f1.get().getSession(), f2.get().getSession());
+
+        f1.get().releaseReservation();
+        f2.get().releaseReservation();
+        pool.close();
+    }
+
+}

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/TestH2StreamLease.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/nio/pool/TestH2StreamLease.java
@@ -1,0 +1,95 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.http2.nio.pool;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.hc.core5.reactor.IOSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TestH2StreamLease {
+
+    @Test
+    void testReleaseInvokesAction() {
+        final IOSession session = Mockito.mock(IOSession.class);
+        final AtomicInteger count = new AtomicInteger();
+        final H2StreamLease lease = new H2StreamLease(session, count::incrementAndGet);
+
+        Assertions.assertFalse(lease.isReleased());
+        Assertions.assertSame(session, lease.getSession());
+
+        lease.releaseReservation();
+
+        Assertions.assertTrue(lease.isReleased());
+        Assertions.assertEquals(1, count.get());
+    }
+
+    @Test
+    void testReleaseIsIdempotent() {
+        final IOSession session = Mockito.mock(IOSession.class);
+        final AtomicInteger count = new AtomicInteger();
+        final H2StreamLease lease = new H2StreamLease(session, count::incrementAndGet);
+
+        lease.releaseReservation();
+        lease.releaseReservation();
+        lease.releaseReservation();
+
+        Assertions.assertTrue(lease.isReleased());
+        Assertions.assertEquals(1, count.get(), "release action must run at most once");
+    }
+
+    @Test
+    void testToStringReportsReleasedState() {
+        final IOSession session = Mockito.mock(IOSession.class);
+        Mockito.when(session.getId()).thenReturn("session-1");
+        final H2StreamLease lease = new H2StreamLease(session, () -> {
+        });
+
+        Assertions.assertTrue(lease.toString().contains("released: false"));
+
+        lease.releaseReservation();
+
+        Assertions.assertTrue(lease.toString().contains("released: true"));
+    }
+
+    @Test
+    void testNullSessionRejected() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new H2StreamLease(null, () -> {
+                }));
+    }
+
+    @Test
+    void testNullReleaseActionRejected() {
+        final IOSession session = Mockito.mock(IOSession.class);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new H2StreamLease(session, null));
+    }
+
+}

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/H2PoolPolicyJmh.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/benchmark/H2PoolPolicyJmh.java
@@ -1,0 +1,244 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.core5.benchmark;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.hc.core5.function.Supplier;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Message;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.impl.bootstrap.HttpAsyncServer;
+import org.apache.hc.core5.http.impl.routing.RequestRouter;
+import org.apache.hc.core5.http.nio.AsyncServerExchangeHandler;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityProducer;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
+import org.apache.hc.core5.http.nio.support.BasicResponseConsumer;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2MultiplexingRequester;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2MultiplexingRequesterBootstrap;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2ServerBootstrap;
+import org.apache.hc.core5.http2.nio.pool.H2PoolPolicy;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.reactor.IOReactorConfig;
+import org.apache.hc.core5.reactor.ListenerEndpoint;
+import org.apache.hc.core5.testing.nio.EchoHandler;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * JMH harness comparing H2 pool policies (BASIC vs MULTIPLEXING) using
+ * the real httpcore5-h2 I/O reactor and HTTP/2 protocol stack. Each
+ * iteration fires a GET request through the requester, exercises the
+ * full pool lease / stream enqueue / response read / release cycle.
+ */
+@BenchmarkMode({Mode.Throughput})
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class H2PoolPolicyJmh {
+
+    private static final Timeout TIMEOUT = Timeout.ofMinutes(2);
+
+    @State(Scope.Benchmark)
+    public static class BenchState {
+
+        @Param({"BASIC", "MULTIPLEXING"})
+        public String policy;
+
+        @Param({"1", "4", "10"})
+        public int routes;
+
+        @Param({"10","20","50","100"})
+        public int maxConcurrentStreams;
+
+        @Param({"128"})
+        public int payloadBytes;
+
+        HttpAsyncServer server;
+        H2MultiplexingRequester requester;
+        HttpHost[] targets;
+        String payload;
+
+        @Setup(Level.Trial)
+        public void setUp() throws Exception {
+            final IOReactorConfig ioConfig = IOReactorConfig.custom()
+                    .setSoTimeout(TIMEOUT)
+                    .build();
+
+            final H2Config serverH2Config = H2Config.custom()
+                    .setPushEnabled(false)
+                    .setMaxConcurrentStreams(maxConcurrentStreams)
+                    .build();
+
+            server = H2ServerBootstrap.bootstrap()
+                    .setIOReactorConfig(ioConfig)
+                    .setH2Config(serverH2Config)
+                    .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_2)
+                    .setRequestRouter(RequestRouter.<Supplier<AsyncServerExchangeHandler>>builder()
+                            .addRoute(RequestRouter.LOCAL_AUTHORITY, "*",
+                                    () -> new EchoHandler(2048))
+                            .resolveAuthority(RequestRouter.LOCAL_AUTHORITY_RESOLVER)
+                            .build())
+                    .create();
+            server.start();
+
+            final List<HttpHost> hostList = new ArrayList<>();
+            for (int i = 0; i < routes; i++) {
+                final Future<ListenerEndpoint> future = server.listen(
+                        new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
+                        URIScheme.HTTP);
+                final ListenerEndpoint endpoint = future.get();
+                final InetSocketAddress addr = (InetSocketAddress) endpoint.getAddress();
+                hostList.add(new HttpHost(URIScheme.HTTP.id, "localhost", addr.getPort()));
+            }
+            targets = hostList.toArray(new HttpHost[0]);
+
+            final H2PoolPolicy poolPolicy;
+            switch (policy.toUpperCase(Locale.ROOT)) {
+                case "MULTIPLEXING":
+                    poolPolicy = H2PoolPolicy.MULTIPLEXING;
+                    break;
+                case "BASIC":
+                default:
+                    poolPolicy = H2PoolPolicy.BASIC;
+                    break;
+            }
+
+            final H2Config clientH2Config = H2Config.custom()
+                    .setPushEnabled(false)
+                    .setMaxConcurrentStreams(maxConcurrentStreams)
+                    .build();
+
+            requester = H2MultiplexingRequesterBootstrap.bootstrap()
+                    .setIOReactorConfig(ioConfig)
+                    .setH2Config(clientH2Config)
+                    .setH2PoolPolicy(poolPolicy)
+                    .create();
+            requester.start();
+
+            final StringBuilder sb = new StringBuilder(payloadBytes);
+            for (int i = 0; i < payloadBytes; i++) {
+                sb.append('x');
+            }
+            payload = sb.toString();
+
+            // Prime each route so the H2 session and SETTINGS exchange
+            // are completed before the benchmark clock starts.
+            final Timeout primeTimeout = Timeout.ofSeconds(10);
+            for (final HttpHost t : targets) {
+                try {
+                    requester.execute(
+                            new BasicRequestProducer(Method.POST, t, "/",
+                                    new StringAsyncEntityProducer(payload, ContentType.TEXT_PLAIN)),
+                            new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
+                            primeTimeout,
+                            null).get(primeTimeout.getDuration(), primeTimeout.getTimeUnit());
+                } catch (final Exception ex) {
+                    System.err.println("Priming " + t + " failed: " + ex);
+                }
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            if (requester != null) {
+                try {
+                    requester.initiateShutdown();
+                    requester.awaitShutdown(TimeValue.ofSeconds(5));
+                } catch (final Exception ignore) {
+                }
+                requester.close(CloseMode.IMMEDIATE);
+            }
+            if (server != null) {
+                try {
+                    server.initiateShutdown();
+                    server.awaitShutdown(TimeValue.ofSeconds(5));
+                } catch (final Exception ignore) {
+                }
+                server.close(CloseMode.IMMEDIATE);
+            }
+        }
+
+        HttpHost pickTarget() {
+            return targets[ThreadLocalRandom.current().nextInt(targets.length)];
+        }
+
+    }
+
+    @Benchmark
+    @Threads(50)
+    public Message<HttpResponse, String> request(final BenchState s) throws Exception {
+        final HttpHost target = s.pickTarget();
+        final Future<Message<HttpResponse, String>> future = s.requester.execute(
+                new BasicRequestProducer(Method.POST, target, "/",
+                        new StringAsyncEntityProducer(s.payload, ContentType.TEXT_PLAIN)),
+                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
+                TIMEOUT,
+                null);
+        try {
+            return future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+        } catch (final TimeoutException te) {
+            future.cancel(true);
+            return null;
+        } catch (final Exception ex) {
+            if (ex.getCause() instanceof TimeoutException) {
+                future.cancel(true);
+            }
+            return null;
+        }
+    }
+
+}

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ConnPoolTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2ConnPoolTest.java
@@ -42,7 +42,8 @@ import org.apache.hc.core5.http.nio.AsyncServerExchangeHandler;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.http2.impl.nio.bootstrap.H2MultiplexingRequester;
 import org.apache.hc.core5.http2.nio.command.PingCommand;
-import org.apache.hc.core5.http2.nio.pool.H2ConnPool;
+import org.apache.hc.core5.http2.nio.pool.H2RequesterConnPool;
+import org.apache.hc.core5.http2.nio.pool.H2StreamLease;
 import org.apache.hc.core5.http2.nio.support.BasicPingHandler;
 import org.apache.hc.core5.http2.ssl.H2ClientTlsStrategy;
 import org.apache.hc.core5.http2.ssl.H2ServerTlsStrategy;
@@ -109,29 +110,31 @@ class H2ConnPoolTest {
     }
 
     @Test
-    void testManyGetSession() throws Exception {
+    void testManyLeaseSession() throws Exception {
         final int n = 200;
 
         final HttpAsyncServer server = serverResource.start();
-        final Future<ListenerEndpoint> future = server.listen(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), URIScheme.HTTP);
+        final Future<ListenerEndpoint> future = server.listen(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), URIScheme.HTTP);
         final ListenerEndpoint listener = future.get();
         final InetSocketAddress address = (InetSocketAddress) listener.getAddress();
         final HttpHost target = new HttpHost(URIScheme.HTTP.id, "localhost", address.getPort());
 
         final H2MultiplexingRequester requester = clientResource.start();
-        final H2ConnPool connPool = requester.getConnPool();
-        final CountDownLatchFutureCallback<IOSession> latch = new CountDownLatchFutureCallback<IOSession>(n) {
+        final H2RequesterConnPool connPool = requester.getConnectionPool();
+        final CountDownLatchFutureCallback<H2StreamLease> latch = new CountDownLatchFutureCallback<H2StreamLease>(n) {
 
             @Override
-            public void completed(final IOSession session) {
+            public void completed(final H2StreamLease lease) {
+                final IOSession session = lease.getSession();
                 session.enqueue(new PingCommand(new BasicPingHandler(
                         result -> countDown()
-                        )), Command.Priority.IMMEDIATE);
+                )), Command.Priority.IMMEDIATE);
             }
 
         };
         for (int i = 0; i < n; i++) {
-            connPool.getSession(target, TIMEOUT, latch);
+            connPool.leaseSession(target, TIMEOUT, latch);
         }
         Assertions.assertTrue(latch.await(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit()));
 
@@ -142,18 +145,20 @@ class H2ConnPoolTest {
     }
 
     @Test
-    void testManyGetSessionFailures() throws Exception {
+    void testManyLeaseSessionFailures() throws Exception {
         final int n = 200;
 
         final HttpHost target = new HttpHost(URIScheme.HTTP.id, "pampa.invalid", 8888);
 
         final H2MultiplexingRequester requester = clientResource.start();
-        final H2ConnPool connPool = requester.getConnPool();
-        final CountDownLatchFutureCallback<IOSession> latch = new CountDownLatchFutureCallback<>(n);
+        final H2RequesterConnPool connPool = requester.getConnectionPool();
+        final CountDownLatchFutureCallback<H2StreamLease> latch = new CountDownLatchFutureCallback<>(n);
 
         for (int i = 0; i < n; i++) {
-            connPool.getSession(target, TIMEOUT, latch);
+            connPool.leaseSession(target, TIMEOUT, latch);
         }
+
+        Assertions.assertTrue(latch.await(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit()));
 
         requester.initiateShutdown();
         requester.awaitShutdown(TIMEOUT);

--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2MultiplexingConnPoolTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/H2MultiplexingConnPoolTest.java
@@ -1,0 +1,314 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.testing.nio;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hc.core5.function.Supplier;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Message;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.impl.bootstrap.HttpAsyncServer;
+import org.apache.hc.core5.http.impl.routing.RequestRouter;
+import org.apache.hc.core5.http.nio.AsyncServerExchangeHandler;
+import org.apache.hc.core5.http.nio.AsyncServerRequestHandler;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityProducer;
+import org.apache.hc.core5.http.nio.support.AsyncResponseBuilder;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
+import org.apache.hc.core5.http.nio.support.BasicResponseConsumer;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.impl.nio.bootstrap.H2MultiplexingRequester;
+import org.apache.hc.core5.http2.nio.pool.H2PoolPolicy;
+import org.apache.hc.core5.reactor.IOReactorConfig;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ListenerEndpoint;
+import org.apache.hc.core5.testing.extension.nio.H2AsyncServerResource;
+import org.apache.hc.core5.testing.extension.nio.H2MultiplexingRequesterResource;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class H2MultiplexingConnPoolTest {
+
+    private static final Timeout TIMEOUT = Timeout.ofSeconds(30);
+    private static final int SINGLE_ROUTE_CONCURRENCY = 20;
+
+    private final AtomicLong clientConnCount;
+    private final AtomicInteger activeRequests;
+    private final AtomicInteger maxActiveRequests;
+    private final AtomicReference<Throwable> handlerFailure;
+
+    private volatile CountDownLatch requestsArrived;
+    private volatile CountDownLatch releaseResponses;
+
+    @RegisterExtension
+    private final H2AsyncServerResource serverResource;
+    @RegisterExtension
+    private final H2MultiplexingRequesterResource clientResource;
+
+    public H2MultiplexingConnPoolTest() {
+        this.clientConnCount = new AtomicLong();
+        this.activeRequests = new AtomicInteger();
+        this.maxActiveRequests = new AtomicInteger();
+        this.handlerFailure = new AtomicReference<>();
+
+        this.serverResource = new H2AsyncServerResource();
+        this.serverResource.configure(bootstrap -> bootstrap
+                .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_2)
+                .setIOReactorConfig(
+                        IOReactorConfig.custom()
+                                .setSoTimeout(TIMEOUT)
+                                .build())
+                .setH2Config(H2Config.custom()
+                        .setPushEnabled(false)
+                        .setMaxConcurrentStreams(100)
+                        .build())
+                .setRequestRouter(RequestRouter.<Supplier<AsyncServerExchangeHandler>>builder()
+                        .addRoute(RequestRouter.LOCAL_AUTHORITY, "/barrier",
+                                () -> new BarrierHandler(
+                                        activeRequests,
+                                        maxActiveRequests,
+                                        requestsArrived,
+                                        releaseResponses,
+                                        handlerFailure))
+                        .addRoute(RequestRouter.LOCAL_AUTHORITY, "*",
+                                () -> new EchoHandler(2048))
+                        .resolveAuthority(RequestRouter.LOCAL_AUTHORITY_RESOLVER)
+                        .build())
+        );
+
+        this.clientResource = new H2MultiplexingRequesterResource();
+        this.clientResource.configure(bootstrap -> bootstrap
+                .setIOReactorConfig(IOReactorConfig.custom()
+                        .setSoTimeout(TIMEOUT)
+                        .build())
+                .setH2Config(H2Config.custom()
+                        .setPushEnabled(false)
+                        .setMaxConcurrentStreams(100)
+                        .build())
+                .setH2PoolPolicy(H2PoolPolicy.MULTIPLEXING)
+                .setIOSessionListener(new LoggingIOSessionListener() {
+
+                    @Override
+                    public void connected(final IOSession session) {
+                        clientConnCount.incrementAndGet();
+                        super.connected(session);
+                    }
+
+                })
+        );
+    }
+
+    @BeforeEach
+    void resetCounts() {
+        clientConnCount.set(0);
+        activeRequests.set(0);
+        maxActiveRequests.set(0);
+        handlerFailure.set(null);
+        requestsArrived = new CountDownLatch(SINGLE_ROUTE_CONCURRENCY);
+        releaseResponses = new CountDownLatch(1);
+    }
+
+    @Test
+    void testConcurrentRequestsSingleRoute() throws Exception {
+        final HttpAsyncServer server = serverResource.start();
+        final Future<ListenerEndpoint> future = server.listen(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
+                URIScheme.HTTP);
+        final ListenerEndpoint listener = future.get();
+        final InetSocketAddress address = (InetSocketAddress) listener.getAddress();
+        final HttpHost target = new HttpHost(URIScheme.HTTP.id, "localhost",
+                address.getPort());
+
+        final H2MultiplexingRequester requester = clientResource.start();
+
+        final Message<HttpResponse, String> warmup = requester.execute(
+                new BasicRequestProducer(Method.POST, target, "/warmup",
+                        new StringAsyncEntityProducer("warmup", ContentType.TEXT_PLAIN)),
+                new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
+                TIMEOUT, null).get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+
+        Assertions.assertNotNull(warmup);
+        Assertions.assertEquals(HttpStatus.SC_OK, warmup.head().getCode());
+        Assertions.assertEquals("warmup", warmup.body());
+
+        final List<Future<Message<HttpResponse, String>>> futures =
+                new ArrayList<>(SINGLE_ROUTE_CONCURRENCY);
+        for (int i = 0; i < SINGLE_ROUTE_CONCURRENCY; i++) {
+            futures.add(requester.execute(
+                    new BasicRequestProducer(Method.POST, target, "/barrier",
+                            new StringAsyncEntityProducer("msg-" + i,
+                                    ContentType.TEXT_PLAIN)),
+                    new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
+                    TIMEOUT, null));
+        }
+
+        Assertions.assertTrue(requestsArrived.await(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit()),
+                "All requests should arrive before responses are released");
+
+        Assertions.assertEquals(SINGLE_ROUTE_CONCURRENCY, maxActiveRequests.get(),
+                "Requests should be concurrently in flight on the server");
+
+        Assertions.assertEquals(1L, clientConnCount.get(),
+                "Single route should multiplex over one HTTP/2 connection");
+
+        releaseResponses.countDown();
+
+        for (int i = 0; i < SINGLE_ROUTE_CONCURRENCY; i++) {
+            final Message<HttpResponse, String> message = futures.get(i).get(
+                    TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assertions.assertNotNull(message);
+            Assertions.assertEquals(HttpStatus.SC_OK, message.head().getCode());
+            Assertions.assertEquals("msg-" + i, message.body());
+        }
+
+        if (handlerFailure.get() != null) {
+            Assertions.fail(handlerFailure.get());
+        }
+    }
+
+    @Test
+    void testConcurrentRequestsMultipleRoutes() throws Exception {
+        final int routeCount = 3;
+        final int requestsPerRoute = 20;
+
+        final HttpAsyncServer server = serverResource.start();
+        final HttpHost[] targets = new HttpHost[routeCount];
+        for (int r = 0; r < routeCount; r++) {
+            final Future<ListenerEndpoint> future = server.listen(
+                    new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), URIScheme.HTTP);
+            final ListenerEndpoint listener = future.get();
+            final InetSocketAddress address = (InetSocketAddress) listener.getAddress();
+            targets[r] = new HttpHost(URIScheme.HTTP.id, "localhost",
+                    address.getPort());
+        }
+
+        final H2MultiplexingRequester requester = clientResource.start();
+
+        final List<Future<Message<HttpResponse, String>>> futures = new ArrayList<>();
+        for (int r = 0; r < routeCount; r++) {
+            for (int i = 0; i < requestsPerRoute; i++) {
+                final String body = "route-" + r + "-msg-" + i;
+                futures.add(requester.execute(
+                        new BasicRequestProducer(Method.POST, targets[r], "/echo", new StringAsyncEntityProducer(body, ContentType.TEXT_PLAIN)),
+                        new BasicResponseConsumer<>(new StringAsyncEntityConsumer()),
+                        TIMEOUT, null));
+            }
+        }
+
+        int idx = 0;
+        for (int r = 0; r < routeCount; r++) {
+            for (int i = 0; i < requestsPerRoute; i++) {
+                final Message<HttpResponse, String> message = futures.get(idx).get(
+                        TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+                Assertions.assertNotNull(message);
+                Assertions.assertEquals(HttpStatus.SC_OK, message.head().getCode());
+                Assertions.assertEquals("route-" + r + "-msg-" + i, message.body());
+                idx++;
+            }
+        }
+
+        Assertions.assertTrue(clientConnCount.get() >= routeCount,
+                "Each route should have at least one connection");
+        Assertions.assertTrue(clientConnCount.get() <= routeCount * 3,
+                "Each route should use at most defaultMaxPerRoute connections");
+    }
+
+    static final class BarrierHandler extends MessageExchangeHandler<String> {
+
+        private final AtomicInteger activeRequests;
+        private final AtomicInteger maxActiveRequests;
+        private final CountDownLatch requestsArrived;
+        private final CountDownLatch releaseResponses;
+        private final AtomicReference<Throwable> failureRef;
+
+        BarrierHandler(
+                final AtomicInteger activeRequests,
+                final AtomicInteger maxActiveRequests,
+                final CountDownLatch requestsArrived,
+                final CountDownLatch releaseResponses,
+                final AtomicReference<Throwable> failureRef) {
+            super(new StringAsyncEntityConsumer());
+            this.activeRequests = activeRequests;
+            this.maxActiveRequests = maxActiveRequests;
+            this.requestsArrived = requestsArrived;
+            this.releaseResponses = releaseResponses;
+            this.failureRef = failureRef;
+        }
+
+        @Override
+        protected void handle(
+                final Message<HttpRequest, String> requestMessage,
+                final AsyncServerRequestHandler.ResponseTrigger responseTrigger,
+                final HttpContext context) {
+            final int current = activeRequests.incrementAndGet();
+            maxActiveRequests.accumulateAndGet(current, Math::max);
+            requestsArrived.countDown();
+
+            final Thread responder = new Thread(() -> {
+                try {
+                    if (!releaseResponses.await(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit())) {
+                        failureRef.compareAndSet(null,
+                                new AssertionError("Timed out waiting to release responses"));
+                        return;
+                    }
+                    responseTrigger.submitResponse(
+                            AsyncResponseBuilder.create(HttpStatus.SC_OK)
+                                    .setEntity(requestMessage.getBody(), ContentType.TEXT_PLAIN)
+                                    .build(),
+                            context);
+                } catch (final Exception ex) {
+                    failureRef.compareAndSet(null, ex);
+                } finally {
+                    activeRequests.decrementAndGet();
+                }
+            });
+            responder.setDaemon(true);
+            responder.start();
+        }
+    }
+
+}


### PR DESCRIPTION
Implement an HTTP/2 stream-capacity-aware connection pool with per-route and global connection limits, reservation-aware leasing, GOAWAY draining, disconnect handling, and route-level wakeup logic. Optimize uncontended lease paths and add coverage for the main pooling and lifecycle edge cases.

## Performance

Benchmark: `H2PoolPolicyJmh.request`  
Mode: throughput (`ops/s`)  
Payload: `128 bytes`

| maxConcurrentStreams | routes | BASIC ops/s | MULTIPLEXING ops/s | Result |
|---:|---:|---:|---:|---|
| 10  | 1  | 40,937 | 76,508 | MULTIPLEXING +86.9% |
| 10  | 4  | 80,072 | 77,919 | BASIC +2.7% |
| 10  | 10 | 84,421 | 71,621 | BASIC +15.2% |
| 20  | 1  | 40,412 | 77,503 | MULTIPLEXING +91.8% |
| 20  | 4  | 75,011 | 78,735 | MULTIPLEXING +5.0% |
| 20  | 10 | 77,851 | 72,444 | BASIC +6.9% |
| 50  | 1  | 41,086 | 63,775 | MULTIPLEXING +55.2% |
| 50  | 4  | 75,775 | 76,414 | MULTIPLEXING +0.8% |
| 50  | 10 | 77,908 | 76,405 | BASIC +1.9% |
| 100 | 1  | 40,418 | 40,807 | MULTIPLEXING +1.0% |
| 100 | 4  | 74,411 | 76,005 | MULTIPLEXING +2.1% |
| 100 | 10 | 75,293 | 76,036 | MULTIPLEXING +1.0% |

## Summary

`MULTIPLEXING` performs best on workloads concentrated on a small number of hot routes, where connection-level stream capacity becomes a limiting factor.

For broader route fan-out, the advantage is smaller. In the 10-route benchmark shape, `MULTIPLEXING` is still slower at lower stream limits, but approaches parity as the peer stream limit increases.

The new pool should therefore be viewed as a workload-specific policy rather than a universal replacement for `BASIC`.