### PR TITLE
SSLIOSession: Fix regression in backpressure handling

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/Http1IntegrationTest.java
@@ -750,6 +750,9 @@ abstract class Http1IntegrationTest extends HttpIntegrationTest {
 
         @Override
         public int write(final ByteBuffer src) throws IOException {
+            if (!channel().isOpen()) {
+                return 0;
+            }
             final int chunk;
             if (!done) {
                 lineBuffer.clear();

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLIOSession.java
@@ -93,7 +93,6 @@ public class SSLIOSession implements IOSession {
     private final AtomicInteger outboundClosedCount;
     private final AtomicReference<TLSHandShakeState> handshakeStateRef;
     private final IOEventHandler internalEventHandler;
-    private final int packetBufferSize;
 
     private int appEventMask;
 
@@ -180,9 +179,9 @@ public class SSLIOSession implements IOSession {
 
         final SSLSession sslSession = this.sslEngine.getSession();
         // Allocate buffers for network (encrypted) data
-        this.packetBufferSize = sslSession.getPacketBufferSize();
-        this.inEncrypted = SSLManagedBuffer.create(sslBufferMode, packetBufferSize);
-        this.outEncrypted = SSLManagedBuffer.create(sslBufferMode, packetBufferSize);
+        final int netBufferSize = sslSession.getPacketBufferSize();
+        this.inEncrypted = SSLManagedBuffer.create(sslBufferMode, netBufferSize);
+        this.outEncrypted = SSLManagedBuffer.create(sslBufferMode, netBufferSize);
 
         // Allocate buffers for application (unencrypted) data
         final int appBufferSize = sslSession.getApplicationBufferSize();
@@ -670,18 +669,9 @@ public class SSLIOSession implements IOSession {
             if (this.handshakeStateRef.get() == TLSHandShakeState.READY) {
                 return 0;
             }
-
-            for (;;) {
-                final ByteBuffer outEncryptedBuf = this.outEncrypted.acquire();
-                final SSLEngineResult result = doWrap(src, outEncryptedBuf);
-                if (result.getStatus() == SSLEngineResult.Status.BUFFER_OVERFLOW) {
-                    // We don't release the buffer here, it will be expanded (if needed)
-                    // and returned by the next attempt of SSLManagedBuffer#acquire() call.
-                    this.outEncrypted.ensureWriteable(packetBufferSize);
-                } else {
-                    return result.bytesConsumed();
-                }
-            }
+            final ByteBuffer outEncryptedBuf = this.outEncrypted.acquire();
+            final SSLEngineResult result = doWrap(src, outEncryptedBuf);
+            return result.bytesConsumed();
         } finally {
             this.session.getLock().unlock();
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLManagedBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/ssl/SSLManagedBuffer.java
@@ -57,54 +57,13 @@ abstract class SSLManagedBuffer {
      */
     abstract boolean hasData();
 
-    /**
-     * Expands the underlying buffer's to make sure it has enough write capacity to accommodate
-     * the required amount of bytes. This method has no side effect if the buffer has enough writeable
-     * capacity left.
-     * @param size the required write capacity
-     */
-    abstract void ensureWriteable(final int size);
-
-    /**
-     * Helper method to ensure additional writeable capacity with respect to the source buffer. It
-     * allocates a new buffer and copies all the data if needed, returning the new buffer. This method
-     * has no side effect if the source buffer has enough writeable capacity left.
-     * @param src source buffer
-     * @param size the required write capacity
-     * @return new buffer (or the source buffer of it  has enough writeable capacity left)
-     */
-    ByteBuffer ensureWriteable(final ByteBuffer src, final int size) {
-        if (src == null) {
-            // Nothing to do, the buffer is not allocated
-            return null;
-        }
-
-        // There is not enough capacity left, we need to expand
-        if (src.remaining() < size) {
-            final int additionalCapacityNeeded = size - src.remaining();
-            final ByteBuffer expanded = ByteBuffer.allocate(src.capacity() + additionalCapacityNeeded);
-
-            // use a duplicated buffer so we don't disrupt the limit of the original buffer
-            final ByteBuffer tmp = src.duplicate();
-            tmp.flip();
-
-            // Copy to expanded buffer
-            expanded.put(tmp);
-
-            // Use a new buffer
-            return expanded;
-        } else {
-            return src;
-        }
-    }
-
     static SSLManagedBuffer create(final SSLBufferMode mode, final int size) {
         return mode == SSLBufferMode.DYNAMIC ? new DynamicBuffer(size) : new StaticBuffer(size);
     }
 
     static final class StaticBuffer extends SSLManagedBuffer {
 
-        private ByteBuffer buffer;
+        private final ByteBuffer buffer;
 
         public StaticBuffer(final int size) {
             Args.positive(size, "size");
@@ -131,10 +90,6 @@ abstract class SSLManagedBuffer {
             return buffer.position() > 0;
         }
 
-        @Override
-        void ensureWriteable(final int size) {
-            buffer = ensureWriteable(buffer, size);
-        }
     }
 
     static final class DynamicBuffer extends SSLManagedBuffer {
@@ -171,10 +126,6 @@ abstract class SSLManagedBuffer {
             return wrapped != null && wrapped.position() > 0;
         }
 
-        @Override
-        void ensureWriteable(final int size) {
-            wrapped = ensureWriteable(wrapped, size);
-        }
     }
 
 }


### PR DESCRIPTION
A regression was introduced by PR #513, submitted as a fix for HTTPCORE-775, which claimed that `SSLIOSession::write` was failing to "handle" `SSLEngineResult#BUFFER_OVERFLOW`. The issue was encountered by Apache CXF, who provided a test case demonstrating the problem:

https://github.com/apache/cxf/pull/2214/changes

I investigated this reproducer and found that CXF was actually hanging due to not signaling the availability of more data:

https://github.com/apache/cxf/blob/f1b2c37bd9f3606cf7ca2d5d39cc1168e94fd9e4/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncRequestProducer.java#L97

when `SSLIOSession#write` signaled backpressure here:

https://github.com/apache/cxf/blob/f1b2c37bd9f3606cf7ca2d5d39cc1168e94fd9e4/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncRequestProducer.java#L75

The return value of `buf.produceContent` (which is ultimately `SSLEngineResult#bytesConsumed` -- 0, in this case) is simply being discarded. Changing the `CXFHttpAsyncRequestProducer#available` method as follows causes the problematic test cases to succeed instantly:

```
    @Override
    public int available() {
        if (buffer != null && buffer.hasRemaining()) {
            return buffer.remaining();
        } else if (buf != null && buf.length() > 0) {
            return buf.length();
        }
        return 0;
    }
```

Additionally, that PR appears to have introduced dysfunctional backpressure handling into `SSLIOSession` by simply expanding the buffer as much as necessary to hold the encrypted `src` buffer. This in turn has caused a significant regression in heap usage and latency, hence the need to revert. I've retained the test changes, since they did introduce more coverage for TLSv1.3.