### PR TITLE
Upgrade Conscrypt

### DIFF
--- a/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/AlpnTests.java
+++ b/httpcore5-testing/src/test/java/org/apache/hc/core5/testing/nio/AlpnTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.parallel.Isolated;
 
 class AlpnTests {
@@ -54,7 +55,7 @@ class AlpnTests {
     @Nested
     @Isolated
     @DisplayName("ALPN Conscrypt (Java 9 or newer)")
-    @DisabledOnOs(architectures = "aarch64")
+    @DisabledOnOs(value = OS.WINDOWS, architectures = "aarch64")
     @EnabledForJreRange(min = JRE.JAVA_9)
     class ConscryptJSSEAlpnTest extends AlpnTest {
 
@@ -67,7 +68,7 @@ class AlpnTests {
     @Nested
     @Isolated
     @DisplayName("ALPN Conscrypt (Conscrypt specific TLS strategies)")
-    @DisabledOnOs(architectures = "aarch64")
+    @DisabledOnOs(value = OS.WINDOWS, architectures = "aarch64")
     class ConscryptJSSEAndStrategiesAlpnTest extends AlpnTest {
 
         public ConscryptJSSEAndStrategiesAlpnTest() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <!-- Maven itself runs on Java 17+, but compilation and tests can still use an older toolchain JDK. -->
     <hc.build.toolchain.version>${maven.compiler.source}</hc.build.toolchain.version>
-    <conscrypt.version>2.5.2</conscrypt.version>
+    <conscrypt.version>2.6.1</conscrypt.version>
     <junit.version>5.14.4</junit.version>
     <junit.migrationsupport.version>5.0.0</junit.migrationsupport.version>
     <mockito.version>4.11.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <!-- Maven itself runs on Java 17+, but compilation and tests can still use an older toolchain JDK. -->
     <hc.build.toolchain.version>${maven.compiler.source}</hc.build.toolchain.version>
-    <conscrypt.version>2.5.2</conscrypt.version>
+    <conscrypt.version>2.6.1</conscrypt.version>
     <jackson.version>3.2.0</jackson.version>
     <junit.version>5.14.4</junit.version>
     <junit.migrationsupport.version>5.0.0</junit.migrationsupport.version>


### PR DESCRIPTION
Currently, we depend on Conscrypt 2.5.2. The most recent release is version 2.6.1, which adds aarch64 native libraries for both Mac and Linux:

|                 | 2.5.2 | 2.6.1 |
|-----------------|-------|-------|
| Windows x86     |  ✅   |       |
| Windows x86_64  |  ✅   |  ✅   |
| Windows aarch64 |       |       |
| Mac x86_64      |  ✅   |  ✅   |
| Mac aarch64     |       |  ✅   |
| Linux x86_64    |  ✅   |  ✅   |
| Linux aarch64   |       |  ✅   |

This change upgrades to the latest version and updates `AlpnTests` to ensure Conscrypt test coverage on all supported platforms.