### PR TITLE
Remove @Experimental for QUERY method and implement conformance to RFC 10008

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Protocol conformance
 - [RFC 1945](https://datatracker.ietf.org/doc/html/rfc1945) - Hypertext Transfer Protocol -- HTTP/1.0
 - [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) - Uniform Resource Identifier (URI): Generic Syntax
 - [RFC 9218](https://datatracker.ietf.org/doc/html/rfc9218) - Extensible Prioritization Scheme for HTTP
+- [RFC 10008](https://datatracker.ietf.org/doc/html/rfc10008) - The HTTP QUERY Method
+
 
 Licensing
 ---------

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestConformance.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/protocol/H2RequestConformance.java
@@ -38,6 +38,7 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -76,6 +77,13 @@ public class H2RequestConformance implements HttpRequestInterceptor {
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext localContext)
             throws HttpException, IOException {
         Args.notNull(request, "HTTP request");
+
+        if (Method.QUERY.isSame(request.getMethod())) {
+            if (!request.containsHeader(HttpHeaders.CONTENT_TYPE)) {
+                throw new ProtocolException("QUERY request must have Content-Type header");
+            }
+        }
+
         for (int i = 0; i < illegalHeaderNames.length; i++) {
             final String headerName = illegalHeaderNames[i];
             if (request.containsHeader(headerName)) {

--- a/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/protocol/TestH2RequestConformance.java
+++ b/httpcore5-h2/src/test/java/org/apache/hc/core5/http2/protocol/TestH2RequestConformance.java
@@ -37,6 +37,20 @@ import org.junit.jupiter.api.Test;
 class TestH2RequestConformance {
 
     @Test
+    void testQueryMissingContentType() {
+        final HttpRequest request = new BasicHttpRequest("QUERY", "/");
+        Assertions.assertThrows(ProtocolException.class,
+                () -> H2RequestConformance.INSTANCE.process(request, null, HttpCoreContext.create()));
+    }
+
+    @Test
+    void testQueryWithContentType() throws Exception {
+        final HttpRequest request = new BasicHttpRequest("QUERY", "/");
+        request.setHeader(HttpHeaders.CONTENT_TYPE, "application/sql");
+        H2RequestConformance.INSTANCE.process(request, null, HttpCoreContext.create());
+    }
+
+    @Test
     void testTEAbsent() throws Exception {
         final HttpRequest request = new BasicHttpRequest("GET", "/");
         H2RequestConformance.INSTANCE.process(request, null, HttpCoreContext.create());

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHeaders.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHeaders.java
@@ -49,6 +49,13 @@ public final class HttpHeaders {
     public static final String ACCEPT_RANGES = "Accept-Ranges";
 
     /**
+     * The RFC 10008 {@code Accept-Query} response header field name.
+     *
+     * @since 5.5
+     */
+    public static final String ACCEPT_QUERY = "Accept-Query";
+
+    /**
      * The CORS {@code Access-Control-Allow-Credentials} response header field name.
      */
     public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/Method.java
@@ -29,7 +29,6 @@ package org.apache.hc.core5.http;
 
 import java.util.Locale;
 
-import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -104,8 +103,6 @@ public enum Method {
      *
      * @since 5.4
      */
-    @Experimental
-    //("QUERY method is still in DRAFT status")
     QUERY(true, true);
 
     private final boolean safe;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -404,7 +404,7 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
         final String method = getMethod();
         final List<NameValuePair> parameters = getParameters();
         if (parameters != null && !parameters.isEmpty()) {
-            if (entityCopy == null && (Method.POST.isSame(method) || Method.PUT.isSame(method))) {
+            if (entityCopy == null && (Method.POST.isSame(method) || Method.PUT.isSame(method) || Method.QUERY.isSame(method))) {
                 entityCopy = HttpEntities.createUrlEncoded(parameters, getCharset());
             } else {
                 try {

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilder.java
@@ -33,7 +33,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
@@ -129,7 +128,6 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
      *
      * @since 5.4
      */
-    @Experimental
     public static ClassicRequestBuilder query() {
         return new ClassicRequestBuilder(Method.QUERY);
     }
@@ -142,7 +140,6 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
      *
      * @since 5.4
      */
-    @Experimental
     public static ClassicRequestBuilder query(final URI uri) {
         return new ClassicRequestBuilder(Method.QUERY, uri);
     }
@@ -155,7 +152,6 @@ public class ClassicRequestBuilder extends AbstractRequestBuilder<ClassicHttpReq
      *
      * @since 5.4
      */
-    @Experimental
     public static ClassicRequestBuilder query(final String uri) {
         return new ClassicRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -379,7 +379,7 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
         final List<NameValuePair> parameters = getParameters();
         if (parameters != null && !parameters.isEmpty()) {
             final Charset charset = getCharset();
-            if (entityProducerCopy == null && (Method.POST.isSame(method) || Method.PUT.isSame(method))) {
+            if (entityProducerCopy == null && (Method.POST.isSame(method) || Method.PUT.isSame(method) || Method.QUERY.isSame(method))) {
                 final String content = WWWFormCodec.format(
                         parameters,
                         charset != null ? charset : ContentType.APPLICATION_FORM_URLENCODED.getCharset());

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/support/AsyncRequestBuilder.java
@@ -33,7 +33,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
@@ -128,7 +127,6 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
      *
      * @since 5.4
      */
-    @Experimental
     public static AsyncRequestBuilder query() {
         return new AsyncRequestBuilder(Method.QUERY);
     }
@@ -141,7 +139,6 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
      *
      * @since 5.4
      */
-    @Experimental
     public static AsyncRequestBuilder query(final URI uri) {
         return new AsyncRequestBuilder(Method.QUERY, uri);
     }
@@ -154,7 +151,6 @@ public class AsyncRequestBuilder extends AbstractRequestBuilder<AsyncRequestProd
      *
      * @since 5.4
      */
-    @Experimental
     public static AsyncRequestBuilder query(final String uri) {
         return new AsyncRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/RequestConformance.java
@@ -35,6 +35,8 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.MisdirectedRequestException;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.URIScheme;
@@ -65,6 +67,12 @@ public class RequestConformance implements HttpRequestInterceptor {
     public void process(final HttpRequest request, final EntityDetails entity, final HttpContext localContext)
             throws HttpException, IOException {
         Args.notNull(request, "HTTP request");
+
+        if (Method.QUERY.isSame(request.getMethod())) {
+            if (!request.containsHeader(HttpHeaders.CONTENT_TYPE)) {
+                throw new ProtocolException("QUERY request must have Content-Type header");
+            }
+        }
 
         if (TextUtils.isBlank(request.getScheme())) {
             throw new ProtocolException("Request scheme is not set");

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/support/BasicRequestBuilder.java
@@ -33,7 +33,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
@@ -112,7 +111,6 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
      *
      * @since 5.4
      */
-    @Experimental
     public static BasicRequestBuilder query() {
         return new BasicRequestBuilder(Method.QUERY);
     }
@@ -125,7 +123,6 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
      *
      * @since 5.4
      */
-    @Experimental
     public static BasicRequestBuilder query(final URI uri) {
         return new BasicRequestBuilder(Method.QUERY, uri);
     }
@@ -138,7 +135,6 @@ public class BasicRequestBuilder extends AbstractRequestBuilder<BasicHttpRequest
      *
      * @since 5.4
      */
-    @Experimental
     public static BasicRequestBuilder query(final String uri) {
         return new BasicRequestBuilder(Method.QUERY, uri);
     }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilderTest.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/io/support/ClassicRequestBuilderTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -42,6 +43,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
@@ -247,6 +249,25 @@ class ClassicRequestBuilderTest {
                         .setVersion(HttpVersion.HTTP_1_1)
                         .setEntity(new ByteArrayEntity(new byte[10240], ContentType.TEXT_PLAIN))
                         .build());
+    }
+
+    @Test
+    void builderQuery() throws IOException {
+        final ClassicHttpRequest classicHttpRequest = ClassicRequestBuilder.query()
+                .setHttpHost(new HttpHost("httpbin.org"))
+                .setPath("/theUri")
+                .addParameter("param1", "value1")
+                .addParameter("param2", "value2")
+                .build();
+
+        assertAll("QUERY builder tests",
+                () -> assertEquals(Method.QUERY.name(), classicHttpRequest.getMethod()),
+                () -> assertEquals("httpbin.org", classicHttpRequest.getAuthority().getHostName()),
+                () -> assertEquals("/theUri", classicHttpRequest.getPath()),
+                () -> assertNotNull(classicHttpRequest.getEntity()),
+                () -> assertEquals(ContentType.APPLICATION_FORM_URLENCODED.getMimeType(), ContentType.parse(classicHttpRequest.getEntity().getContentType()).getMimeType()),
+                () -> assertEquals("param1=value1&param2=value2", EntityUtils.toString(classicHttpRequest.getEntity()))
+        );
     }
 
 }

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/protocol/TestStandardInterceptors.java
@@ -1044,6 +1044,30 @@ class TestStandardInterceptors {
     }
 
     @Test
+    void testRequestConformanceQueryMissingContentType() {
+        final HttpCoreContext context = HttpCoreContext.create();
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.QUERY, "/");
+        request.setScheme("http");
+        request.setAuthority(new URIAuthority("somehost", 8888));
+        request.setPath("/path");
+        final RequestConformance interceptor = new RequestConformance();
+        Assertions.assertThrows(ProtocolException.class, () ->
+                interceptor.process(request, request.getEntity(), context));
+    }
+
+    @Test
+    void testRequestConformanceQueryWithContentType() {
+        final HttpCoreContext context = HttpCoreContext.create();
+        final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.QUERY, "/");
+        request.setScheme("http");
+        request.setAuthority(new URIAuthority("somehost", 8888));
+        request.setPath("/path");
+        request.setHeader(HttpHeaders.CONTENT_TYPE, "application/jsonpath");
+        final RequestConformance interceptor = new RequestConformance();
+        Assertions.assertDoesNotThrow(() -> interceptor.process(request, request.getEntity(), context));
+    }
+
+    @Test
     void testRequestConformanceSchemeMissing() {
         final HttpCoreContext context = HttpCoreContext.create();
         final BasicClassicHttpRequest request = new BasicClassicHttpRequest(Method.GET, "/");


### PR DESCRIPTION
###  Removing Experimental Markings

Since the QUERY method draft has been promoted to a proper [RFC]( https://www.rfc-editor.org/rfc/rfc10008.html), this change removes the @Experimental tag from   QUERY method.

### RFC 10008 Conformance

  According to Section 2 of RFC 10008 https://www.rfc-editor.org/rfc/rfc10008.html:

  │ Servers MUST fail the request if the Content-Type request field is missing or is inconsistent with the request content.

  I've added code to enforce this constraint.
  
  This is follow up of #499