### PR TITLE
HTTPCORE-774: apply missing connection input window fix to 5.4.x

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/nio/AbstractH2StreamMultiplexer.java
@@ -1492,7 +1492,6 @@ abstract class AbstractH2StreamMultiplexer implements Identifiable, HttpConnecti
 
         @Override
         public void update(final int increment) throws IOException {
-            incrementInputCapacity(0, connInputWindow, increment);
             incrementInputCapacity(id, inputWindow, increment);
         }
 


### PR DESCRIPTION
This cherry-picks d31d0000084d1ffdd37a9596b53e2aa7779451bc (#511) onto 5.4.x. The companion HTTPCORE-774 window management commit is already present on 5.4.x (2cb5fb73faf85cbc4efa380d8ee9c442b94831f3), but this one-line connection input window fix appears to be missing.

Probably should also be cherry-picked onto `main`.